### PR TITLE
python(fix): add missing double channel computation

### DIFF
--- a/python/lib/sift_py/ingestion/channel.py
+++ b/python/lib/sift_py/ingestion/channel.py
@@ -95,6 +95,8 @@ class ChannelConfig(AsProtobuf):
                 return uint64_value(int(value))
             elif self.data_type == ChannelDataType.FLOAT:
                 return float_value(float(value))
+            elif self.data_type == ChannelDataType.DOUBLE:
+                return double_value(float(value))
             elif self.data_type == ChannelDataType.ENUM:
                 return enum_value(int(value))
         elif isinstance(value, str) and self.data_type == ChannelDataType.STRING:


### PR DESCRIPTION
## Changes

A check for the double channel data type was omitted from method that produced a channel value from a channel config.