### PR TITLE
python(bug): fix download bug for same channel requested

### DIFF
--- a/python/lib/sift_py/data/service.py
+++ b/python/lib/sift_py/data/service.py
@@ -330,16 +330,19 @@ class DataService:
             if chans.get(fqn) is None:
                 channels_to_retrieve.append(fqn)
 
-        sift_channels = await self._get_channels_by_asset_id_and_channel_fqns(
-            asset.asset_id, channels_to_retrieve
-        )
+        sift_channels = []
+        if len(channels_to_retrieve) > 0:
+            sift_channels = await self._get_channels_by_asset_id_and_channel_fqns(
+                asset.asset_id, channels_to_retrieve
+            )
 
         channels = defaultdict(list)
 
         for c in sift_channels:
             channels[channel_fqn(c.name, c.component)].append(c)
 
-        self._cached_channels[asset.name].update(channels)
+        if len(channels) > 0:
+            self._cached_channels[asset.name].update(channels)
 
         return self._cached_channels[asset.name]
 
@@ -422,7 +425,7 @@ class DataService:
     async def _get_channels_by_asset_id_and_channel_fqns(
         self, asset_id: str, channel_fqns: List[str]
     ) -> List[Channel]:
-        if len(asset_id) == 0:
+        if len(asset_id) == 0 or len(channel_fqns) == 0:
             return []
 
         channels: List[Channel] = []


### PR DESCRIPTION
## Changes

There was a logic error in how we retrieve channel information from the channel cache in the data service. Essentially if the channel is in the cache we end up passing an empty list to the `ChannelService_ListChannels` endpoint which then returns an error response causing an exception to be raised. This PR fixes that.

## Note

This branch was created from the latest commit in this [0.2.2 tag](https://github.com/sift-stack/sift/commits/python/v0.2.2) and once merged, it will sit immediately after that commit. This is so that we can create a patch release version bump that doesn't contain all the things we're intending to keep in `0.3`. I will do a merge commit for this.