### PR TITLE
python(feature): automate gRPC retries

### DIFF
--- a/python/lib/sift_py/grpc/_interceptors.py
+++ b/python/lib/sift_py/grpc/_interceptors.py
@@ -18,6 +18,8 @@ Metadata = List[Tuple[str, str]]
 
 
 class MetadataInterceptor(ClientInterceptor):
+    metadata: Metadata
+
     """
     Interceptor to add metadata to all unary and streaming RPCs
     """

--- a/python/lib/sift_py/grpc/_retry.py
+++ b/python/lib/sift_py/grpc/_retry.py
@@ -28,9 +28,9 @@ class RetryPolicy:
                 "retryPolicy": {
                     # gRPC does not allow more than 5 attempts
                     "maxAttempts": 5,
-                    "initialBackoff": "0.1s",
-                    "maxBackoff": "1s",
-                    "backoffMultiplier": 2,
+                    "initialBackoff": "0.05s",
+                    "maxBackoff": "5s",
+                    "backoffMultiplier": 4,
                     "retryableStatusCodes": [
                         StatusCode.UNKNOWN.name,
                         StatusCode.UNAVAILABLE.name,

--- a/python/lib/sift_py/grpc/_retry.py
+++ b/python/lib/sift_py/grpc/_retry.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+from typing import Dict, List, TypedDict
+
+from grpc import StatusCode
+from typing_extensions import Self
+
+
+class RetryPolicy:
+    """
+    Retry policy meant to be used for `sift_py.grpc.transport.SiftChannel`. Users may have the ability to configure their own
+    custom retry policy in the future, but for now this is primarily intended for internal use.
+
+    - [Retry policy schema](https://github.com/grpc/grpc-proto/blob/ec30f589e2519d595688b9a42f88a91bdd6b733f/grpc/service_config/service_config.proto#L136)
+    - [Enable gRPC retry option](https://github.com/grpc/grpc/blob/9a5fdfc3d3a7fc575a394360be4532ee09a85620/include/grpc/impl/channel_arg_names.h#L311)
+    - [Service config option](https://github.com/grpc/grpc/blob/9a5fdfc3d3a7fc575a394360be4532ee09a85620/include/grpc/impl/channel_arg_names.h#L207)
+    """
+
+    config: RetryConfig
+
+    DEFAULT_POLICY: RetryConfig = {
+        "methodConfig": [
+            {
+                # We can configure this on a per-service and RPC basis but for now we'll
+                # apply this across all services and RPCs.
+                "name": [{}],
+                "retryPolicy": {
+                    # gRPC does not allow more than 5 attempts
+                    "maxAttempts": 5,
+                    "initialBackoff": "0.1s",
+                    "maxBackoff": "1s",
+                    "backoffMultiplier": 2,
+                    "retryableStatusCodes": [
+                        StatusCode.UNKNOWN.name,
+                        StatusCode.UNAVAILABLE.name,
+                        StatusCode.ABORTED.name,
+                        StatusCode.DEADLINE_EXCEEDED.name,
+                    ],
+                },
+            }
+        ]
+    }
+
+    def __init__(self, config: RetryConfig):
+        self.config = config
+
+    def as_json(self) -> str:
+        return json.dumps(self.config)
+
+    @classmethod
+    def default(cls) -> Self:
+        return cls(config=cls.DEFAULT_POLICY)
+
+
+class RetryConfig(TypedDict):
+    methodConfig: List[MethodConfigDict]
+
+
+class MethodConfigDict(TypedDict):
+    name: List[Dict[str, str]]
+    retryPolicy: RetryConfigDict
+
+
+class RetryConfigDict(TypedDict):
+    maxAttempts: int
+    initialBackoff: str
+    maxBackoff: str
+    backoffMultiplier: int
+    retryableStatusCodes: List[str]

--- a/python/lib/sift_py/grpc/transport.py
+++ b/python/lib/sift_py/grpc/transport.py
@@ -26,7 +26,7 @@ def use_sift_channel(config: SiftChannelConfig) -> SiftChannel:
 
     Should an RPC fail for a reason that isn't explicitly controlled by Sift, `SiftChannel`
     will automatically leverage gRPC's retry mechanism to try and recover until the max-attempts
-    are exceeded, after which the underlying exception will be raised
+    are exceeded, after which the underlying exception will be raised.
     """
     if not config.get("use_ssl", True):
         return _use_insecure_sift_channel(config)

--- a/python/lib/sift_py/grpc/transport.py
+++ b/python/lib/sift_py/grpc/transport.py
@@ -23,6 +23,10 @@ def use_sift_channel(config: SiftChannelConfig) -> SiftChannel:
     Returns an intercepted channel that is meant to be used across all services that
     make RPCs to Sift's API. It is highly encouraged to use this within a with-block
     for correct resource clean-up.
+
+    Should an RPC fail for a reason that isn't explicitly controlled by Sift, `SiftChannel`
+    will automatically leverage gRPC's retry mechanism to try and recover until the max-attempts
+    are exceeded, after which the underlying exception will be raised
     """
     if not config.get("use_ssl", True):
         return _use_insecure_sift_channel(config)

--- a/python/lib/sift_py/grpc/transport.py
+++ b/python/lib/sift_py/grpc/transport.py
@@ -6,13 +6,14 @@ and should generally be used within a with-block for correct resource management
 
 from __future__ import annotations
 
-from typing import List, TypedDict
+from typing import Any, List, Tuple, TypedDict
 
 import grpc
 from grpc_interceptor import ClientInterceptor
-from typing_extensions import TypeAlias
+from typing_extensions import NotRequired, TypeAlias
 
 from sift_py.grpc._interceptors import Metadata, MetadataInterceptor
+from sift_py.grpc._retry import RetryPolicy
 
 SiftChannel: TypeAlias = grpc.Channel
 
@@ -21,10 +22,14 @@ def use_sift_channel(config: SiftChannelConfig) -> SiftChannel:
     """
     Returns an intercepted channel that is meant to be used across all services that
     make RPCs to Sift's API. It is highly encouraged to use this within a with-block
-    for correct resouce clean-up as to ensure no long-lived idle channels.
+    for correct resource clean-up.
     """
+    if not config.get("use_ssl", True):
+        return _use_insecure_sift_channel(config)
+
     credentials = grpc.ssl_channel_credentials()
-    channel = grpc.secure_channel(config["uri"], credentials)
+    options = _compute_channel_options()
+    channel = grpc.secure_channel(config["uri"], credentials, options)
     interceptors = _compute_sift_interceptors(config)
     return grpc.intercept_channel(channel, *interceptors)
 
@@ -33,7 +38,8 @@ def _use_insecure_sift_channel(config: SiftChannelConfig) -> SiftChannel:
     """
     FOR DEVELOPMENT PURPOSES ONLY
     """
-    channel = grpc.insecure_channel(config["uri"])
+    options = _compute_channel_options()
+    channel = grpc.insecure_channel(config["uri"], options)
     interceptors = _compute_sift_interceptors(config)
     return grpc.intercept_channel(channel, *interceptors)
 
@@ -45,6 +51,13 @@ def _compute_sift_interceptors(config: SiftChannelConfig) -> List[ClientIntercep
     return [
         _metadata_interceptor(config),
     ]
+
+
+def _compute_channel_options() -> List[Tuple[str, Any]]:
+    """
+    Initialize all [channel options](https://github.com/grpc/grpc/blob/v1.64.x/include/grpc/impl/channel_arg_names.h) here.
+    """
+    return [("grpc.enable_retries", 1), ("grpc.service_config", RetryPolicy.default().as_json())]
 
 
 def _metadata_interceptor(config: SiftChannelConfig) -> ClientInterceptor:
@@ -63,7 +76,9 @@ class SiftChannelConfig(TypedDict):
     Config class used to instantiate a `SiftChannel` via `use_sift_channel`.
     - `uri`: The URI of Sift's gRPC API. The scheme portion of the URI i.e. `https://` should be ommitted.
     - `apikey`: User-generated API key generated via the Sift application.
+    - `use_ssl`: INTERNAL USE. Meant to be used for local development.
     """
 
     uri: str
     apikey: str
+    use_ssl: NotRequired[bool]

--- a/python/lib/sift_py/grpc/transport_test.py
+++ b/python/lib/sift_py/grpc/transport_test.py
@@ -1,0 +1,170 @@
+# ruff: noqa: N802
+
+import re
+from concurrent import futures
+from contextlib import contextmanager
+from typing import Any, Callable, Iterator, cast
+
+import grpc
+import pytest
+from grpc_interceptor import ServerInterceptor
+from pytest_mock import MockFixture, MockType
+from sift.data.v1.data_pb2 import GetDataRequest, GetDataResponse
+from sift.data.v1.data_pb2_grpc import (
+    DataServiceServicer,
+    DataServiceStub,
+    add_DataServiceServicer_to_server,
+)
+
+from sift_py.grpc.transport import SiftChannelConfig, use_sift_channel
+
+
+class DataService(DataServiceServicer):
+    def GetData(self, request: GetDataRequest, context: grpc.ServicerContext):
+        return GetDataResponse(next_page_token="next-page-token")
+
+
+class AuthInterceptor(ServerInterceptor):
+    AUTH_REGEX = re.compile(r"^Bearer (.+)$")
+
+    def intercept(
+        self,
+        method: Callable,
+        request_or_iterator: Any,
+        context: grpc.ServicerContext,
+        method_name: str,
+    ) -> Any:
+        authenticated = False
+        for metadata in context.invocation_metadata():
+            if metadata.key == "authorization":
+                auth = self.__class__.AUTH_REGEX.match(metadata.value)
+
+                if auth is not None and len(auth.group(1)) > 0:
+                    authenticated = True
+
+                break
+
+        if authenticated:
+            return method(request_or_iterator, context)
+        else:
+            context.set_code(grpc.StatusCode.UNAUTHENTICATED)
+            context.set_details("Invalid or missing API key")
+            raise
+
+
+class ForceFailInterceptor(ServerInterceptor):
+    """
+    Force RPC to fail a few times before letting it pass.
+
+    `failed_attempts`: Count of how many times failed
+    `expected_num_fails`: How many times you want call to fail
+    """
+
+    failed_attempts: int
+    expected_num_fails: int
+
+    def __init__(self, expected_num_fails: int):
+        self.expected_num_fails = expected_num_fails
+        self.failed_attempts = 0
+        super().__init__()
+
+    def intercept(
+        self,
+        method: Callable,
+        request_or_iterator: Any,
+        context: grpc.ServicerContext,
+        method_name: str,
+    ) -> Any:
+        if self.failed_attempts < self.expected_num_fails:
+            self.failed_attempts += 1
+            context.set_code(grpc.StatusCode.UNKNOWN)
+            context.set_details("something unknown happened")
+            raise
+
+        return method(request_or_iterator, context)
+
+
+def test_sift_channel(mocker: MockFixture):
+    @contextmanager
+    def test_server_spy(*interceptors: ServerInterceptor) -> Iterator[MockType]:
+        server = grpc.server(
+            thread_pool=futures.ThreadPoolExecutor(max_workers=1), interceptors=list(interceptors)
+        )
+
+        data_service = DataService()
+        spy = mocker.spy(data_service, "GetData")
+
+        add_DataServiceServicer_to_server(data_service, server)
+        server.add_insecure_port("[::]:50052")
+        server.start()
+        try:
+            yield spy
+        finally:
+            server.stop(None)
+            server.wait_for_termination()
+
+    with test_server_spy(AuthInterceptor()) as get_data_spy:
+        sift_channel_config_a: SiftChannelConfig = {
+            "uri": "localhost:50052",
+            "apikey": "",
+            "use_ssl": False,
+        }
+
+        with use_sift_channel(sift_channel_config_a) as channel:
+            with pytest.raises(grpc.RpcError, match="UNAUTHENTICATED"):
+                stub = DataServiceStub(channel)
+                _ = cast(GetDataResponse, stub.GetData(GetDataRequest()))
+
+            get_data_spy.assert_not_called()
+
+        sift_channel_config_b: SiftChannelConfig = {
+            "uri": "localhost:50052",
+            "apikey": "some-token",
+            "use_ssl": False,
+        }
+
+        with use_sift_channel(sift_channel_config_b) as channel:
+            stub = DataServiceStub(channel)
+            res = cast(GetDataResponse, stub.GetData(GetDataRequest()))
+            assert res.next_page_token == "next-page-token"
+            get_data_spy.assert_called_once()
+
+    force_fail_interceptor = ForceFailInterceptor(4)
+    with test_server_spy(AuthInterceptor(), force_fail_interceptor) as get_data_spy:
+        sift_channel_config_c: SiftChannelConfig = {
+            "uri": "localhost:50052",
+            "apikey": "some-token",
+            "use_ssl": False,
+        }
+
+        with use_sift_channel(sift_channel_config_c) as channel:
+            stub = DataServiceStub(channel)
+            # This will attempt 5 times: fail 4 times, succeed on 5th
+            res = cast(GetDataResponse, stub.GetData(GetDataRequest()))
+            assert res.next_page_token == "next-page-token"
+            get_data_spy.assert_called_once()
+
+    # fail 4 times, pass the 5th attempt
+    assert force_fail_interceptor.failed_attempts == 4
+
+    # Now we're going to fail beyond the max retry attempts
+
+    force_fail_interceptor_max = ForceFailInterceptor(7)
+    with test_server_spy(AuthInterceptor(), force_fail_interceptor_max) as get_data_spy:
+        sift_channel_config_d: SiftChannelConfig = {
+            "uri": "localhost:50052",
+            "apikey": "some-token",
+            "use_ssl": False,
+        }
+
+        with use_sift_channel(sift_channel_config_d) as channel:
+            stub = DataServiceStub(channel)
+
+            # This will go beyond the max number of attempts
+            with pytest.raises(Exception):
+                res = cast(GetDataResponse, stub.GetData(GetDataRequest()))
+
+            get_data_spy.assert_not_called()
+
+    # All attempts failed
+    assert force_fail_interceptor_max.failed_attempts == 5

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -44,10 +44,10 @@ development = [
   "mypy==1.10.0",
 
    # testing tools
-  "pytest",
-  "pytest-benchmark",
-  "pytest-mock",
-  "grpcio-testing",
+  "pytest==8.2.2",
+  "pytest-benchmark==4.0.0",
+  "pytest-mock==3.14.0",
+  "grpcio-testing==1.64.1",
 
   # formatter + linter
   "ruff",


### PR DESCRIPTION
## Changes

This PR adds support for automated retries using gRPC's retry mechanism should an RPC fail and return any of the following status codes:
- `UNKNOWN`
- `UNAVAILABLE`
- `ABORTED`
- `DEADLINE EXCEEDED`

These status codes were chosen on the basis that they are not explicitly set by Sift and often occur due to some external factor. Here is the retry policy that is introduced in this PR:

```python
  DEFAULT_POLICY: RetryConfig = {
      "methodConfig": [
          {
              # We can configure this on a per-service and RPC basis but for now we'll
              # apply this across all services and RPCs.
              "name": [{}],
              "retryPolicy": {
                  # gRPC does not allow more than 5 attempts
                  "maxAttempts": 5,
                  "initialBackoff": "0.1s",
                  "maxBackoff": "1s",
                  "backoffMultiplier": 2,
                  "retryableStatusCodes": [
                      StatusCode.UNKNOWN.name,
                      StatusCode.UNAVAILABLE.name,
                      StatusCode.ABORTED.name,
                      StatusCode.DEADLINE_EXCEEDED.name,
                  ],
              },
          }
      ]
  }
```

Users may be given the ability to customize retry policies in the future, but for now this is kept internal. The following is a link to the retry policy schema for the reviewer's convenience:

- [Retry policy schema](https://github.com/grpc/grpc-proto/blob/ec30f589e2519d595688b9a42f88a91bdd6b733f/grpc/service_config/service_config.proto#L136)

## Verification

The unit test in `python/lib/sift_py/grpc/transport_test.py` spins up a local test server that returns `UNKNOWN` error codes, recording number of failed attempts and ensuring successful attempts.

