### PR TITLE
python(feature): support keepalive

### DIFF
--- a/python/lib/sift_py/grpc/keepalive.py
+++ b/python/lib/sift_py/grpc/keepalive.py
@@ -1,0 +1,34 @@
+from typing import TypedDict
+
+DEFAULT_KEEPALIVE_TIME_MS = 20_000
+"""Interval with which to send keepalive pings"""
+
+DEFAULT_KEEPALIVE_TIMEOUT_MS = 60_000
+"""Timeout while waiting for server to acknowledge keepalive ping"""
+
+DEFAULT_KEEPALIVE_PERMIT_WITHOUT_CALLS = 0
+"""Disabled"""
+
+DEFAULT_MAX_PINGS_WITHOUT_DATA = 0
+"""Disabled"""
+
+
+# https://github.com/grpc/grpc/blob/master/doc/keepalive.md
+class KeepaliveConfig(TypedDict):
+    """
+    Make make this public in the future to allow folks to configure their own keepalive settings
+    if there is demand for it.
+    """
+
+    keepalive_time_ms: int
+    keepalive_timeout_ms: int
+    keepalive_permit_without_calls: int
+    max_pings_without_data: int
+
+
+DEFAULT_KEEPALIVE_CONFIG: KeepaliveConfig = {
+    "keepalive_time_ms": DEFAULT_KEEPALIVE_TIME_MS,
+    "keepalive_timeout_ms": DEFAULT_KEEPALIVE_TIMEOUT_MS,
+    "keepalive_permit_without_calls": DEFAULT_KEEPALIVE_PERMIT_WITHOUT_CALLS,
+    "max_pings_without_data": DEFAULT_MAX_PINGS_WITHOUT_DATA,
+}

--- a/python/lib/sift_py/grpc/transport.py
+++ b/python/lib/sift_py/grpc/transport.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from typing import Any, List, Optional, Tuple, TypedDict, Union
 from urllib.parse import ParseResult, urlparse
 
-
 import grpc
 import grpc.aio as grpc_aio
 from typing_extensions import NotRequired, TypeAlias

--- a/python/lib/sift_py/grpc/transport.py
+++ b/python/lib/sift_py/grpc/transport.py
@@ -10,7 +10,6 @@ from typing import Any, List, Optional, Tuple, TypedDict, Union
 
 import grpc
 import grpc.aio as grpc_aio
-from sift_py.grpc.keepalive import DEFAULT_KEEPALIVE_CONFIG, KeepaliveConfig
 from typing_extensions import NotRequired, TypeAlias
 
 from sift_py.grpc._async_interceptors.base import ClientAsyncInterceptor
@@ -18,6 +17,7 @@ from sift_py.grpc._async_interceptors.metadata import MetadataAsyncInterceptor
 from sift_py.grpc._interceptors.base import ClientInterceptor
 from sift_py.grpc._interceptors.metadata import Metadata, MetadataInterceptor
 from sift_py.grpc._retry import RetryPolicy
+from sift_py.grpc.keepalive import DEFAULT_KEEPALIVE_CONFIG, KeepaliveConfig
 
 SiftChannel: TypeAlias = grpc.Channel
 SiftAsyncChannel: TypeAlias = grpc_aio.Channel


### PR DESCRIPTION
## Changes

Support keepalive for `SiftChannel` for HTTP2 keepalive-pings.