### PR TITLE
python(feature): timeout-based flushing for buffered ingestion

### DIFF
--- a/python/lib/sift_py/ingestion/_service_test.py
+++ b/python/lib/sift_py/ingestion/_service_test.py
@@ -1,6 +1,7 @@
 import random
 from contextlib import contextmanager
 from datetime import datetime, timezone
+from time import sleep
 
 import pytest
 from pytest_mock import MockFixture
@@ -353,3 +354,72 @@ def test_ingestion_service_register_new_flow(mocker: MockFixture):
     ingestion_service.create_flow(new_flow_config_name_collision)
     assert ingestion_service.flow_configs_by_name["my_new_flow"] == new_flow_config_name_collision
     assert ingestion_service.flow_configs_by_name["my_new_flow"] != new_flow_config
+
+
+def test_ingestion_service_buffered_ingestion_flush_timeout(mocker: MockFixture):
+    """
+    Test for timeout based flush mechanism in buffered ingestion. If buffer hasn't been flushed
+    after a certain time then the buffer will be automatically flushed.
+    """
+
+    mock_ingest = mocker.patch.object(IngestionService, "ingest")
+    mock_ingest.return_value = None
+
+    readings_flow = FlowConfig(
+        name="readings",
+        channels=[
+            ChannelConfig(
+                name="my-channel",
+                data_type=ChannelDataType.DOUBLE,
+            ),
+        ],
+    )
+
+    telemetry_config = TelemetryConfig(
+        asset_name="my-asset",
+        ingestion_client_key="ingestion-client-key",
+        flows=[readings_flow],
+    )
+
+    mock_ingestion_config = IngestionConfigPb(
+        ingestion_config_id="ingestion-config-id",
+        asset_id="asset-id",
+        client_key="client-key",
+    )
+
+    mock_get_ingestion_config_by_client_key = mocker.patch(
+        _mock_path(get_ingestion_config_by_client_key)
+    )
+    mock_get_ingestion_config_by_client_key.return_value = mock_ingestion_config
+
+    mock_get_ingestion_config_flows = mocker.patch(_mock_path(get_ingestion_config_flows))
+    mock_get_ingestion_config_flows.return_value = [readings_flow.as_pb(FlowConfigPb)]
+
+    ingestion_service = IngestionService(MockChannel(), telemetry_config)
+
+    @contextmanager
+    def mock_ctx_manager():
+        yield
+        mock_ingest.reset_mock()
+
+    with mock_ctx_manager():
+        with ingestion_service.buffered_ingestion(flush_interval_sec=2) as buffered_ingestion:
+            assert buffered_ingestion._buffer_size == 1_000
+
+            for _ in range(1_500):
+                buffered_ingestion.try_ingest_flows(
+                    {
+                        "flow_name": "readings",
+                        "timestamp": datetime.now(timezone.utc),
+                        "channel_values": [
+                            {"channel_name": "my-channel", "value": double_value(random.random())}
+                        ],
+                    }
+                )
+            assert mock_ingest.call_count == 1
+            assert len(buffered_ingestion._buffer) == 500
+
+            # This will cause the flush timer to flush based on provided interval
+            sleep(5)
+            assert mock_ingest.call_count == 2
+            assert len(buffered_ingestion._buffer) == 0

--- a/python/lib/sift_py/ingestion/buffer.py
+++ b/python/lib/sift_py/ingestion/buffer.py
@@ -1,4 +1,5 @@
 import threading
+from contextlib import contextmanager
 from types import TracebackType
 from typing import Generic, List, Optional, Type, TypeVar
 
@@ -68,33 +69,34 @@ class BufferedIngestionService(Generic[T]):
         See `sift_py.ingestion.service.IngestionService.create_ingestion_request`
         for more information.
         """
-        lhs_cursor = 0
-        rhs_cursor = min(
-            self._buffer_size - len(self._buffer),
-            len(flows),
-        )
-
-        while lhs_cursor < len(flows):
-            for flow in flows[lhs_cursor:rhs_cursor]:
-                flow_name = flow["flow_name"]
-                timestamp = flow["timestamp"]
-                channel_values = flow["channel_values"]
-
-                req = self._ingestion_service.create_ingestion_request(
-                    flow_name=flow_name,
-                    timestamp=timestamp,
-                    channel_values=channel_values,
-                )
-                self._buffer.append(req)
-
-            if len(self._buffer) >= self._buffer_size:
-                self.flush()
-
-            lhs_cursor = rhs_cursor
+        with self._use_lock():
+            lhs_cursor = 0
             rhs_cursor = min(
-                rhs_cursor + (self._buffer_size - len(self._buffer)),
+                self._buffer_size - len(self._buffer),
                 len(flows),
             )
+
+            while lhs_cursor < len(flows):
+                for flow in flows[lhs_cursor:rhs_cursor]:
+                    flow_name = flow["flow_name"]
+                    timestamp = flow["timestamp"]
+                    channel_values = flow["channel_values"]
+
+                    req = self._ingestion_service.create_ingestion_request(
+                        flow_name=flow_name,
+                        timestamp=timestamp,
+                        channel_values=channel_values,
+                    )
+                    self._buffer.append(req)
+
+                if len(self._buffer) >= self._buffer_size:
+                    self._flush()
+
+                lhs_cursor = rhs_cursor
+                rhs_cursor = min(
+                    rhs_cursor + (self._buffer_size - len(self._buffer)),
+                    len(flows),
+                )
 
     def try_ingest_flows(self, *flows: Flow):
         """
@@ -102,41 +104,40 @@ class BufferedIngestionService(Generic[T]):
         generated from a flow. See `sift_py.ingestion.service.IngestionService.try_create_ingestion_request`
         for more information.
         """
-        lhs_cursor = 0
-        rhs_cursor = min(
-            self._buffer_size - len(self._buffer),
-            len(flows),
-        )
-
-        while lhs_cursor < len(flows):
-            for flow in flows[lhs_cursor:rhs_cursor]:
-                flow_name = flow["flow_name"]
-                timestamp = flow["timestamp"]
-                channel_values = flow["channel_values"]
-
-                req = self._ingestion_service.try_create_ingestion_request(
-                    flow_name=flow_name,
-                    timestamp=timestamp,
-                    channel_values=channel_values,
-                )
-                self._buffer.append(req)
-
-            if len(self._buffer) >= self._buffer_size:
-                self.flush()
-
-            lhs_cursor = rhs_cursor
+        with self._use_lock():
+            lhs_cursor = 0
             rhs_cursor = min(
-                rhs_cursor + (self._buffer_size - len(self._buffer)),
+                self._buffer_size - len(self._buffer),
                 len(flows),
             )
+
+            while lhs_cursor < len(flows):
+                for flow in flows[lhs_cursor:rhs_cursor]:
+                    flow_name = flow["flow_name"]
+                    timestamp = flow["timestamp"]
+                    channel_values = flow["channel_values"]
+
+                    req = self._ingestion_service.try_create_ingestion_request(
+                        flow_name=flow_name,
+                        timestamp=timestamp,
+                        channel_values=channel_values,
+                    )
+                    self._buffer.append(req)
+
+                if len(self._buffer) >= self._buffer_size:
+                    self._flush()
+
+                lhs_cursor = rhs_cursor
+                rhs_cursor = min(
+                    rhs_cursor + (self._buffer_size - len(self._buffer)),
+                    len(flows),
+                )
 
     def flush(self):
         """
         Flush and ingest all requests in buffer.
         """
 
-        # TODO: Make sure that this is the correct way to ensure that this is the only
-        # Python thread running. Buffer is written to in the ingest flow methods..
         if self._flush_timer and self._lock:
             with self._lock:
                 self._flush()
@@ -156,8 +157,19 @@ class BufferedIngestionService(Generic[T]):
 
     def _cancel_flush_timer(self):
         if self._flush_timer:
-            self._flush_timer = self._flush_timer.cancel()
+            self._flush_timer.cancel()
+            self._flush_timer = None
 
     def _restart_flush_timer(self):
         self._cancel_flush_timer()
         self._start_flush_timer()
+
+    @contextmanager
+    def _use_lock(self):
+        try:
+            if self._lock:
+                self._lock.acquire()
+            yield
+        finally:
+            if self._lock:
+                self._lock.release()

--- a/python/lib/sift_py/ingestion/service.py
+++ b/python/lib/sift_py/ingestion/service.py
@@ -11,7 +11,7 @@ from sift.ingestion_configs.v1.ingestion_configs_pb2 import IngestionConfig
 
 from sift_py.grpc.transport import SiftChannel
 from sift_py.ingestion._internal.ingest import _IngestionServiceImpl
-from sift_py.ingestion.buffer import BufferedIngestionService
+from sift_py.ingestion.buffer import BufferedIngestionService, OnErrorCallback
 from sift_py.ingestion.channel import ChannelValue
 from sift_py.ingestion.config.telemetry import TelemetryConfig
 from sift_py.ingestion.flow import Flow, FlowConfig, FlowOrderedChannelValues
@@ -150,7 +150,10 @@ class IngestionService(_IngestionServiceImpl):
         return super().try_ingest_flows(*flows)
 
     def buffered_ingestion(
-        self, buffer_size: Optional[int] = None, flush_interval_sec: Optional[float] = None
+        self,
+        buffer_size: Optional[int] = None,
+        flush_interval_sec: Optional[float] = None,
+        on_error: Optional[OnErrorCallback] = None,
     ) -> BufferedIngestionService:
         """
         This method automates buffering requests and streams them in batches. It is recommended to be used
@@ -166,6 +169,12 @@ class IngestionService(_IngestionServiceImpl):
         is filled. The interval between flushes is set via the `flush_interval_sec` argument which is the number of seconds between each flush.
         If a flush were to occur due to the buffer being filled, then the timer will restart. If `flush_interval_sec` is `None`, then flushes will only
         occur once the buffer is filled and at the end of the scope of the with-block.
+
+        If an error were to occur that would cause the context manager to call `__exit__`, one last attempt to flush the buffer will be made
+        before the error is re-raised for the caller to handle. If the caller would instead like to customize `__exit__` behavior in the case
+        of an error, they can make use of the `on_error` argument whose type signature is a function where the first argument is the error,
+        the second is the buffer containing the uningested request, and the third argument being a function where, when called, will attempt
+        to flush the buffer.
 
         Example usage:
 
@@ -199,9 +208,19 @@ class IngestionService(_IngestionServiceImpl):
                     "timestamp": datetime.now(timezone.utc),
                     "channel_values": [double_value(3)]
                 })
+
+        # Custom code to run when error
+        def on_error_calback(err, buffer, flush):
+            # Save contents of buffer to disk
+            ...
+            # Try once more to flush the buffer
+            flush()
+
+        with ingestion_service.buffered_ingestion(on_error=on_error_calback) as buffered_ingestion:
+            ...
         ```
         """
-        return BufferedIngestionService(self, buffer_size, flush_interval_sec)
+        return BufferedIngestionService(self, buffer_size, flush_interval_sec, on_error)
 
     def create_flow(self, flow_config: FlowConfig):
         """


### PR DESCRIPTION
## Changes

This PR adds support for timeout-based flushing for buffered ingestion. Users can now configure an interval in which a buffer will get flushed regardless of whether or not the buffer has been filled. If a buffer is flushed due to being filled, the timer gets restarted.

Additionally, this PR introduces the ability to customize `__exit__` behavior when using the buffered ingestion API in a context manager when there is an error.