### PR TITLE
feat: Asset agnostic rule configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ python/protos/**/*
 python/build
 python/docs/sift_py
 *.egg-info/
+
+.vscode/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "python"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "python.testing.pytestArgs": [
-        "python"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
-}

--- a/python/examples/ingestion_with_python_config/rule_modules/velocity.yml
+++ b/python/examples/ingestion_with_python_config/rule_modules/velocity.yml
@@ -1,0 +1,12 @@
+namespace: velocity
+
+rules:
+  - name: vehicle_stuck
+    description: Checks that vehicle velocity becomes nonzero 5s after entering accelerating state
+    expression: $1 == "Accelerating" && persistence($2 == 0, 5)
+    type: review
+
+  - name: vehicle_not_stopped
+    description: Makes sure vehicle velocity remains 0 while stopped
+    expression: $1 == "Stopped" && $2 > 0
+    type: review

--- a/python/examples/ingestion_with_python_config/rule_modules/velocity.yml
+++ b/python/examples/ingestion_with_python_config/rule_modules/velocity.yml
@@ -2,11 +2,11 @@ namespace: velocity
 
 rules:
   - name: vehicle_stuck
-    description: Checks that vehicle velocity becomes nonzero 5s after entering accelerating state
+    description: Triggers if the vehicle velocity is not 0 for 5s after entering accelerating state
     expression: $1 == "Accelerating" && persistence($2 == 0, 5)
     type: review
 
   - name: vehicle_not_stopped
-    description: Makes sure vehicle velocity remains 0 while stopped
+    description: Triggers if the vehicle velocity does not remain 0 while stopped
     expression: $1 == "Stopped" && $2 > 0
     type: review

--- a/python/examples/ingestion_with_python_config/rule_modules/voltage.yml
+++ b/python/examples/ingestion_with_python_config/rule_modules/voltage.yml
@@ -1,0 +1,12 @@
+namespace: voltage
+
+rules:
+  - name: overvoltage
+    description: Checks for overvoltage while accelerating
+    expression: $1 == "Accelerating" && $2 > 80
+    type: review
+
+  - name: undervoltage
+    description: Checks for undervoltage while accelerating
+    expression: $1 == "Accelerating" && $2 < 40
+    type: review

--- a/python/examples/ingestion_with_python_config/telemetry_config.py
+++ b/python/examples/ingestion_with_python_config/telemetry_config.py
@@ -7,13 +7,14 @@ from sift_py.ingestion.channel import (
     ChannelEnumType,
 )
 from sift_py.ingestion.config.telemetry import FlowConfig, TelemetryConfig
-from sift_py.ingestion.config.yaml.load import load_named_expression_modules
+from sift_py.ingestion.config.yaml.load import load_named_expression_modules, load_rule_namespaces
 from sift_py.ingestion.rule.config import (
     RuleActionCreateDataReviewAnnotation,
     RuleConfig,
 )
 
 EXPRESSION_MODULES_DIR = Path().joinpath("expression_modules")
+RULE_NAMESPACES_DIR = Path().joinpath("rule_modules")
 
 
 def nostromos_lv_426() -> TelemetryConfig:
@@ -21,6 +22,12 @@ def nostromos_lv_426() -> TelemetryConfig:
         [
             EXPRESSION_MODULES_DIR.joinpath("kinematics.yml"),
             EXPRESSION_MODULES_DIR.joinpath("string.yml"),
+        ]
+    )
+
+    rule_namespaces = load_rule_namespaces(
+        [
+            RULE_NAMESPACES_DIR,
         ]
     )
 
@@ -123,6 +130,70 @@ def nostromos_lv_426() -> TelemetryConfig:
                     # assignee="ellen.ripley@weylandcorp.com",
                     tags=["nostromo", "failure"],
                 ),
+            ),
+            RuleConfig(
+                name="overvoltage",
+                namespace="voltage",
+                namespace_rules=rule_namespaces,
+                channel_references=[
+                    # INFO: Can use either "channel_identifier" or "channel_config"
+                    {
+                        "channel_reference": "$1",
+                        "channel_identifier": vehicle_state_channel.fqn(),
+                    },
+                    {
+                        "channel_reference": "$2",
+                        "channel_config": voltage_channel,
+                    },
+                ],
+            ),
+            RuleConfig(
+                name="undervoltage",
+                namespace="voltage",
+                namespace_rules=rule_namespaces,
+                channel_references=[
+                    # INFO: Can use either "channel_identifier" or "channel_config"
+                    {
+                        "channel_reference": "$1",
+                        "channel_identifier": vehicle_state_channel.fqn(),
+                    },
+                    {
+                        "channel_reference": "$2",
+                        "channel_config": voltage_channel,
+                    },
+                ],
+            ),
+            RuleConfig(
+                name="vehicle_stuck",
+                namespace="velocity",
+                namespace_rules=rule_namespaces,
+                channel_references=[
+                    # INFO: Can use either "channel_identifier" or "channel_config"
+                    {
+                        "channel_reference": "$1",
+                        "channel_identifier": vehicle_state_channel.fqn(),
+                    },
+                    {
+                        "channel_reference": "$2",
+                        "channel_config": velocity_channel,
+                    },
+                ],
+            ),
+            RuleConfig(
+                name="vehicle_not_stopped",
+                namespace="velocity",
+                namespace_rules=rule_namespaces,
+                channel_references=[
+                    # INFO: Can use either "channel_identifier" or "channel_config"
+                    {
+                        "channel_reference": "$1",
+                        "channel_identifier": vehicle_state_channel.fqn(),
+                    },
+                    {
+                        "channel_reference": "$2",
+                        "channel_config": velocity_channel,
+                    },
+                ],
             ),
         ],
         flows=[

--- a/python/examples/ingestion_with_yaml_config/rule_modules/velocity.yml
+++ b/python/examples/ingestion_with_yaml_config/rule_modules/velocity.yml
@@ -3,7 +3,7 @@ namespace: velocity
 rules:
   - name: vehicle_stuck
     description: Checks that vehicle velocity becomes nonzero 5s after entering accelerating state
-    expression: $1 == "Accelerating" && persistence($2 = 0, 5)
+    expression: $1 == "Accelerating" && persistence($2 == 0, 5)
     type: review
 
   - name: vehicle_not_stopped

--- a/python/examples/ingestion_with_yaml_config/rule_modules/velocity.yml
+++ b/python/examples/ingestion_with_yaml_config/rule_modules/velocity.yml
@@ -2,11 +2,11 @@ namespace: velocity
 
 rules:
   - name: vehicle_stuck
-    description: Checks that vehicle velocity becomes nonzero 5s after entering accelerating state
+    description: Triggers if the vehicle velocity is not 0 for 5s after entering accelerating state
     expression: $1 == "Accelerating" && persistence($2 == 0, 5)
     type: review
 
   - name: vehicle_not_stopped
-    description: Makes sure vehicle velocity remains 0 while stopped
+    description: Triggers if the vehicle velocity does not remain 0 while stopped
     expression: $1 == "Stopped" && $2 > 0
     type: review

--- a/python/examples/ingestion_with_yaml_config/rule_modules/velocity.yml
+++ b/python/examples/ingestion_with_yaml_config/rule_modules/velocity.yml
@@ -3,7 +3,7 @@ namespace: velocity
 rules:
   - name: vehicle_stuck
     description: Checks that vehicle velocity becomes nonzero 5s after entering accelerating state
-    expression: $1 == "Accelerating" && persistence($2 > 0, 5)
+    expression: $1 == "Accelerating" && persistence($2 = 0, 5)
     type: review
 
   - name: vehicle_not_stopped

--- a/python/examples/ingestion_with_yaml_config/rule_modules/velocity.yml
+++ b/python/examples/ingestion_with_yaml_config/rule_modules/velocity.yml
@@ -9,3 +9,4 @@ rules:
   - name: vehicle_not_stopped
     description: Makes sure vehicle velocity remains 0 while stopped
     expression: $1 == "Stopped" && $2 > 0
+    type: review

--- a/python/examples/ingestion_with_yaml_config/rule_modules/velocity.yml
+++ b/python/examples/ingestion_with_yaml_config/rule_modules/velocity.yml
@@ -1,0 +1,11 @@
+namespace: velocity
+
+rules:
+  - name: vehicle_stuck
+    description: Checks that vehicle velocity becomes nonzero 5s after entering accelerating state
+    expression: $1 == "Accelerating" && persistence($2 > 0, 5)
+    type: review
+
+  - name: vehicle_not_stopped
+    description: Makes sure vehicle velocity remains 0 while stopped
+    expression: $1 == "Stopped" && $2 > 0

--- a/python/examples/ingestion_with_yaml_config/rule_modules/voltage.yml
+++ b/python/examples/ingestion_with_yaml_config/rule_modules/voltage.yml
@@ -5,3 +5,7 @@ rules:
     description: Checks for overvoltage while accelerating
     expression: $1 == "Accelerating" && $2 > 80
     type: review
+
+  - name: undervoltage
+    description: Checks for undervoltage while accelerating
+    expression: $1 == "Accelerating" && $2 < 40

--- a/python/examples/ingestion_with_yaml_config/rule_modules/voltage.yml
+++ b/python/examples/ingestion_with_yaml_config/rule_modules/voltage.yml
@@ -1,4 +1,4 @@
-module_name: voltage
+namespace: voltage
 
 rules:
   - name: overvoltage

--- a/python/examples/ingestion_with_yaml_config/rule_modules/voltage.yml
+++ b/python/examples/ingestion_with_yaml_config/rule_modules/voltage.yml
@@ -9,3 +9,4 @@ rules:
   - name: undervoltage
     description: Checks for undervoltage while accelerating
     expression: $1 == "Accelerating" && $2 < 40
+    type: review

--- a/python/examples/ingestion_with_yaml_config/rule_modules/voltage.yml
+++ b/python/examples/ingestion_with_yaml_config/rule_modules/voltage.yml
@@ -1,0 +1,7 @@
+module_name: voltage
+
+rules:
+  - name: overvoltage
+    description: Checks for overvoltage while accelerating
+    expression: $1 == "Accelerating" && $2 > 80
+    type: review

--- a/python/examples/ingestion_with_yaml_config/telemetry_config.py
+++ b/python/examples/ingestion_with_yaml_config/telemetry_config.py
@@ -23,7 +23,5 @@ def nostromos_lv_426() -> TelemetryConfig:
             EXPRESSION_MODULES_DIR.joinpath("kinematics.yml"),
             EXPRESSION_MODULES_DIR.joinpath("string.yml"),
         ],
-        [
-            RULE_MODULES_DIR.joinpath("voltage.yml")
-        ],
+        [RULE_MODULES_DIR.joinpath("voltage.yml")],
     )

--- a/python/examples/ingestion_with_yaml_config/telemetry_config.py
+++ b/python/examples/ingestion_with_yaml_config/telemetry_config.py
@@ -16,12 +16,12 @@ def nostromos_lv_426() -> TelemetryConfig:
 
     telemetry_config_path = TELEMETRY_CONFIGS_DIR.joinpath(telemetry_config_name)
 
-    # Load your telemetry config with your reusable expressions modules
+    # Load your telemetry config with your reusable expressions modules and rule modules
     return TelemetryConfig.try_from_yaml(
         telemetry_config_path,
         [
             EXPRESSION_MODULES_DIR.joinpath("kinematics.yml"),
             EXPRESSION_MODULES_DIR.joinpath("string.yml"),
         ],
-        [RULE_MODULES_DIR.joinpath("voltage.yml")],
+        [RULE_MODULES_DIR],
     )

--- a/python/examples/ingestion_with_yaml_config/telemetry_config.py
+++ b/python/examples/ingestion_with_yaml_config/telemetry_config.py
@@ -5,6 +5,7 @@ from sift_py.ingestion.service import TelemetryConfig
 
 TELEMETRY_CONFIGS_DIR = Path().joinpath("telemetry_configs")
 EXPRESSION_MODULES_DIR = Path().joinpath("expression_modules")
+RULE_MODULES_DIR = Path().joinpath("rule_modules")
 
 
 def nostromos_lv_426() -> TelemetryConfig:
@@ -21,5 +22,8 @@ def nostromos_lv_426() -> TelemetryConfig:
         [
             EXPRESSION_MODULES_DIR.joinpath("kinematics.yml"),
             EXPRESSION_MODULES_DIR.joinpath("string.yml"),
+        ],
+        [
+            RULE_MODULES_DIR.joinpath("voltage.yml")
         ],
     )

--- a/python/examples/ingestion_with_yaml_config/telemetry_config.py
+++ b/python/examples/ingestion_with_yaml_config/telemetry_config.py
@@ -3,10 +3,9 @@ from pathlib import Path
 
 from sift_py.ingestion.service import TelemetryConfig
 
-TEMP = Path().joinpath("python/examples/ingestion_with_yaml_config")
-TELEMETRY_CONFIGS_DIR = Path().joinpath(TEMP).joinpath("telemetry_configs")
-EXPRESSION_MODULES_DIR = Path().joinpath(TEMP).joinpath("expression_modules")
-RULE_MODULES_DIR = Path().joinpath(TEMP).joinpath("rule_modules")
+TELEMETRY_CONFIGS_DIR = Path().joinpath("telemetry_configs")
+EXPRESSION_MODULES_DIR = Path().joinpath("expression_modules")
+RULE_MODULES_DIR = Path().joinpath("rule_modules")
 
 
 def nostromos_lv_426() -> TelemetryConfig:

--- a/python/examples/ingestion_with_yaml_config/telemetry_config.py
+++ b/python/examples/ingestion_with_yaml_config/telemetry_config.py
@@ -3,9 +3,10 @@ from pathlib import Path
 
 from sift_py.ingestion.service import TelemetryConfig
 
-TELEMETRY_CONFIGS_DIR = Path().joinpath("telemetry_configs")
-EXPRESSION_MODULES_DIR = Path().joinpath("expression_modules")
-RULE_MODULES_DIR = Path().joinpath("rule_modules")
+TEMP = Path().joinpath("python/examples/ingestion_with_yaml_config")
+TELEMETRY_CONFIGS_DIR = Path().joinpath(TEMP).joinpath("telemetry_configs")
+EXPRESSION_MODULES_DIR = Path().joinpath(TEMP).joinpath("expression_modules")
+RULE_MODULES_DIR = Path().joinpath(TEMP).joinpath("rule_modules")
 
 
 def nostromos_lv_426() -> TelemetryConfig:

--- a/python/examples/ingestion_with_yaml_config/telemetry_configs/nostromo_lv_426.yml
+++ b/python/examples/ingestion_with_yaml_config/telemetry_configs/nostromo_lv_426.yml
@@ -127,7 +127,7 @@ flows:
   - name: gpio_channel
     channels:
       - <<: *gpio_channel
-      
+
   - name: logs
     channels:
       - <<: *log_channel

--- a/python/examples/ingestion_with_yaml_config/telemetry_configs/nostromo_lv_426.yml
+++ b/python/examples/ingestion_with_yaml_config/telemetry_configs/nostromo_lv_426.yml
@@ -88,6 +88,11 @@ rules:
         - failure
         - nostromo
 
+  - name: voltage.overvoltage
+    channel_references:
+      - $1: *vehicle_state_channel
+      - $2: *voltage_channel
+ 
 flows:
   - name: readings
     channels:

--- a/python/examples/ingestion_with_yaml_config/telemetry_configs/nostromo_lv_426.yml
+++ b/python/examples/ingestion_with_yaml_config/telemetry_configs/nostromo_lv_426.yml
@@ -93,7 +93,25 @@ rules:
     channel_references:
       - $1: *vehicle_state_channel
       - $2: *voltage_channel
- 
+
+  - namespace: voltage
+    name: undervoltage
+    channel_references:
+      - $1: *vehicle_state_channel
+      - $2: *voltage_channel
+
+  - namespace: velocity
+    name: vehicle_stuck
+    channel_references:
+      - $1: *vehicle_state_channel
+      - $2: *velocity_channel
+
+  - namespace: velocity
+    name: vehicle_not_stopped
+    channel_references:
+      - $1: *vehicle_state_channel
+      - $2: *velocity_channel
+
 flows:
   - name: readings
     channels:

--- a/python/examples/ingestion_with_yaml_config/telemetry_configs/nostromo_lv_426.yml
+++ b/python/examples/ingestion_with_yaml_config/telemetry_configs/nostromo_lv_426.yml
@@ -88,7 +88,8 @@ rules:
         - failure
         - nostromo
 
-  - name: voltage.overvoltage
+  - namespace: voltage
+    name: overvoltage
     channel_references:
       - $1: *vehicle_state_channel
       - $2: *voltage_channel

--- a/python/lib/sift_py/ingestion/config/telemetry.py
+++ b/python/lib/sift_py/ingestion/config/telemetry.py
@@ -12,7 +12,11 @@ from sift_py.ingestion.channel import (
     ChannelEnumType,
     _channel_fqn,
 )
-from sift_py.ingestion.config.yaml.load import load_named_expression_modules, load_named_rule_modules,read_and_validate
+from sift_py.ingestion.config.yaml.load import (
+    load_named_expression_modules,
+    load_named_rule_modules,
+    read_and_validate,
+)
 from sift_py.ingestion.config.yaml.spec import TelemetryConfigYamlSpec
 from sift_py.ingestion.flow import FlowConfig
 from sift_py.ingestion.rule.config import (

--- a/python/lib/sift_py/ingestion/config/telemetry.py
+++ b/python/lib/sift_py/ingestion/config/telemetry.py
@@ -205,6 +205,7 @@ class TelemetryConfig:
                 if not found_rule:
                     # TODO: Maybe we should try and catch this earlier?
                     raise ValueError(f"Could not find rule name {rule['name']} in {namespace}")
+                rule = found_rule
 
             annotation_type = RuleActionAnnotationKind.from_str(rule["type"])
 

--- a/python/lib/sift_py/ingestion/config/telemetry.py
+++ b/python/lib/sift_py/ingestion/config/telemetry.py
@@ -188,10 +188,10 @@ class TelemetryConfig:
             )
 
         for rule in config_as_yaml.get("rules", []):
-            namespace = rule.get("namespace")
+            namespace = rule.get("namespace", "")
 
             action: Optional[RuleAction] = None
-            description: Optional[str] = ""
+            description: str = ""
             if not namespace:
                 annotation_type = RuleActionAnnotationKind.from_str(rule["type"])
                 tags = rule.get("tags")

--- a/python/lib/sift_py/ingestion/config/telemetry.py
+++ b/python/lib/sift_py/ingestion/config/telemetry.py
@@ -14,7 +14,7 @@ from sift_py.ingestion.channel import (
 )
 from sift_py.ingestion.config.yaml.load import (
     load_named_expression_modules,
-    load_named_rule_modules,
+    load_rule_namespaces,
     read_and_validate,
 )
 from sift_py.ingestion.config.yaml.spec import TelemetryConfigYamlSpec
@@ -125,20 +125,20 @@ class TelemetryConfig:
         config_as_yaml = read_and_validate(path)
 
         named_expressions = {}
-        named_rules = {}
+        rule_namespaces = {}
         if named_expression_modules is not None:
             named_expressions = load_named_expression_modules(named_expression_modules)
         if named_rule_modules is not None:
-            named_rules = load_named_rule_modules(named_rule_modules)
+            rule_namespaces = load_rule_namespaces(named_rule_modules)
 
-        return cls._from_yaml(config_as_yaml, named_expressions, named_rules)
+        return cls._from_yaml(config_as_yaml, named_expressions, rule_namespaces)
 
     @classmethod
     def _from_yaml(
         cls,
         config_as_yaml: TelemetryConfigYamlSpec,
         named_expressions: Dict[str, str] = {},
-        named_rules: Dict[str, str] = {},  # TODO, do stuff with this
+        rule_namespaces: Dict[str, List] = {},  # TODO, do stuff with this
     ) -> Self:
         rules = []
         flows = []
@@ -188,6 +188,19 @@ class TelemetryConfig:
             )
 
         for rule in config_as_yaml.get("rules", []):
+            # TODO: Handle rules here; assemble rules from namespace keys
+            namespace = rule.get("namespace")
+
+            if namespace:
+                rule_namespace = rule_namespaces.get(str(namespace))
+                if not rule_namespace:
+                     # TODO: This is a placeholder.
+                     # Maybe we should try and catch this earlier?
+                     # Otherwise what happens if the namespace doesn't exist?
+                    raise ValueError(f"Could not find namespace {namespace}")
+                for rule_from_namespace in rule_namespace:
+                    pass # Match on name
+
             annotation_type = RuleActionAnnotationKind.from_str(rule["type"])
 
             tags = rule.get("tags")

--- a/python/lib/sift_py/ingestion/config/telemetry.py
+++ b/python/lib/sift_py/ingestion/config/telemetry.py
@@ -12,7 +12,7 @@ from sift_py.ingestion.channel import (
     ChannelEnumType,
     _channel_fqn,
 )
-from sift_py.ingestion.config.yaml.load import load_named_expression_modules, read_and_validate
+from sift_py.ingestion.config.yaml.load import load_named_expression_modules, load_named_rule_modules,read_and_validate
 from sift_py.ingestion.config.yaml.spec import TelemetryConfigYamlSpec
 from sift_py.ingestion.flow import FlowConfig
 from sift_py.ingestion.rule.config import (
@@ -111,6 +111,7 @@ class TelemetryConfig:
         cls,
         path: Path,
         named_expression_modules: Optional[List[Path]] = None,
+        named_rule_modules: Optional[List[Path]] = None,
     ) -> Self:
         """
         Initializes a telemetry config from a YAML file found at the provided `path` as well as optional
@@ -119,17 +120,21 @@ class TelemetryConfig:
 
         config_as_yaml = read_and_validate(path)
 
+        named_expressions = {}
+        named_rules = {}
         if named_expression_modules is not None:
             named_expressions = load_named_expression_modules(named_expression_modules)
-            return cls._from_yaml(config_as_yaml, named_expressions)
-        else:
-            return cls._from_yaml(config_as_yaml)
+        if named_rule_modules is not None:
+            named_rules = load_named_rule_modules(named_rule_modules)
+
+        return cls._from_yaml(config_as_yaml, named_expressions, named_rules)
 
     @classmethod
     def _from_yaml(
         cls,
         config_as_yaml: TelemetryConfigYamlSpec,
         named_expressions: Dict[str, str] = {},
+        named_rules: Dict[str, str] = {},  # TODO, do stuff with this
     ) -> Self:
         rules = []
         flows = []

--- a/python/lib/sift_py/ingestion/config/telemetry.py
+++ b/python/lib/sift_py/ingestion/config/telemetry.py
@@ -218,7 +218,9 @@ class TelemetryConfig:
                     if rule["name"] == rule_from_namespace["name"]:
                         found_rule = rule_from_namespace
                 if not found_rule:
-                    raise TelemetryConfigValidationError(f"Could not find rule name {rule['name']} in {namespace}")
+                    raise TelemetryConfigValidationError(
+                        f"Could not find rule name {rule['name']} in {namespace}"
+                    )
                 rule = found_rule
 
             annotation_type = RuleActionAnnotationKind.from_str(rule["type"])

--- a/python/lib/sift_py/ingestion/config/telemetry.py
+++ b/python/lib/sift_py/ingestion/config/telemetry.py
@@ -190,18 +190,17 @@ class TelemetryConfig:
         for rule in config_as_yaml.get("rules", []):
             namespace = rule.get("namespace")
 
+            action: Optional[RuleAction] = None
             if not namespace:
                 annotation_type = RuleActionAnnotationKind.from_str(rule["type"])
                 tags = rule.get("tags")
 
-                action: Optional[RuleAction] = RuleActionCreatePhaseAnnotation(tags)
+                action = RuleActionCreatePhaseAnnotation(tags)
                 if annotation_type == RuleActionAnnotationKind.REVIEW:
                     action = RuleActionCreateDataReviewAnnotation(
                         assignee=rule.get("assignee"),
                         tags=tags,
                     )
-            else:
-                action = None
 
             channel_references: List[
                 ExpressionChannelReference | ExpressionChannelReferenceChannelConfig

--- a/python/lib/sift_py/ingestion/config/telemetry.py
+++ b/python/lib/sift_py/ingestion/config/telemetry.py
@@ -188,6 +188,24 @@ class TelemetryConfig:
             )
 
         for rule in config_as_yaml.get("rules", []):
+            # Order matters -- capture the channel references before checking the namespace
+            channel_references: List[
+                ExpressionChannelReference | ExpressionChannelReferenceChannelConfig
+            ] = []
+
+            for channel_reference in rule.get("channel_references", []):
+                for ref, val in channel_reference.items():
+                    name = val["name"]
+                    component = val.get("component")
+
+                    channel_references.append(
+                        {
+                            "channel_reference": ref,
+                            "channel_identifier": _channel_fqn(name, component),
+                        }
+                    )
+
+            print(channel_references)
             namespace = rule.get("namespace")
 
             if namespace:
@@ -213,22 +231,6 @@ class TelemetryConfig:
                     assignee=rule.get("assignee"),
                     tags=tags,
                 )
-
-            channel_references: List[
-                ExpressionChannelReference | ExpressionChannelReferenceChannelConfig
-            ] = []
-
-            for channel_reference in rule.get("channel_references", []):
-                for ref, val in channel_reference.items():
-                    name = val["name"]
-                    component = val.get("component")
-
-                    channel_references.append(
-                        {
-                            "channel_reference": ref,
-                            "channel_identifier": _channel_fqn(name, component),
-                        }
-                    )
 
             expression = rule["expression"]
             if isinstance(expression, str):

--- a/python/lib/sift_py/ingestion/config/telemetry.py
+++ b/python/lib/sift_py/ingestion/config/telemetry.py
@@ -191,9 +191,11 @@ class TelemetryConfig:
             namespace = rule.get("namespace")
 
             action: Optional[RuleAction] = None
+            description: Optional[str] = ""
             if not namespace:
                 annotation_type = RuleActionAnnotationKind.from_str(rule["type"])
                 tags = rule.get("tags")
+                description = rule.get("description", "")
 
                 action = RuleActionCreatePhaseAnnotation(tags)
                 if annotation_type == RuleActionAnnotationKind.REVIEW:
@@ -223,7 +225,7 @@ class TelemetryConfig:
                 rules.append(
                     RuleConfig(
                         name=rule["name"],
-                        description=rule.get("description", ""),
+                        description=description,
                         expression=expression,
                         action=action,
                         channel_references=channel_references,
@@ -251,11 +253,13 @@ class TelemetryConfig:
                 rules.append(
                     RuleConfig(
                         name=rule["name"],
-                        description=rule.get("description", ""),
+                        description=description,
                         expression=expr,
                         action=action,
                         channel_references=channel_references,
                         sub_expressions=sub_exprs,
+                        namespace=namespace,
+                        namespace_rules=rule_namespaces,
                     )
                 )
 

--- a/python/lib/sift_py/ingestion/config/telemetry.py
+++ b/python/lib/sift_py/ingestion/config/telemetry.py
@@ -193,18 +193,14 @@ class TelemetryConfig:
             if namespace:
                 rule_namespace = rule_namespaces.get(str(namespace))
                 if not rule_namespace:
-                    # TODO: This is a placeholder.
-                    # Maybe we should try and catch this earlier?
-                    # Otherwise what happens if the namespace doesn't exist?
-                    raise ValueError(f"Could not find namespace {namespace}")
+                    raise TelemetryConfigValidationError(f"Could not find namespace {namespace}")
 
                 found_rule = None
                 for rule_from_namespace in rule_namespace:
                     if rule["name"] == rule_from_namespace["name"]:
                         found_rule = rule_from_namespace
                 if not found_rule:
-                    # TODO: Maybe we should try and catch this earlier?
-                    raise ValueError(f"Could not find rule name {rule['name']} in {namespace}")
+                    raise TelemetryConfigValidationError(f"Could not find rule name {rule['name']} in {namespace}")
                 rule = found_rule
 
             annotation_type = RuleActionAnnotationKind.from_str(rule["type"])

--- a/python/lib/sift_py/ingestion/config/telemetry.py
+++ b/python/lib/sift_py/ingestion/config/telemetry.py
@@ -205,7 +205,6 @@ class TelemetryConfig:
                         }
                     )
 
-            print(channel_references)
             namespace = rule.get("namespace")
 
             if namespace:

--- a/python/lib/sift_py/ingestion/config/telemetry.py
+++ b/python/lib/sift_py/ingestion/config/telemetry.py
@@ -188,7 +188,6 @@ class TelemetryConfig:
             )
 
         for rule in config_as_yaml.get("rules", []):
-            # TODO: Handle rules here; assemble rules from namespace keys
             namespace = rule.get("namespace")
 
             if namespace:
@@ -198,8 +197,14 @@ class TelemetryConfig:
                      # Maybe we should try and catch this earlier?
                      # Otherwise what happens if the namespace doesn't exist?
                     raise ValueError(f"Could not find namespace {namespace}")
+
+                found_rule = None
                 for rule_from_namespace in rule_namespace:
-                    pass # Match on name
+                    if rule["name"] == rule_from_namespace["name"]:
+                        found_rule = rule_from_namespace
+                if not found_rule:
+                     # TODO: Maybe we should try and catch this earlier?
+                    raise ValueError(f"Could not find rule name {rule['name']} in {namespace}")
 
             annotation_type = RuleActionAnnotationKind.from_str(rule["type"])
 

--- a/python/lib/sift_py/ingestion/config/telemetry.py
+++ b/python/lib/sift_py/ingestion/config/telemetry.py
@@ -193,9 +193,9 @@ class TelemetryConfig:
             if namespace:
                 rule_namespace = rule_namespaces.get(str(namespace))
                 if not rule_namespace:
-                     # TODO: This is a placeholder.
-                     # Maybe we should try and catch this earlier?
-                     # Otherwise what happens if the namespace doesn't exist?
+                    # TODO: This is a placeholder.
+                    # Maybe we should try and catch this earlier?
+                    # Otherwise what happens if the namespace doesn't exist?
                     raise ValueError(f"Could not find namespace {namespace}")
 
                 found_rule = None
@@ -203,7 +203,7 @@ class TelemetryConfig:
                     if rule["name"] == rule_from_namespace["name"]:
                         found_rule = rule_from_namespace
                 if not found_rule:
-                     # TODO: Maybe we should try and catch this earlier?
+                    # TODO: Maybe we should try and catch this earlier?
                     raise ValueError(f"Could not find rule name {rule['name']} in {namespace}")
 
             annotation_type = RuleActionAnnotationKind.from_str(rule["type"])

--- a/python/lib/sift_py/ingestion/config/telemetry.py
+++ b/python/lib/sift_py/ingestion/config/telemetry.py
@@ -138,7 +138,7 @@ class TelemetryConfig:
         cls,
         config_as_yaml: TelemetryConfigYamlSpec,
         named_expressions: Dict[str, str] = {},
-        rule_namespaces: Dict[str, List] = {},  # TODO, do stuff with this
+        rule_namespaces: Dict[str, List] = {},
     ) -> Self:
         rules = []
         flows = []

--- a/python/lib/sift_py/ingestion/config/telemetry_test.py
+++ b/python/lib/sift_py/ingestion/config/telemetry_test.py
@@ -283,6 +283,16 @@ def test_telemetry_config_validations_flows_with_same_name():
         )
 
 
+def test_telemetry_config_validations_rules_with_same_namespace():
+    pass
+
+def test_telemetry_config_validations_rule_missing_namespace():
+    pass
+
+def test_telemetry_config_validations_rule_missing_from_namespace():
+    pass
+
+
 TEST_YAML_CONFIG_STR = """
 asset_name: LunarVehicle426
 ingestion_client_key: lunar_vehicle_426

--- a/python/lib/sift_py/ingestion/config/telemetry_test.py
+++ b/python/lib/sift_py/ingestion/config/telemetry_test.py
@@ -39,11 +39,23 @@ def test_telemetry_config_load_from_yaml(mocker: MockFixture):
         "kinetic_energy_gt": "0.5 * $mass * $1 * $1 > $threshold",
     }
 
-    mock_load_rule_namespaces = mocker.patch(_mock_path(sift_py.ingestion.config.yaml.load.load_rule_namespaces))
+    mock_load_rule_namespaces = mocker.patch(
+        _mock_path(sift_py.ingestion.config.yaml.load.load_rule_namespaces)
+    )
     mock_load_rule_namespaces.return_value = {
         "velocity": [
-            {"name": "vehicle_stuck", "description": "Checks that vehicle velocity becomes nonzero 5s after entering accelerating state", "expression": "$1 == \"Accelerating\" && persistence($2 == 0, 5)", "type": "review"},
-            {"name": "vehicle_not_stopped", "description": "Makes sure vehicle velocity remains 0 while stopped", "expression": "$1 == \"Stopped\" && $2 > 0", "type": "review"}
+            {
+                "name": "vehicle_stuck",
+                "description": "Checks that vehicle velocity becomes nonzero 5s after entering accelerating state",
+                "expression": '$1 == "Accelerating" && persistence($2 == 0, 5)',
+                "type": "review",
+            },
+            {
+                "name": "vehicle_not_stopped",
+                "description": "Makes sure vehicle velocity remains 0 while stopped",
+                "expression": '$1 == "Stopped" && $2 > 0',
+                "type": "review",
+            },
         ]
     }
 
@@ -51,7 +63,9 @@ def test_telemetry_config_load_from_yaml(mocker: MockFixture):
     dummy_named_expr_mod_path = Path()
     dummy_rule_namespace_path = [Path()]
 
-    telemetry_config = TelemetryConfig.try_from_yaml(dummy_yaml_path, [dummy_named_expr_mod_path], dummy_rule_namespace_path)
+    telemetry_config = TelemetryConfig.try_from_yaml(
+        dummy_yaml_path, [dummy_named_expr_mod_path], dummy_rule_namespace_path
+    )
 
     assert telemetry_config.asset_name == "LunarVehicle426"
     assert telemetry_config.ingestion_client_key == "lunar_vehicle_426"
@@ -116,7 +130,14 @@ def test_telemetry_config_load_from_yaml(mocker: MockFixture):
 
     assert len(telemetry_config.rules) == 6
 
-    overheating_rule, speeding_rule, failures_rule, kinetic_energy_rule, vehicle_stuck, vehicle_not_stopped = telemetry_config.rules
+    (
+        overheating_rule,
+        speeding_rule,
+        failures_rule,
+        kinetic_energy_rule,
+        vehicle_stuck,
+        vehicle_not_stopped,
+    ) = telemetry_config.rules
 
     assert overheating_rule.name == "overheating"
     assert overheating_rule.description == "Checks for vehicle overheating"
@@ -143,14 +164,17 @@ def test_telemetry_config_load_from_yaml(mocker: MockFixture):
     assert isinstance(kinetic_energy_rule.action, RuleActionCreateDataReviewAnnotation)
 
     assert vehicle_stuck.name == "vehicle_stuck"
-    assert vehicle_stuck.description == "Checks that vehicle velocity becomes nonzero 5s after entering accelerating state"
-    assert vehicle_stuck.expression == "$1 == \"Accelerating\" && persistence($2 == 0, 5)"
+    assert (
+        vehicle_stuck.description
+        == "Checks that vehicle velocity becomes nonzero 5s after entering accelerating state"
+    )
+    assert vehicle_stuck.expression == '$1 == "Accelerating" && persistence($2 == 0, 5)'
     assert vehicle_stuck.action.kind() == RuleActionKind.ANNOTATION
     assert isinstance(vehicle_stuck.action, RuleActionCreateDataReviewAnnotation)
 
     assert vehicle_not_stopped.name == "vehicle_not_stopped"
     assert vehicle_not_stopped.description == "Makes sure vehicle velocity remains 0 while stopped"
-    assert vehicle_not_stopped.expression == "$1 == \"Stopped\" && $2 > 0"
+    assert vehicle_not_stopped.expression == '$1 == "Stopped" && $2 > 0'
     assert vehicle_not_stopped.action.kind() == RuleActionKind.ANNOTATION
     assert isinstance(vehicle_not_stopped.action, RuleActionCreateDataReviewAnnotation)
 
@@ -286,8 +310,10 @@ def test_telemetry_config_validations_flows_with_same_name():
 def test_telemetry_config_validations_rules_with_same_namespace():
     pass
 
+
 def test_telemetry_config_validations_rule_missing_namespace():
     pass
+
 
 def test_telemetry_config_validations_rule_missing_from_namespace():
     pass

--- a/python/lib/sift_py/ingestion/config/telemetry_test.py
+++ b/python/lib/sift_py/ingestion/config/telemetry_test.py
@@ -39,10 +39,19 @@ def test_telemetry_config_load_from_yaml(mocker: MockFixture):
         "kinetic_energy_gt": "0.5 * $mass * $1 * $1 > $threshold",
     }
 
+    mock_load_rule_namespaces = mocker.patch(_mock_path(sift_py.ingestion.config.yaml.load.load_rule_namespaces))
+    mock_load_rule_namespaces.return_value = {
+        "velocity": [
+            {"name": "vehicle_stuck", "description": "Checks that vehicle velocity becomes nonzero 5s after entering accelerating state", "expression": "$1 == \"Accelerating\" && persistence($2 == 0, 5)", "type": "review"},
+            {"name": "vehicle_not_stopped", "description": "Makes sure vehicle velocity remains 0 while stopped", "expression": "$1 == \"Stopped\" && $2 > 0", "type": "review"}
+        ]
+    }
+
     dummy_yaml_path = Path()
     dummy_named_expr_mod_path = Path()
+    dummy_rule_namespace_path = [Path()]
 
-    telemetry_config = TelemetryConfig.try_from_yaml(dummy_yaml_path, [dummy_named_expr_mod_path])
+    telemetry_config = TelemetryConfig.try_from_yaml(dummy_yaml_path, [dummy_named_expr_mod_path], dummy_rule_namespace_path)
 
     assert telemetry_config.asset_name == "LunarVehicle426"
     assert telemetry_config.ingestion_client_key == "lunar_vehicle_426"
@@ -105,9 +114,9 @@ def test_telemetry_config_load_from_yaml(mocker: MockFixture):
     assert gpio_channel.bit_field_elements[3].index == 7
     assert gpio_channel.bit_field_elements[3].bit_count == 1
 
-    assert len(telemetry_config.rules) == 4
+    assert len(telemetry_config.rules) == 6
 
-    overheating_rule, speeding_rule, failures_rule, kinetic_energy_rule = telemetry_config.rules
+    overheating_rule, speeding_rule, failures_rule, kinetic_energy_rule, vehicle_stuck, vehicle_not_stopped = telemetry_config.rules
 
     assert overheating_rule.name == "overheating"
     assert overheating_rule.description == "Checks for vehicle overheating"
@@ -132,6 +141,18 @@ def test_telemetry_config_load_from_yaml(mocker: MockFixture):
     assert kinetic_energy_rule.expression == "0.5 * 10 * $1 * $1 > 470"
     assert overheating_rule.action.kind() == RuleActionKind.ANNOTATION
     assert isinstance(kinetic_energy_rule.action, RuleActionCreateDataReviewAnnotation)
+
+    assert vehicle_stuck.name == "vehicle_stuck"
+    assert vehicle_stuck.description == "Checks that vehicle velocity becomes nonzero 5s after entering accelerating state"
+    assert vehicle_stuck.expression == "$1 == \"Accelerating\" && persistence($2 == 0, 5)"
+    assert vehicle_stuck.action.kind() == RuleActionKind.ANNOTATION
+    assert isinstance(vehicle_stuck.action, RuleActionCreateDataReviewAnnotation)
+
+    assert vehicle_not_stopped.name == "vehicle_not_stopped"
+    assert vehicle_not_stopped.description == "Makes sure vehicle velocity remains 0 while stopped"
+    assert vehicle_not_stopped.expression == "$1 == \"Stopped\" && $2 > 0"
+    assert vehicle_not_stopped.action.kind() == RuleActionKind.ANNOTATION
+    assert isinstance(vehicle_not_stopped.action, RuleActionCreateDataReviewAnnotation)
 
 
 def test_telemetry_config_err_if_duplicate_channels_in_flow(mocker: MockerFixture):
@@ -361,6 +382,18 @@ rules:
     tags:
         - nostromo
 
+  - namespace: velocity
+    name: vehicle_stuck
+    channel_references:
+      - $1: *vehicle_state_channel
+      - $2: *velocity_channel
+
+  - namespace: velocity
+    name: vehicle_not_stopped
+    channel_references:
+      - $1: *vehicle_state_channel
+      - $2: *velocity_channel
+
 flows:
   - name: readings
     channels:
@@ -397,4 +430,19 @@ flows:
     channels:
       - <<: *velocity_channel
       - <<: *velocity_channel
+"""
+
+RULE_NAMESPACE_YAML_CONFIG = """
+namespace: velocity
+
+rules:
+  - name: vehicle_stuck
+    description: Checks that vehicle velocity becomes nonzero 5s after entering accelerating state
+    expression: $1 == "Accelerating" && persistence($2 == 0, 5)
+    type: review
+
+  - name: vehicle_not_stopped
+    description: Makes sure vehicle velocity remains 0 while stopped
+    expression: $1 == "Stopped" && $2 > 0
+    type: review
 """

--- a/python/lib/sift_py/ingestion/config/telemetry_test.py
+++ b/python/lib/sift_py/ingestion/config/telemetry_test.py
@@ -142,7 +142,7 @@ def test_telemetry_config_load_from_yaml(mocker: MockFixture):
     assert overheating_rule.name == "overheating"
     assert overheating_rule.description == "Checks for vehicle overheating"
     assert overheating_rule.expression == '$1 == "Accelerating" && $2 > 80'
-    assert overheating_rule.action.kind() == RuleActionKind.ANNOTATION
+    assert overheating_rule.action.kind() == RuleActionKind.ANNOTATION  # type: ignore
     assert isinstance(overheating_rule.action, RuleActionCreateDataReviewAnnotation)
 
     assert speeding_rule.name == "speeding"
@@ -169,13 +169,13 @@ def test_telemetry_config_load_from_yaml(mocker: MockFixture):
         == "Checks that vehicle velocity becomes nonzero 5s after entering accelerating state"
     )
     assert vehicle_stuck.expression == '$1 == "Accelerating" && persistence($2 == 0, 5)'
-    assert vehicle_stuck.action.kind() == RuleActionKind.ANNOTATION
+    assert vehicle_stuck.action.kind() == RuleActionKind.ANNOTATION  # type: ignore
     assert isinstance(vehicle_stuck.action, RuleActionCreateDataReviewAnnotation)
 
     assert vehicle_not_stopped.name == "vehicle_not_stopped"
     assert vehicle_not_stopped.description == "Makes sure vehicle velocity remains 0 while stopped"
     assert vehicle_not_stopped.expression == '$1 == "Stopped" && $2 > 0'
-    assert vehicle_not_stopped.action.kind() == RuleActionKind.ANNOTATION
+    assert vehicle_not_stopped.action.kind() == RuleActionKind.ANNOTATION  # type: ignore
     assert isinstance(vehicle_not_stopped.action, RuleActionCreateDataReviewAnnotation)
 
 
@@ -305,18 +305,6 @@ def test_telemetry_config_validations_flows_with_same_name():
                 ),
             ],
         )
-
-
-def test_telemetry_config_validations_rules_with_same_namespace():
-    pass
-
-
-def test_telemetry_config_validations_rule_missing_namespace():
-    pass
-
-
-def test_telemetry_config_validations_rule_missing_from_namespace():
-    pass
 
 
 TEST_YAML_CONFIG_STR = """
@@ -466,19 +454,4 @@ flows:
     channels:
       - <<: *velocity_channel
       - <<: *velocity_channel
-"""
-
-RULE_NAMESPACE_YAML_CONFIG = """
-namespace: velocity
-
-rules:
-  - name: vehicle_stuck
-    description: Checks that vehicle velocity becomes nonzero 5s after entering accelerating state
-    expression: $1 == "Accelerating" && persistence($2 == 0, 5)
-    type: review
-
-  - name: vehicle_not_stopped
-    description: Makes sure vehicle velocity remains 0 while stopped
-    expression: $1 == "Stopped" && $2 > 0
-    type: review
 """

--- a/python/lib/sift_py/ingestion/config/yaml/load.py
+++ b/python/lib/sift_py/ingestion/config/yaml/load.py
@@ -73,10 +73,16 @@ def load_rule_namespaces(paths: List[Path]) -> Dict[str, List]:
 
         rule_namespaces.update(rule_module)
 
+    def handle_dir(path: Path):
+        for file_in_dir in path.iterdir():
+            if file_in_dir.is_dir():
+                handle_dir(file_in_dir)
+            elif file_in_dir.is_file():
+                update_rule_namespaces(file_in_dir)
+
     for path in paths:
         if path.is_dir():
-            for rule_file in path.iterdir():
-                update_rule_namespaces(rule_file)
+            handle_dir(path)
         elif path.is_file():
             update_rule_namespaces(path)
 

--- a/python/lib/sift_py/ingestion/config/yaml/load.py
+++ b/python/lib/sift_py/ingestion/config/yaml/load.py
@@ -122,9 +122,10 @@ def _read_rule_namespace_yaml(path: Path) -> Dict[str, List]:
                )
            _validate_rule(rule)
 
-        # TODO: This format just seemed easier to work with... it does seem to
-        # sort of break from the pattern since everything else I think keeps the
-        # YAML format intact. Will come back and give this a think.
+        # TODO: This format just seemed easier to work with... it does feel like
+        # sort of breaks from patterns elsewhere here since everything else I think
+        # keeps the YAML format "intact" after reading into memory.
+        # Will come back and give this a think.
         return {namespace: cast(List[Any], rules)}
 
 

--- a/python/lib/sift_py/ingestion/config/yaml/load.py
+++ b/python/lib/sift_py/ingestion/config/yaml/load.py
@@ -11,8 +11,8 @@ from sift_py.ingestion.config.yaml.spec import (
     ChannelConfigYamlSpec,
     ChannelEnumTypeYamlSpec,
     FlowYamlSpec,
-    RuleYamlSpec,
     RuleModuleYamlSpec,
+    RuleYamlSpec,
     TelemetryConfigYamlSpec,
 )
 from sift_py.ingestion.rule.config import RuleActionAnnotationKind

--- a/python/lib/sift_py/ingestion/config/yaml/load.py
+++ b/python/lib/sift_py/ingestion/config/yaml/load.py
@@ -114,13 +114,13 @@ def _read_rule_namespace_yaml(path: Path) -> Dict[str, List]:
             )
 
         for rule in cast(List[Any], rules):
-           nested_namespace = rule.get("namespace")
-           if nested_namespace:  # TODO: Do we want to allow this?
-               raise YamlConfigError(
-                   "Rules referencing other namespaces cannot be nested. "
-                   f"Found nested namespace '{nested_namespace}' in '{path}'. "
-               )
-           _validate_rule(rule)
+            nested_namespace = rule.get("namespace")
+            if nested_namespace:  # TODO: Do we want to allow this?
+                raise YamlConfigError(
+                    "Rules referencing other namespaces cannot be nested. "
+                    f"Found nested namespace '{nested_namespace}' in '{path}'. "
+                )
+            _validate_rule(rule)
 
         # TODO: This format just seemed easier to work with... it does feel like
         # sort of breaks from patterns elsewhere here since everything else I think

--- a/python/lib/sift_py/ingestion/config/yaml/load.py
+++ b/python/lib/sift_py/ingestion/config/yaml/load.py
@@ -1,6 +1,6 @@
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Type, Callable, cast
+from typing import Any, Dict, List, Type, cast
 
 import yaml
 
@@ -52,7 +52,7 @@ def load_named_expression_modules(paths: List[Path]) -> Dict[str, str]:
     return named_expressions
 
 
-def load_named_rule_modules(paths: List[Path]) -> Dict[str, str]: #TODO: Remove redundancy
+def load_named_rule_modules(paths: List[Path]) -> Dict[str, str]:  # TODO: Remove redundancy
     """
     Takes in a list of paths to YAML files which contains named expressions and processes them into a `dict`.
     The key is the name of the expression and the value is the expression itself. For more information on
@@ -108,7 +108,6 @@ def _read_named_rule_module_yaml(path: Path) -> Dict[str, Any]:
                 raise YamlConfigError(
                     f"Expected expression of '{key}' to be a list in named expression module '{path}'."
                 )
-
 
         return cast(Dict[str, str], named_expressions)
 
@@ -317,6 +316,7 @@ def _validate_bit_field_element(val: Any):
 
 
 def _validate_rule(val: Any):
+    # TODO: Only name and channel_references if referencing a module
     rule = cast(Dict[Any, Any], val)
 
     name = rule.get("name")
@@ -349,7 +349,6 @@ def _validate_rule(val: Any):
             "<class 'str'> | <class 'dict'>",
             ["rules"],
         )
-    # TODO: If None, assume it's a module
 
     rule_type = rule.get("type")
     valid_rule_types = [kind.value for kind in RuleActionAnnotationKind]

--- a/python/lib/sift_py/ingestion/config/yaml/load.py
+++ b/python/lib/sift_py/ingestion/config/yaml/load.py
@@ -12,6 +12,7 @@ from sift_py.ingestion.config.yaml.spec import (
     ChannelEnumTypeYamlSpec,
     FlowYamlSpec,
     RuleYamlSpec,
+    RuleModuleYamlSpec,
     TelemetryConfigYamlSpec,
 )
 from sift_py.ingestion.rule.config import RuleActionAnnotationKind
@@ -167,7 +168,7 @@ def _validate_yaml(raw_config: Dict[Any, Any]) -> TelemetryConfigYamlSpec:
             raise YamlConfigError._invalid_property(
                 rules,
                 "rules",
-                f"List[{_type_fqn(RuleYamlSpec)}]",
+                f"List[{_type_fqn(RuleYamlSpec)}] or List[{_type_fqn(RuleModuleYamlSpec)}]",
                 None,
             )
 

--- a/python/lib/sift_py/ingestion/config/yaml/load.py
+++ b/python/lib/sift_py/ingestion/config/yaml/load.py
@@ -165,8 +165,8 @@ def _validate_yaml(raw_config: Dict[Any, Any]) -> TelemetryConfigYamlSpec:
     if rules is not None:
         if not isinstance(rules, list):
             raise YamlConfigError._invalid_property(
-                channels,  # TODO: Should this be rules?
-                "channels",  # TODO: Should this be rules?
+                rules,
+                "rules",
                 f"List[{_type_fqn(RuleYamlSpec)}]",
                 None,
             )

--- a/python/lib/sift_py/ingestion/config/yaml/load.py
+++ b/python/lib/sift_py/ingestion/config/yaml/load.py
@@ -389,7 +389,6 @@ def _validate_rule(val: Any):
     if description is not None and not isinstance(description, str):
         raise YamlConfigError._invalid_property(description, "- description", "str", ["rules"])
 
-
     if isinstance(expression, dict):
         expression_name = cast(Dict[Any, Any], expression).get("name")
 
@@ -419,7 +418,6 @@ def _validate_rule(val: Any):
             ["rules"],
         )
 
-
     if assignee is not None and not isinstance(assignee, str):
         raise YamlConfigError._invalid_property(
             assignee,
@@ -428,7 +426,6 @@ def _validate_rule(val: Any):
             ["rules"],
         )
 
-
     if tags is not None and not isinstance(tags, list):
         raise YamlConfigError._invalid_property(
             tags,
@@ -436,7 +433,6 @@ def _validate_rule(val: Any):
             "List[str]",
             ["rules"],
         )
-
 
     if sub_expressions is not None:
         if not isinstance(channel_references, list):

--- a/python/lib/sift_py/ingestion/config/yaml/spec.py
+++ b/python/lib/sift_py/ingestion/config/yaml/spec.py
@@ -107,7 +107,7 @@ class RuleYamlSpec(TypedDict):
     The formal definition of what a single rule looks like in YAML.
 
     `name`: Name of the rule.
-    `namespace`: Optional namespace of the rule.
+    `namespace`: Optional namespace of the rule. Only used if referencing a rule defined in a namespace.
     `description`: Description of rule.
     `expression`:
         Either an expression-string or a `sift_py.ingestion.config.yaml.spec.NamedExpressionYamlSpec` referencing a named expression.
@@ -116,6 +116,26 @@ class RuleYamlSpec(TypedDict):
     `tags`: Tags to associate with the rule.
     `channel_references`: A list of channel references that maps to an actual channel. More below.
     `sub_expressions`: A list of sub-expressions which is a mapping of place-holders to sub-expressions. Only used if using named expressions.
+
+    Namespaces:
+    Rule may be defined in a separate YAML within a namespace. The reference to the namespace rule would look like the following:
+    ```yaml
+    rules:
+      - namespace: voltage
+        name: overvoltage
+        channel_references:
+          - $1: *vehicle_state_channel
+          - $2: *voltage_channel
+    ```
+    With the corresponding rule being defined in a separate YAML file like the following:
+    ```yaml
+    namespace: voltage
+    rules:
+      - name: overvoltage
+        description: Checks for overvoltage while accelerating
+        expression: $1 == "Accelerating" && $2 > 80
+        type: review
+    ```
 
     Channel references:
     A channel reference is a string containing a numerical value prefixed with "$". Examples include "$1", "$2", "$11", and so on.

--- a/python/lib/sift_py/ingestion/config/yaml/spec.py
+++ b/python/lib/sift_py/ingestion/config/yaml/spec.py
@@ -90,6 +90,15 @@ class FlowYamlSpec(TypedDict):
     channels: List[ChannelConfigYamlSpec]
 
 
+class RuleModuleYamlSpec(TypedDict):
+    """
+    TODO: A nice docstring
+    """
+    name: str
+    namespace: str
+    channel_references: NotRequired[List[Dict[str, ChannelConfigYamlSpec]]]
+
+
 class RuleYamlSpec(TypedDict):
     """
     The formal definition of what a single rule looks like in YAML.

--- a/python/lib/sift_py/ingestion/config/yaml/spec.py
+++ b/python/lib/sift_py/ingestion/config/yaml/spec.py
@@ -90,14 +90,16 @@ class FlowYamlSpec(TypedDict):
     channels: List[ChannelConfigYamlSpec]
 
 
-class RuleModuleYamlSpec(TypedDict):
+class RuleNamespaceYamlSpec(TypedDict):
     """
-    TODO: A nice docstring
+    The formal definition of what a rule namespace looks like in YAML.
+
+    `namespace`: Name of the namespace.
+    `rules`: A list of rules that belong to the namespace.
     """
 
-    name: str
     namespace: str
-    channel_references: NotRequired[List[Dict[str, ChannelConfigYamlSpec]]]
+    rules: List[RuleYamlSpec]
 
 
 class RuleYamlSpec(TypedDict):
@@ -105,6 +107,7 @@ class RuleYamlSpec(TypedDict):
     The formal definition of what a single rule looks like in YAML.
 
     `name`: Name of the rule.
+    `namespace`: Optional namespace of the rule.
     `description`: Description of rule.
     `expression`:
         Either an expression-string or a `sift_py.ingestion.config.yaml.spec.NamedExpressionYamlSpec` referencing a named expression.
@@ -156,6 +159,7 @@ class RuleYamlSpec(TypedDict):
     """
 
     name: str
+    namespace: NotRequired[str]
     description: NotRequired[str]
     expression: Union[str, NamedExpressionYamlSpec]
     type: Union[Literal["phase"], Literal["review"]]

--- a/python/lib/sift_py/ingestion/config/yaml/spec.py
+++ b/python/lib/sift_py/ingestion/config/yaml/spec.py
@@ -94,6 +94,7 @@ class RuleModuleYamlSpec(TypedDict):
     """
     TODO: A nice docstring
     """
+
     name: str
     namespace: str
     channel_references: NotRequired[List[Dict[str, ChannelConfigYamlSpec]]]

--- a/python/lib/sift_py/ingestion/config/yaml/test_load.py
+++ b/python/lib/sift_py/ingestion/config/yaml/test_load.py
@@ -345,7 +345,6 @@ def test__validate_rule():
         )
 
 
-
 def test__validate_flow():
     load._validate_flow(
         {

--- a/python/lib/sift_py/ingestion/config/yaml/test_load.py
+++ b/python/lib/sift_py/ingestion/config/yaml/test_load.py
@@ -327,6 +327,24 @@ def test__validate_rule():
             }
         )
 
+    with pytest.raises(YamlConfigError, match="should not have any other properties set"):
+        load._validate_rule(
+            {
+                "name": "overheat_rule",
+                "namespace": "my_namespace",
+                "description": "some_description",
+                "expression": "$1 > 10 && $2 > 10",
+                "type": "review",
+                "assignee": "homer@example.com",
+                "tags": ["foo", "bar"],
+                "channel_references": [
+                    {"$1": {"name": "voltage", "data_type": "double"}},
+                    {"$2": {"name": "vehicle_state", "data_type": "double"}},
+                ],
+            }
+        )
+
+
 
 def test__validate_flow():
     load._validate_flow(

--- a/python/lib/sift_py/ingestion/config/yaml/test_load.py
+++ b/python/lib/sift_py/ingestion/config/yaml/test_load.py
@@ -199,6 +199,18 @@ def test__validate_rule():
         }
     )
 
+    # Rule in referenced namespace
+    load._validate_rule(
+        {
+            "namespace": "voltage",
+            "name": "overvoltage_rule",
+            "channel_references": [
+                {"$1": {"name": "voltage", "data_type": "double"}},
+                {"$2": {"name": "vehicle_state", "data_type": "double"}},
+            ],
+        }
+    )
+
     with pytest.raises(YamlConfigError, match="Expected 'name' to be <str> but it is <int>"):
         load._validate_rule(
             {

--- a/python/lib/sift_py/ingestion/rule/config.py
+++ b/python/lib/sift_py/ingestion/rule/config.py
@@ -153,11 +153,11 @@ class RuleConfig(AsJson):
                     action = RuleActionCreateDataReviewAnnotation(
                         assignee=rule.get("assignee"), tags=tags
                     )
+                return description, expression, action
 
-        if not expression:
-            raise ValueError(f"Couldn't find rule name '{name}' in rule_list: {rule_list}")
-
-        return description, expression, action
+        raise ValueError(
+            f"Could not find rule '{rule}'. Does this rule exist in the namespace? {rule_list}"
+        )
 
 
 class RuleAction(ABC):

--- a/python/lib/sift_py/ingestion/rule/config.py
+++ b/python/lib/sift_py/ingestion/rule/config.py
@@ -70,7 +70,7 @@ class RuleConfig(AsJson):
 
         if namespace:
             description, expression, action = self.__class__.interpolate_namespace_rule(
-                namespace, namespace_rules
+                name, namespace, namespace_rules
             )
 
         self.action = action
@@ -128,7 +128,7 @@ class RuleConfig(AsJson):
 
     @staticmethod
     def interpolate_namespace_rule(
-        namespace: str, namespace_rules: Optional[Dict[str, List[Dict]]]
+        name: str, namespace: str, namespace_rules: Optional[Dict[str, List[Dict]]]
     ) -> Tuple[str, str, RuleAction]:
         if not namespace_rules:
             raise ValueError(
@@ -142,8 +142,8 @@ class RuleConfig(AsJson):
             )
 
         for rule in rule_list:
-            name = rule.get("name")
-            if name:
+            candidate_name = rule.get("name")
+            if candidate_name == name:
                 description = rule.get("description", "")
                 expression = rule.get("expression", "")
                 type = rule.get("type", "")
@@ -154,7 +154,7 @@ class RuleConfig(AsJson):
                         assignee=rule.get("assignee"), tags=tags
                     )
 
-        if not name:
+        if not expression:
             raise ValueError(f"Couldn't find rule name '{name}' in rule_list: {rule_list}")
 
         return description, expression, action

--- a/python/lib/sift_py/ingestion/rule/config.py
+++ b/python/lib/sift_py/ingestion/rule/config.py
@@ -75,7 +75,6 @@ class RuleConfig(AsJson):
 
         self.action = action
         self.description = description
-        self.expression = expression
         self.expression = self.__class__.interpolate_sub_expressions(expression, sub_expressions)
 
     def as_json(self) -> Any:

--- a/python/lib/sift_py/ingestion/rule/config.py
+++ b/python/lib/sift_py/ingestion/rule/config.py
@@ -76,9 +76,7 @@ class RuleConfig(AsJson):
         self.action = action
         self.description = description
         self.expression = expression
-        self.expression = self.__class__.interpolate_sub_expressions(
-            expression, sub_expressions
-        )
+        self.expression = self.__class__.interpolate_sub_expressions(expression, sub_expressions)
 
     def as_json(self) -> Any:
         """
@@ -115,7 +113,9 @@ class RuleConfig(AsJson):
         return hash_map
 
     @staticmethod
-    def interpolate_sub_expressions(expression: Optional[str], sub_expressions: Optional[Dict[str, str]]) -> Optional[str]:
+    def interpolate_sub_expressions(
+        expression: Optional[str], sub_expressions: Optional[Dict[str, str]]
+    ) -> Optional[str]:
         if expression and sub_expressions:
             for ref, expr in sub_expressions.items():
                 if ref not in expression:
@@ -132,7 +132,9 @@ class RuleConfig(AsJson):
         namespace: str, namespace_rules: Optional[Dict[str, List[Dict]]]
     ) -> Tuple[str, str, RuleAction]:
         if not namespace_rules:
-            raise ValueError(f"Namespace rules must be provided with namespace key. Got: {namespace_rules}")
+            raise ValueError(
+                f"Namespace rules must be provided with namespace key. Got: {namespace_rules}"
+            )
 
         rule_list = namespace_rules.get(namespace)
         if not rule_list:

--- a/python/lib/sift_py/ingestion/rule/config.py
+++ b/python/lib/sift_py/ingestion/rule/config.py
@@ -24,8 +24,8 @@ class RuleConfig(AsJson):
     """
 
     name: str
-    description: Optional[str]
-    expression: Optional[str]
+    description: str
+    expression: str
     action: Optional[RuleAction]
     channel_references: List[ExpressionChannelReference]
 
@@ -35,12 +35,12 @@ class RuleConfig(AsJson):
         channel_references: List[
             Union[ExpressionChannelReference, ExpressionChannelReferenceChannelConfig]
         ],
-        description: Optional[str] = "",
-        expression: Optional[str] = "",
+        description: str = "",
+        expression: str = "",
         action: Optional[RuleAction] = None,
-        sub_expressions: Optional[Dict[str, Any]] = {},
-        namespace: Optional[str] = "",
-        namespace_rules: Optional[Dict[str, List[Dict]]] = {},
+        sub_expressions: Dict[str, Any] = {},
+        namespace: str = "",
+        namespace_rules: Dict[str, List[Dict]] = {},
     ):
         self.channel_references = []
 
@@ -113,9 +113,9 @@ class RuleConfig(AsJson):
 
     @staticmethod
     def interpolate_sub_expressions(
-        expression: Optional[str], sub_expressions: Optional[Dict[str, str]]
-    ) -> Optional[str]:
-        if expression and sub_expressions:
+        expression: str, sub_expressions: Optional[Dict[str, str]]
+    ) -> str:
+        if sub_expressions:
             for ref, expr in sub_expressions.items():
                 if ref not in expression:
                     raise ValueError(f"Couldn't find '{ref}' in expression '{expression}'.")

--- a/python/lib/sift_py/ingestion/rule/config_test.py
+++ b/python/lib/sift_py/ingestion/rule/config_test.py
@@ -1,8 +1,11 @@
+import pytest
+
 from sift_py.ingestion.channel import ChannelConfig, ChannelDataType
 
 from .config import (
     RuleActionCreateDataReviewAnnotation,
     RuleActionCreatePhaseAnnotation,
+    RuleActionKind,
     RuleConfig,
 )
 
@@ -107,3 +110,147 @@ def test_rule_named_expressions():
         },
     )
     assert rule_on_kinetic_energy.expression == "0.5 * 10 * $1 * $1 > 35"
+
+
+def test_rule_namespace():
+    namespace_rules = {
+        "valid_namespace": [
+            {
+                "name": "valid_rule",
+                "description": "A rule in a namespace",
+                "expression": "$1 > 10",
+                "type": "review",
+                "assignee": "bob@example.com",
+                "tags": ["foo", "bar"],
+            },
+            {
+                "name": "another_valid_rule",
+                "description": "Another rule in a namespace",
+                "expression": "$1 < 10",
+                "type": "review",
+                "assignee": "mary@example.com",
+                "tags": ["baz", "qux"],
+            },
+        ]
+    }
+
+    valid_namespace_rule = RuleConfig(
+        name="valid_rule",
+        namespace="valid_namespace",
+        namespace_rules=namespace_rules,
+        channel_references=[
+            {
+                "channel_reference": "$1",
+                "channel_config": ChannelConfig(
+                    name="a_channel",
+                    data_type=ChannelDataType.DOUBLE,
+                ),
+            }
+        ],
+    )
+    assert valid_namespace_rule.name == "valid_rule"
+    assert valid_namespace_rule.description == "A rule in a namespace"
+    assert valid_namespace_rule.expression == "$1 > 10"
+    assert valid_namespace_rule.action.assignee == "bob@example.com"
+    assert valid_namespace_rule.action.tags == ["foo", "bar"]
+    assert valid_namespace_rule.action.kind() == RuleActionKind.ANNOTATION
+    assert isinstance(valid_namespace_rule.action, RuleActionCreateDataReviewAnnotation)
+
+
+def test_rule_namespace_missing_namespace_rules():
+    with pytest.raises(ValueError, match="Namespace rules must be provided with namespace key."):
+        RuleConfig(
+            name="a_rule",
+            namespace="a_namespace",
+            channel_references=[
+                {
+                    "channel_reference": "$1",
+                    "channel_config": ChannelConfig(
+                        name="a_channel",
+                        data_type=ChannelDataType.DOUBLE,
+                    ),
+                }
+            ],
+        )
+
+
+def test_rule_namespace_missing_namespace():
+    with pytest.raises(ValueError, match="Couldn't find namespace"):
+        namespace_rules = {
+            "a_namespace": [
+                {
+                    "name": "valid_rule",
+                    "description": "A rule in a namespace",
+                    "expression": "$1 > 10",
+                    "type": "review",
+                    "assignee": "bob@example.com",
+                    "tags": ["foo", "bar"],
+                },
+            ],
+            "another_namespace": [
+                {
+                    "name": "valid_rule",
+                    "description": "A rule in a namespace",
+                    "expression": "$1 > 10",
+                    "type": "review",
+                    "assignee": "bob@example.com",
+                    "tags": ["foo", "bar"],
+                },
+            ],
+        }
+
+        RuleConfig(
+            name="valid_rule",
+            namespace="a_missing_namespace",
+            namespace_rules=namespace_rules,
+            channel_references=[
+                {
+                    "channel_reference": "$1",
+                    "channel_config": ChannelConfig(
+                        name="a_channel",
+                        data_type=ChannelDataType.DOUBLE,
+                    ),
+                }
+            ],
+        )
+
+
+def test_rule_namespace_missing_rule():
+    with pytest.raises(ValueError, match="Does this rule exist in the namespace?"):
+        namespace_rules = {
+            "a_namespace": [
+                {
+                    "name": "a_rule_in_namespace",
+                    "description": "A rule in a namespace",
+                    "expression": "$1 > 10",
+                    "type": "review",
+                    "assignee": "bob@example.com",
+                    "tags": ["foo", "bar"],
+                },
+            ],
+            "another_namespace": [
+                {
+                    "name": "another_rule_in_namespace",
+                    "description": "A rule in a namespace",
+                    "expression": "$1 > 10",
+                    "type": "review",
+                    "assignee": "bob@example.com",
+                    "tags": ["foo", "bar"],
+                },
+            ],
+        }
+
+        RuleConfig(
+            name="a_missing_rule",
+            namespace="a_namespace",
+            namespace_rules=namespace_rules,
+            channel_references=[
+                {
+                    "channel_reference": "$1",
+                    "channel_config": ChannelConfig(
+                        name="a_channel",
+                        data_type=ChannelDataType.DOUBLE,
+                    ),
+                }
+            ],
+        )


### PR DESCRIPTION
This PR adds the ability to define rules in YAML separate from the main telemetry config, so that rules may be referenced and reused in the context of multiple assets.

A rule that's defined in a namespace can be referenced in the main telemetry config like so:
```
  - namespace: voltage
     name: undervoltage
     channel_references:
       - $1: *vehicle_state_channel
       - $2: *voltage_channel
```
With the corresponding rule defined in a separate YAML like so:
```
namespace: voltage
   - name: undervoltage
     description: Checks for undervoltage while accelerating
     expression: $1 == "Accelerating" && $2 < 40
     type: review
```
Or if the user wants to instantiate rules in python directly, the `load_rule_namespaces` function has been added that will allow them to provide a path to the directory containing their rule YAMLs and load them into memory:
```
   rule_namespaces = load_rule_namespaces(
         [
             RULE_NAMESPACES_DIR,
         ]
     )

    RuleConfig(
                 name="overvoltage",
                 namespace="voltage",
                 namespace_rules=rule_namespaces,
                 channel_references=[
                     # INFO: Can use either "channel_identifier" or "channel_config"
                     {
                         "channel_reference": "$1",
                         "channel_identifier": vehicle_state_channel.fqn(),
                     },
                     {
                         "channel_reference": "$2",
                         "channel_config": voltage_channel,
                     },
                 ],
             ),
```

You can see examples of this rules in dev in this run: https://dev.app.siftstack.com/share/3xBUAIQ