### PR TITLE
rust(build): remove keyword from project metadata

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,7 +9,7 @@ Rust client library for the Sift API
 categories = ["aerospace", "science::robotics"]
 homepage = "https://github.com/sift-stack/sift/tree/main/rust"
 repository = "https://github.com/sift-stack/sift/tree/main/rust"
-keywords = ["sift", "siftstack", "sift-stack", "sift_rs", "telemetry", "hardware"]
+keywords = ["sift", "siftstack", "sift-stack", "sift_rs", "telemetry"]
 exclude = ["examples/*"]
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Fixes this github actions error: https://github.com/sift-stack/sift/actions/runs/11806687616/job/32891898758

