### PR TITLE
python(feature): multi-asset ingestion + automatic flow updates

### DIFF
--- a/python/lib/sift_py/__init__.py
+++ b/python/lib/sift_py/__init__.py
@@ -10,6 +10,8 @@ official [Sift documentation](https://docs.siftstack.com/glossary).
     - [Telemetry Config from YAML](#telemetry-config-from-yaml)
     - [Telemetry Config YAML Schema](#telemetry-config-yaml-schema)
     - [Named Expression Modules](#named-expression-modules)
+* [Updating a Telemetry Config](#updating-a-telemetry-config)
+    - [Ingestion Client Key](#ingestion-client-key)
 * [Ingestion Service](#ingestion-service)
     - [Sending data to Sift](#sending-data-to-sift)
 * [Ingestion Performance](#ingestion-performance)
@@ -448,6 +450,30 @@ def nostromos_lv_426() -> TelemetryConfig:
         ],
     )
 ```
+
+## Updating a Telemetry Config
+
+The following section covers the situation in which you have an existing telemetry config that you would like to edit
+for future telemetry and how to use the `ingestion_client_key`.
+
+### Ingestion Client Key
+
+A `sift_py.ingestion.config.telemetry.TelemetryConfig` contains a field called `ingestion_client_key`
+which is used by Sift to uniquely identify an existing telemetry config for an asset. For a given telemetry config
+you are free to make the following changes and Sift will be able to pick it up without changing the `ingestion_client_key`:
+- Adding new channels
+- Removing existing channels (Need to also remove channel reference in the flow)
+- Adding new flows
+- Removing existing flows
+- Adding new rules
+- Updating existing rules
+
+These can even be done on the fly at run-time.
+
+The following changes, however, would require you to also update the `ingestion_client_key`, otherwise an exception will be raised
+when a `sift_py.ingestion.service.IngestionService` is initialized.
+- Updating an existing channel
+- Adding a new channel to an existing flow
 
 ## Ingestion Service
 

--- a/python/lib/sift_py/ingestion/_internal/ingestion_config.py
+++ b/python/lib/sift_py/ingestion/_internal/ingestion_config.py
@@ -73,10 +73,17 @@ def get_ingestion_config_flow_names(
     """
     Gets all names of flow configs of an ingestion config.
     """
+    flows = get_ingestion_config_flows(channel, ingestion_config_id)
+    breakpoint()
+    return [flow.name for flow in flows]
 
+
+def get_ingestion_config_flows(
+    channel: SiftChannel, ingestion_config_id: str
+) -> List[FlowConfigPb]:
     svc = IngestionConfigServiceStub(channel)
 
-    flows: List[str] = []
+    flows: List[FlowConfigPb] = []
 
     req = ListIngestionConfigFlowsRequest(
         ingestion_config_id=ingestion_config_id,
@@ -86,7 +93,7 @@ def get_ingestion_config_flow_names(
     res = cast(ListIngestionConfigFlowsResponse, svc.ListIngestionConfigFlows(req))
 
     for flow in res.flows:
-        flows.append(flow.name)
+        flows.append(flow)
 
     page_token = res.next_page_token
 
@@ -100,7 +107,7 @@ def get_ingestion_config_flow_names(
         res = cast(ListIngestionConfigFlowsResponse, svc.ListIngestionConfigFlows(req))
 
         for flow in res.flows:
-            flows.append(flow.name)
+            flows.append(flow)
 
         page_token = res.next_page_token
 

--- a/python/lib/sift_py/ingestion/channel.py
+++ b/python/lib/sift_py/ingestion/channel.py
@@ -219,7 +219,7 @@ class ChannelDataTypeStrRep(Enum):
     UINT_64 = "uint64"
 
 
-def channel_fqn(channel: Union[ChannelConfig, ChannelValue, ChannelPb]) -> str:
+def channel_fqn(channel: Union[ChannelConfig, ChannelConfigPb, ChannelValue, ChannelPb]) -> str:
     """
     Computes the fully qualified channel name.
 
@@ -228,6 +228,8 @@ def channel_fqn(channel: Union[ChannelConfig, ChannelValue, ChannelPb]) -> str:
     """
 
     if isinstance(channel, ChannelConfig):
+        return _channel_fqn(channel.name, channel.component)
+    elif isinstance(channel, ChannelConfigPb):
         return _channel_fqn(channel.name, channel.component)
     elif isinstance(channel, ChannelPb):
         return _channel_fqn(channel.name, channel.component)

--- a/python/lib/sift_py/ingestion/manager.py
+++ b/python/lib/sift_py/ingestion/manager.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Callable, Dict, Iterator, Optional, TypedDict
+
+from typing_extensions import Self, TypeAlias
+
+from sift_py.grpc.transport import SiftChannel
+from sift_py.ingestion.config.telemetry import TelemetryConfig
+from sift_py.ingestion.service import IngestionService
+
+IngestionServiceBuilder: TypeAlias = Callable[[SiftChannel], IngestionService]
+
+
+class IngestionServicesManager:
+    """
+    Allows for the initialization of multiple instances of `sift_py.ingestion.service.IngestionService` from
+    either telemetry configs or builders under a single wrapper class that assists in managing data-ingestion
+    for multiple telemetry configs.
+
+    The initializer of this class can be used directly, but prefer to use either `from_builders` or `from_telemetry_configs`.
+    Prefer to use `from_builders` if you have custom options that you want to provide to `sift_py.ingestion.service.IngestionService.__init__`.
+
+    Example usage:
+
+    ```python
+    manager = IngestionServicesManager.from_telementry_configs(grpc_channel, {
+        "config_a": config_a,
+        "config_b": config_b,
+    })
+
+    with manager.ingestion_service("config_a") as config_a:
+        config_a.try_ingest_flow(...)
+
+    with manager.ingestion_service("config_b") as config_b:
+        config_b.try_ingest_flow(...)
+    ```
+    """
+
+    _transport_channel: SiftChannel
+    _ingestion_services: Dict[str, IngestionService]
+
+    def __init__(
+        self, transport_channel: SiftChannel, ingestion_services: Dict[str, IngestionService]
+    ):
+        self._transport_channel = transport_channel
+        self._ingestion_services = ingestion_services
+
+    @classmethod
+    def from_builders(
+        cls, channel: SiftChannel, builders: Dict[str, IngestionServiceBuilder]
+    ) -> Self:
+        return cls(
+            transport_channel=channel,
+            ingestion_services={key: builder(channel) for key, builder in builders.items()},
+        )
+
+    @classmethod
+    def from_telemetry_configs(
+        cls, channel: SiftChannel, telemetry_configs: Dict[str, TelemetryConfig]
+    ) -> Self:
+        return cls(
+            transport_channel=channel,
+            ingestion_services={
+                key: IngestionService(channel, config) for key, config in telemetry_configs.items()
+            },
+        )
+
+    def get_ingestion_service_by_identifier(self, identifier: str) -> Optional[IngestionService]:
+        return self._ingestion_services.get(identifier)
+
+    def __getitem__(self, identifier: str) -> Optional[IngestionService]:
+        return self.get_ingestion_service_by_identifier(identifier)
+
+    @contextmanager
+    def ingestion_service(self, identifier: str) -> Iterator[IngestionService]:
+        ingestion_service = self[identifier]
+
+        if ingestion_service is None:
+            raise IngestionServiceManagerError(
+                f"An ingestion service is not configured for the identifier '{identifier}'."
+            )
+
+        yield ingestion_service
+
+
+class IngestionServiceManagerError(Exception):
+    def __init__(self, msg: str):
+        return super().__init__(msg)
+
+
+class TelemetryConfigByIdentifierMap(TypedDict):
+    identifier: str
+    telemetry_config: TelemetryConfig
+
+
+class IngestionConfigServiceBuilderIdentifierMap(TypedDict):
+    identifier: str
+    builder: IngestionServiceBuilder

--- a/python/lib/sift_py/ingestion/service.py
+++ b/python/lib/sift_py/ingestion/service.py
@@ -187,3 +187,18 @@ class IngestionService(_IngestionServiceImpl):
         ```
         """
         return BufferedIngestionService(self, buffer_size)
+
+    def create_new_flow(self, flow_config: FlowConfig):
+        """
+        Like `try_create_new_flow` but will automatically overwrite any existing flow config with `flow_config` if they
+        share the same name. If you'd an exception to be raise in the case of a name collision then see `try_create_new_flow`.
+        """
+        super().create_new_flow(flow_config)
+
+    def try_create_new_flow(self, flow_config: FlowConfig):
+        """
+        Tries to create a new flow at runtime. Will raise an `IngestionValidationError` if there already exists
+        a flow with the name of the `flow_config` argument. If you'd like to overwrite any flow configs with that
+        have the same name as the provided `flow_config`, then see `create_new_flow`.
+        """
+        super().try_create_new_flow(flow_config)


### PR DESCRIPTION
## Changes

This PR adds the ability to register a new flow during run-time in an ergonomic manner as well as introducing a multi-telemetry-config manager to be able to telemeter for multiple assets or configs.

  ```python
  manager = IngestionServicesManager.from_telementry_configs(grpc_channel, {
      "config_a": config_a,
      "config_b": config_b,
  })

  with manager.ingestion_service("config_a") as config_a:
      config_a.try_ingest_flow(...)

  with manager.ingestion_service("config_b") as config_b:
      config_b.try_ingest_flow(...)
  ```
