### PR TITLE
Add job to build wheels

### DIFF
--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -1,0 +1,85 @@
+name: Build Wheels
+
+on:
+  workflow_dispatch:
+
+jobs:
+  python-ci:
+    if: github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags')
+    uses: ./.github/workflows/python_ci.yaml
+
+  build_matrix:
+    strategy:
+      matrix:
+        python_version: [3.9, 3.11]
+
+    name: Build Python ${{ matrix.python_version }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Get build metadata
+        id: metadata
+        run: |
+          export VERSION="$(basename ${{ github.ref_name }})"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Create builds directory
+        working-directory: python
+        run: |
+          mkdir builds
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "${{ matrix.python_version }}"
+
+      - name: Pip install
+        run: |
+          python -m pip install --upgrade pip
+          pip install pip-tools
+
+      - name: Compile requirements
+        working-directory: python
+        run: |
+          pip-compile pyproject.toml --output-file requirements.txt
+
+      - name: Build Windows
+        working-directory: python
+        env:
+          PLATFORM: win_amd64
+          ARTIFACT_NAME: sift_stack_py-${{ steps.metadata.outputs.version }}-py${{ matrix.python_version }}-win_amd64
+        run: |
+          pip download -r requirements.txt -d dist --platform=${PLATFORM} --only-binary=:all: --python-version=${{ matrix.python_version }}
+          python setup.py bdist_wheel
+          zip ${ARTIFACT_NAME}.zip dist -r
+          sha1sum ${ARTIFACT_NAME}.zip | cut -f1 -d' ' > ${ARTIFACT_NAME}.sha1
+          mv ${ARTIFACT_NAME}.zip builds
+          mv ${ARTIFACT_NAME}.sha1 builds
+          rm -rf dist
+
+      - name: Build Linux
+        working-directory: python
+        env:
+          PLATFORM: manylinux_2_17_x86_64
+          ARTIFACT_NAME: sift_stack_py-${{ steps.metadata.outputs.version }}-py${{ matrix.python_version }}-manylinux_2_17_x86_64
+        run: |
+          pip download -r requirements.txt -d dist --platform=${PLATFORM} --only-binary=:all: --python-version=${{ matrix.python_version }}
+          python setup.py bdist_wheel
+          zip ${ARTIFACT_NAME}.zip dist -r
+          sha1sum ${ARTIFACT_NAME}.zip | cut -f1 -d' ' > ${ARTIFACT_NAME}.sha1
+          mv ${ARTIFACT_NAME}.zip builds
+          mv ${ARTIFACT_NAME}.sha1 builds
+          rm -rf dist
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sift_stack_py-${{ steps.metadata.outputs.version }}-py${{ matrix.python_version }}
+          path: python/builds

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,7 +22,6 @@ keywords = [
 ]
 dependencies = [
   "grpcio~=1.13",
-  "npTDMS~=1.9",
   "PyYAML~=6.0",
   "pandas~=2.0",
   "protobuf>=4.0",
@@ -48,6 +47,7 @@ Changelog = "https://github.com/sift-stack/sift/tree/main/python/CHANGELOG.md"
 [project.optional-dependencies]
 development = [
   "grpcio-testing==1.13",
+  "npTDMS~=1.9",
   "mypy==1.10.0",
   "pyright==1.1.386",
   "pytest==8.2.2",


### PR DESCRIPTION
Example: https://github.com/marcsiftstack/sift-gha-test/actions/runs/11786369431/job/32829514476

TODO: figure out why Python 3.9 creates UNKNOWN package:
```
creating UNKNOWN.egg-info
writing UNKNOWN.egg-info/PKG-INFO
writing dependency_links to UNKNOWN.egg-info/dependency_links.txt
writing top-level names to UNKNOWN.egg-info/top_level.txt
writing manifest file 'UNKNOWN.egg-info/SOURCES.txt'
reading manifest file 'UNKNOWN.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'UNKNOWN.egg-info/SOURCES.txt'
Copying UNKNOWN.egg-info to build/bdist.linux-x86_64/wheel/UNKNOWN-0.0.0-py3.9.egg-info
running install_scripts
creating build/bdist.linux-x86_64/wheel/UNKNOWN-0.0.0.dist-info/WHEEL
creating 'dist/UNKNOWN-0.0.0-py3-none-any.whl' and adding 'build/bdist.linux-x86_64/wheel' to it
adding 'UNKNOWN-0.0.0.dist-info/LICENSE'
adding 'UNKNOWN-0.0.0.dist-info/METADATA'
adding 'UNKNOWN-0.0.0.dist-info/WHEEL'
adding 'UNKNOWN-0.0.0.dist-info/top_level.txt'
adding 'UNKNOWN-0.0.0.dist-info/RECORD'
```