### PR TITLE
feat: Add ssl credentials workaround with optional OpenSSL import

### DIFF
--- a/.github/workflows/python_ci.yaml
+++ b/.github/workflows/python_ci.yaml
@@ -28,6 +28,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install '.[development]'
+          pip install '.[other]'
           pip install .
 
       - name: Lint

--- a/.github/workflows/python_ci.yaml
+++ b/.github/workflows/python_ci.yaml
@@ -28,7 +28,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install '.[development]'
-          pip install '.[other]'
+          pip install '.[openssl]'
           pip install .
 
       - name: Lint

--- a/python/lib/sift_py/grpc/transport.py
+++ b/python/lib/sift_py/grpc/transport.py
@@ -20,8 +20,31 @@ from sift_py.grpc._interceptors.metadata import Metadata, MetadataInterceptor
 from sift_py.grpc._retry import RetryPolicy
 from sift_py.grpc.keepalive import DEFAULT_KEEPALIVE_CONFIG, KeepaliveConfig
 
+
 SiftChannel: TypeAlias = grpc.Channel
 SiftAsyncChannel: TypeAlias = grpc_aio.Channel
+
+
+def get_ssl_credentials() -> grpc.ChannelCredentials:
+    """
+    Returns SSL credentials for use with gRPC.
+    Workaround for this issue: https://github.com/grpc/grpc/issues/29682
+    """
+    try:
+        import ssl
+
+        from OpenSSL import crypto
+
+        ssl_context = ssl.create_default_context()
+        certs_der = ssl_context.get_ca_certs(binary_form=True)
+        certs_x509 = [crypto.load_certificate(crypto.FILETYPE_ASN1, x) for x in certs_der]
+        certs_pem = [crypto.dump_certificate(crypto.FILETYPE_PEM, x) for x in certs_x509]
+        certs_bytes = b"".join(certs_pem)
+
+        return grpc.ssl_channel_credentials(certs_bytes)
+    except ImportError:
+        return grpc.ssl_channel_credentials()
+
 
 
 def use_sift_channel(
@@ -41,7 +64,7 @@ def use_sift_channel(
     if not use_ssl:
         return _use_insecure_sift_channel(config, metadata)
 
-    credentials = grpc.ssl_channel_credentials()
+    credentials = get_ssl_credentials()
     options = _compute_channel_options(config)
     api_uri = _clean_uri(config["uri"], use_ssl)
     channel = grpc.secure_channel(api_uri, credentials, options)
@@ -63,7 +86,7 @@ def use_sift_async_channel(
 
     return grpc_aio.secure_channel(
         target=_clean_uri(config["uri"], use_ssl),
-        credentials=grpc.ssl_channel_credentials(),
+        credentials=get_ssl_credentials(),
         options=_compute_channel_options(config),
         interceptors=_compute_sift_async_interceptors(config, metadata),
     )

--- a/python/lib/sift_py/grpc/transport.py
+++ b/python/lib/sift_py/grpc/transport.py
@@ -24,11 +24,14 @@ SiftChannel: TypeAlias = grpc.Channel
 SiftAsyncChannel: TypeAlias = grpc_aio.Channel
 
 
-def get_ssl_credentials() -> grpc.ChannelCredentials:
+def get_ssl_credentials(cert_via_openssl: bool) -> grpc.ChannelCredentials:
     """
     Returns SSL credentials for use with gRPC.
     Workaround for this issue: https://github.com/grpc/grpc/issues/29682
     """
+    if not cert_via_openssl:
+        return grpc.ssl_channel_credentials()
+
     try:
         import ssl
 
@@ -41,8 +44,8 @@ def get_ssl_credentials() -> grpc.ChannelCredentials:
         certs_bytes = b"".join(certs_pem)
 
         return grpc.ssl_channel_credentials(certs_bytes)
-    except ImportError:
-        return grpc.ssl_channel_credentials()
+    except ImportError as e:
+        raise Exception("Missing required dependencies for cert_via_openssl. Run `pip install sift-stack-py[openssl]` to install the required dependencies.") from e
 
 
 def use_sift_channel(
@@ -58,11 +61,12 @@ def use_sift_channel(
     are exceeded, after which the underlying exception will be raised.
     """
     use_ssl = config.get("use_ssl", True)
+    cert_via_openssl = config.get("cert_via_openssl", False)
 
     if not use_ssl:
         return _use_insecure_sift_channel(config, metadata)
 
-    credentials = get_ssl_credentials()
+    credentials = get_ssl_credentials(cert_via_openssl)
     options = _compute_channel_options(config)
     api_uri = _clean_uri(config["uri"], use_ssl)
     channel = grpc.secure_channel(api_uri, credentials, options)
@@ -78,13 +82,14 @@ def use_sift_async_channel(
     of an async runtime when asynchonous I/O is required.
     """
     use_ssl = config.get("use_ssl", True)
+    cert_via_openssl = config.get("cert_via_openssl", False)
 
     if not use_ssl:
         return _use_insecure_sift_async_channel(config, metadata)
 
     return grpc_aio.secure_channel(
         target=_clean_uri(config["uri"], use_ssl),
-        credentials=get_ssl_credentials(),
+        credentials=get_ssl_credentials(cert_via_openssl),
         options=_compute_channel_options(config),
         interceptors=_compute_sift_async_interceptors(config, metadata),
     )
@@ -215,9 +220,14 @@ class SiftChannelConfig(TypedDict):
     set to `True`, it will use the default values configured in `sift_py.grpc.keepalive` to configure keepalive. A custom
     `sift_py.grpc.keepalive.KeepaliveConfig` may also be provided. Default disabled.
     - `use_ssl`: INTERNAL USE. Meant to be used for local development.
+    - `cert_via_openssl`: Enable this if you want to use OpenSSL to load the certificates.
+    Run `pip install sift-stack-py[openssl]` to install the dependencies required to use this option.
+    This works around this issue with grpc loading SSL certificates: https://github.com/grpc/grpc/issues/29682.
+    Default is False.
     """
 
     uri: str
     apikey: str
     enable_keepalive: NotRequired[Union[bool, KeepaliveConfig]]
     use_ssl: NotRequired[bool]
+    cert_via_openssl: NotRequired[bool]

--- a/python/lib/sift_py/grpc/transport.py
+++ b/python/lib/sift_py/grpc/transport.py
@@ -45,7 +45,9 @@ def get_ssl_credentials(cert_via_openssl: bool) -> grpc.ChannelCredentials:
 
         return grpc.ssl_channel_credentials(certs_bytes)
     except ImportError as e:
-        raise Exception("Missing required dependencies for cert_via_openssl. Run `pip install sift-stack-py[openssl]` to install the required dependencies.") from e
+        raise Exception(
+            "Missing required dependencies for cert_via_openssl. Run `pip install sift-stack-py[openssl]` to install the required dependencies."
+        ) from e
 
 
 def use_sift_channel(

--- a/python/lib/sift_py/grpc/transport.py
+++ b/python/lib/sift_py/grpc/transport.py
@@ -20,7 +20,6 @@ from sift_py.grpc._interceptors.metadata import Metadata, MetadataInterceptor
 from sift_py.grpc._retry import RetryPolicy
 from sift_py.grpc.keepalive import DEFAULT_KEEPALIVE_CONFIG, KeepaliveConfig
 
-
 SiftChannel: TypeAlias = grpc.Channel
 SiftAsyncChannel: TypeAlias = grpc_aio.Channel
 

--- a/python/lib/sift_py/grpc/transport.py
+++ b/python/lib/sift_py/grpc/transport.py
@@ -45,7 +45,6 @@ def get_ssl_credentials() -> grpc.ChannelCredentials:
         return grpc.ssl_channel_credentials()
 
 
-
 def use_sift_channel(
     config: SiftChannelConfig, metadata: Optional[Dict[str, Any]] = None
 ) -> SiftChannel:

--- a/python/lib/sift_py/grpc/transport_test.py
+++ b/python/lib/sift_py/grpc/transport_test.py
@@ -16,7 +16,7 @@ from sift.data.v1.data_pb2_grpc import (
 )
 
 from sift_py._internal.test_util.server_interceptor import ServerInterceptor
-from sift_py.grpc.transport import SiftChannelConfig, use_sift_channel, get_ssl_credentials
+from sift_py.grpc.transport import SiftChannelConfig, use_sift_channel
 
 
 class DataService(DataServiceServicer):

--- a/python/lib/sift_py/grpc/transport_test.py
+++ b/python/lib/sift_py/grpc/transport_test.py
@@ -16,7 +16,7 @@ from sift.data.v1.data_pb2_grpc import (
 )
 
 from sift_py._internal.test_util.server_interceptor import ServerInterceptor
-from sift_py.grpc.transport import SiftChannelConfig, use_sift_channel
+from sift_py.grpc.transport import SiftChannelConfig, use_sift_channel, get_ssl_credentials
 
 
 class DataService(DataServiceServicer):

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -60,6 +60,10 @@ build = [
   "pdoc==14.5.0",
   "build==1.2.1",
 ]
+other = [
+  "pyOpenSSL<24.0.0",
+  "cffi~=1.14",
+]
 
 [build-system]
 requires = ["setuptools"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -62,6 +62,7 @@ build = [
 ]
 other = [
   "pyOpenSSL<24.0.0",
+  "types-pyOpenSSL<24.0.0",
   "cffi~=1.14",
 ]
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -60,7 +60,7 @@ build = [
   "pdoc==14.5.0",
   "build==1.2.1",
 ]
-other = [
+openssl = [
   "pyOpenSSL<24.0.0",
   "types-pyOpenSSL<24.0.0",
   "cffi~=1.14",

--- a/python/scripts/dev
+++ b/python/scripts/dev
@@ -31,7 +31,7 @@ pip_install() {
   source venv/bin/activate
   pip install '.[development]'
   pip install '.[build]'
-  pip install '.[other]'
+  pip install '.[openssl]'
   pip install -e .
 }
 

--- a/python/scripts/dev
+++ b/python/scripts/dev
@@ -31,6 +31,7 @@ pip_install() {
   source venv/bin/activate
   pip install '.[development]'
   pip install '.[build]'
+  pip install '.[other]'
   pip install -e .
 }
 


### PR DESCRIPTION
Implements [this workaround](https://github.com/grpc/grpc/issues/29682#issuecomment-2347888481) optionally if the OpenSSL dependency is installed.