### PR TITLE
python(bug): fix data download bug for channels with '.' delimited name

### DIFF
--- a/rust/examples/ingestion/main.rs
+++ b/rust/examples/ingestion/main.rs
@@ -78,7 +78,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 /// Channel and flow configuration used to create an ingestion config.
 pub fn channel_configs() -> Vec<FlowConfig> {
-    return vec![FlowConfig {
+    vec![FlowConfig {
         name: String::from("velocity_reading"),
         channels: vec![ChannelConfig {
             name: String::from("velocity"),
@@ -88,7 +88,7 @@ pub fn channel_configs() -> Vec<FlowConfig> {
             data_type: ChannelDataType::Double.into(),
             ..Default::default()
         }],
-    }];
+    }]
 }
 
 /// Retrieves an existing ingestion config or create it.


### PR DESCRIPTION
## Summary

- Channels with `.` in their name experienced issues downloading data due to how channel names were handled. This PR fixes that.


## Verification

Unit testing and manual verification:

<img width="835" alt="image" src="https://github.com/user-attachments/assets/dde6b142-f645-4f49-a6e4-6b1ed5ebb912">

<img width="775" alt="image" src="https://github.com/user-attachments/assets/de6e6c19-c461-4d47-823e-707c4cf2f0b8">

