### PR TITLE
python(feat): Add offline installation archives for various platforms

### DIFF
--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -49,6 +49,8 @@ jobs:
             arch: amd64
             runner: windows-latest
         python-version: ${{fromJson(needs.get-python-versions.outputs.python-versions)}}
+    outputs:
+      platforms: ${{ toJson(matrix.config) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -157,68 +159,42 @@ jobs:
           retention-days: 7
 
   merge_platform_archives:
-    name: Merge platform archives
+    name: Merge archives for ${{ matrix.config.os }} (${{ matrix.config.arch }})
     needs: [build_and_verify]
     runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.build_and_verify.outputs.platforms) }}
+    env:
+      DIST_PLATFORM: ${{ matrix.config.os == 'windows' && format('win_{0}', matrix.config.arch) || format('{0}-{1}', matrix.config.os, matrix.config.arch) }}
     steps:
-      - name: Download all archives
+      - name: Download platform archives
         uses: actions/download-artifact@v4
         with:
-          pattern: sift-py-dist-*-py*
+          pattern: sift-py-dist-${{ env.DIST_PLATFORM }}-py*
           path: platform_archives
           merge-multiple: false
 
-      - name: Merge archives by platform
+      - name: Merge archives
         shell: bash
         run: |
-          # Function to merge archives for a platform
-          merge_platform_archives() {
-            local platform=$1
-            echo "Merging archives for platform: $platform"
-            
-            # Create directory for merged wheels
-            mkdir -p "merged_$platform/dist/deps"
-            
-            # Extract all archives and merge unique wheels
-            for zip in platform_archives/*/sift-py-dist-$platform-py*.zip; do
-              echo "Processing archive: $zip"
-              
-              # Create fresh temp directory
-              rm -rf temp_extract
-              mkdir -p temp_extract
-              
-              # Extract and show contents
-              unzip -o "$zip" -d "temp_extract"
-              echo "Contents of temp_extract:"
-              ls -R temp_extract
-              
-              # Find and copy all files from dist directory
-              find temp_extract -type f -exec cp {} "merged_$platform/dist/" \;
-              
-              # Cleanup
-              rm -rf temp_extract
-            done
-            
-            echo "Contents of merged directory:"
-            ls -R "merged_$platform/dist/"
-            
-            # Create merged archive
-            cd "merged_$platform"
-            zip -r "../sift-py-dist-$platform-all-python.zip" dist/
-            cd ..
-          }
+          # Create directory for merged wheels
+          mkdir -p merged/dist/deps
+          
+          # Extract and merge all archives for this platform
+          for zip in platform_archives/*/sift-py-dist-${{ env.DIST_PLATFORM }}-py*.zip; do
+            echo "Processing archive: $zip"
+            unzip -o "$zip" -d "temp_extract"
+            cp -r temp_extract/dist/* merged/dist/
+            rm -rf temp_extract
+          done
+          
+          # Create merged archive
+          cd merged
+          zip -r "../sift-py-dist-${{ env.DIST_PLATFORM }}-all-python.zip" dist/
 
-          # Merge archives for each platform
-          merge_platform_archives "ubuntu-x86_64"
-          merge_platform_archives "ubuntu-aarch64"
-          merge_platform_archives "macos-x86_64"
-          merge_platform_archives "macos-arm64"
-          merge_platform_archives "win_amd64"
-
-      - name: Upload merged archives
+      - name: Upload merged archive
         uses: actions/upload-artifact@v4
         with:
-          name: sift-py-dist-platform-archives
+          name: sift-py-dist-${{ env.DIST_PLATFORM }}-all-python
           path: sift-py-dist-*-all-python.zip
           retention-days: 7
-          separate-files: true

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -39,7 +39,7 @@ jobs:
   build_and_verify:
     name: Build and verify on ${{ matrix.os }} (${{ matrix.arch }}) with Python ${{ matrix.python-version }}
     needs: get-matrix-config
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ needs.get-matrix-config.outputs.platforms.runner }}
     strategy:
       fail-fast: false
       matrix:
@@ -61,6 +61,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install build pip-tools twine
+
+      - name: debug 
+        run: |
+          python -c "import sysconfig;import re;print(re.sub(r'[-.]', '_', sysconfig.get_platform()))"
 
       - name: Generate requirements
         working-directory: python

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -22,6 +22,8 @@ jobs:
     name: Build and verify on ${{ matrix.os }} (${{ matrix.arch }}) with Python ${{ matrix.python-version }}
     needs: get-python-versions
     runs-on: ${{ matrix.runner }}
+    env:
+      PIP_PLATFORM: ${{ matrix.os == 'windows' && format('win_{0}', matrix.arch) || format('{0}-{1}', matrix.os, matrix.arch) }}
     strategy:
       matrix:
         include:
@@ -41,12 +43,9 @@ jobs:
             arch: arm64
             runner: macos-14
             
-          # Windows builds (x86 and x64)
+          # Windows builds (x64)
           - os: windows
-            arch: x86
-            runner: windows-latest
-          - os: windows
-            arch: x64
+            arch: amd64
             runner: windows-latest
         python-version: ${{fromJson(needs.get-python-versions.outputs.python-versions)}}
 
@@ -55,7 +54,7 @@ jobs:
 
       - name: Set up QEMU
         if: matrix.arch == 'aarch64'
-        uses: docker/setup-qemu-action@v3
+       uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
 
@@ -79,8 +78,6 @@ jobs:
       - name: Download dependencies
         working-directory: python
         shell: bash
-        env:
-          PIP_PLATFORM: ${{ matrix.os == 'windows' && format('{0}_win32', matrix.arch) || format('{0}-{1}', matrix.os, matrix.arch) }}
         run: |
           mkdir -p dist/deps
           # Try to download all packages, preferring wheels but allowing source if wheels aren't available
@@ -132,11 +129,11 @@ jobs:
         working-directory: python
         shell: bash
         run: |
-          python -c "import shutil; shutil.make_archive('dist/sift-py-dist-${{ matrix.os }}-${{ matrix.arch }}-py${{ matrix.python-version }}', 'zip', 'dist')"
+          python -c "import shutil; shutil.make_archive('dist/sift-py-dist-${{ env.PIP_PLATFORM }}-py${{ matrix.python-version }}', 'zip', 'dist')"
 
       - name: Upload distribution archive
         uses: actions/upload-artifact@v4
         with:
-          name: sift-py-dist-${{ matrix.os }}-${{ matrix.arch }}-py${{ matrix.python-version }}
+          name: sift-py-dist-${{ env.PIP_PLATFORM }}-py${{ matrix.python-version }}
           path: python/dist/sift-py-dist-*.zip
           retention-days: 7

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -163,7 +163,8 @@ jobs:
     needs: [build_and_verify]
     runs-on: ubuntu-latest
     strategy:
-      matrix: ${{ fromJson(needs.build_and_verify.outputs.platforms) }}
+      matrix:
+        config: ${{ fromJson(needs.build_and_verify.outputs.platforms) }}
     env:
       DIST_PLATFORM: ${{ matrix.config.os == 'windows' && format('win_{0}', matrix.config.arch) || format('{0}-{1}', matrix.config.os, matrix.config.arch) }}
     steps:

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -50,7 +50,7 @@ jobs:
             runner: windows-latest
         python-version: ${{fromJson(needs.get-python-versions.outputs.python-versions)}}
     outputs:
-      platforms: ${{ toJson(matrix.config) }}
+      platforms: ${{ toJson(matrix.config.*) }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -2,7 +2,7 @@ name: Offline Installation Archive
 
 on:
   workflow_dispatch:
-  pull_request:
+  workflow_call:
 
 jobs:
   get-matrix-config:

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -111,7 +111,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          pip install build pip-tools twine
+          pip install build pip-tools
 
       - name: Generate requirements
         working-directory: python

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -5,6 +5,12 @@ on:
   workflow_call:
 
 jobs:
+  # Run ci on workflow_dispatch to ensure we have a clean build.
+  # If using workflow_call, we expect the caller (python_release.yaml) to have already run ci.
+  python-ci:
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/python_ci.yaml
+
   get-matrix-config:
     name: Get matrix configuration
     runs-on: ubuntu-latest
@@ -14,7 +20,7 @@ jobs:
       sift_package_version: ${{ steps.get-sift-version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Get supported Python versions from pyproject.toml
         id: get-python-versions
         run: |
@@ -52,7 +58,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"  # Use lowest supported version for maximum compatibility
+          python-version: "3.8" # Use lowest supported version for maximum compatibility
 
       - name: Install build tools
         run: |
@@ -182,30 +188,37 @@ jobs:
           pattern: sift-py-dist-${{ needs.get-matrix-config.outputs.sift_package_version }}-py*-${{ matrix.platform.platform_tag }}
           path: platform_archives
           merge-multiple: false
-    
+
       - name: Merge archives
         shell: bash
         run: |
           # Create directory for merged files
           mkdir -p merged
-          
+
           # Extract and merge all archives for this platform
           for zip in platform_archives/*/sift-py-dist-${{ needs.get-matrix-config.outputs.sift_package_version }}-py*-${{ matrix.platform.platform_tag }}.zip; do
             echo "Processing archive: $zip"
-            
-            # Extract directly to merged directory
             unzip -o "$zip" -d "merged"
             echo "Contents after extracting $zip:"
             ls -R merged
           done
-          
-          # Create merged archive
-          cd merged
-          zip -r "../sift-py-dist-${{ needs.get-matrix-config.outputs.sift_package_version }}-py3-${{ matrix.platform.platform_tag }}.zip" *
 
-      - name: Upload merged archive
+          # Create base name for archives
+          ARCHIVE_BASE="sift-py-dist-${{ needs.get-matrix-config.outputs.sift_package_version }}-py3-${{ matrix.platform.platform_tag }}"
+
+          # Create zip archive
+          cd merged
+          zip -r "../${ARCHIVE_BASE}.zip" *
+
+          # Create tar.gz archive
+          tar -czf "../${ARCHIVE_BASE}.tar.gz" *
+          cd ..
+
+      - name: Upload merged archives
         uses: actions/upload-artifact@v4
         with:
           name: sift-py-dist-${{ needs.get-matrix-config.outputs.sift_package_version }}-py3-${{ matrix.platform.platform_tag }}
-          path: sift-py-dist-*.zip
+          path: |
+            sift-py-dist-*.zip
+            sift-py-dist-*.tar.gz
           retention-days: 14

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -1,4 +1,4 @@
-name: Build Wheels
+name: Offline Installation Archive
 
 on:
   workflow_dispatch:
@@ -18,95 +18,97 @@ jobs:
           versions=$(grep "Programming Language :: Python :: " python/pyproject.toml | sed 's/.*Python :: \([0-9.]*\).*/\1/' | jq -R -s -c 'split("\n")[:-1]')
           echo "versions=$versions" >> $GITHUB_OUTPUT
 
-  build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+  build_packages:
+    name: Build on ${{ matrix.os }} (${{ matrix.arch }}) with Python ${{ matrix.python-version }}
     needs: get-python-versions
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          # Ubuntu builds (x86_64 and aarch64)
+          - os: ubuntu
+            arch: x86_64
+            runner: ubuntu-latest
+          - os: ubuntu
+            arch: aarch64
+            runner: ubuntu-latest
+            
+          # macOS builds (x86_64 and arm64)
+          - os: macos
+            arch: x86_64
+            runner: macos-latest
+          - os: macos
+            arch: arm64
+            runner: macos-14
+            
+          # Windows builds (x86 and x64)
+          - os: windows
+            arch: x86
+            runner: windows-latest
+          - os: windows
+            arch: x64
+            runner: windows-latest
         python-version: ${{fromJson(needs.get-python-versions.outputs.python-versions)}}
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        if: matrix.arch == 'aarch64'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel
-
-      - name: Build wheels
-        env:
-          CIBW_BUILD: "cp*"
-          CIBW_SKIP: "cp36-* cp37-* *-win32 *-manylinux_i686 *-musllinux*"
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
-          CIBW_ARCHS_LINUX: "x86_64"
-          CIBW_ARCHS_WINDOWS: "AMD64"
-          # Install all optional dependencies for building
-          CIBW_BEFORE_BUILD: >-
-            cd python &&
-            pip install build &&
-            pip install -e .[openssl,build,dev]
-          # Test dependencies and commands
-          CIBW_TEST_REQUIRES: "pytest"
-          # Test both with and without optional dependencies
-          CIBW_TEST_COMMAND: >-
-            pip install {package} &&
-            pytest {project}/tests &&
-            pip install {package}[openssl] &&
-            pytest {project}/tests
+      - name: Install build tools
         run: |
-          python -m cibuildwheel python --output-dir wheelhouse
+          python -m pip install --upgrade pip
+          pip install build pip-tools
 
-      - name: Upload wheels
+      - name: Generate requirements
+        working-directory: python
+        run: |
+          pip-compile pyproject.toml --extra=openssl,build,dev -o requirements-all.txt
+
+      - name: Download dependencies
+        working-directory: python
+        env:
+          PIP_PLATFORM: ${{ matrix.os == 'windows' && format('{0}_win32', matrix.arch) || format('{0}-{1}', matrix.os, matrix.arch) }}
+        run: |
+          mkdir -p dist/deps
+          pip download -r requirements-all.txt -d dist/deps --platform $PIP_PLATFORM --only-binary=:all:
+
+      - name: Build sift-py wheel
+        working-directory: python
+        run: |
+          python -m build --wheel
+
+      - name: Create distribution archive
+        working-directory: python
+        run: |
+          python -c "import shutil; shutil.make_archive('dist/sift-py-dist-${{ matrix.os }}-${{ matrix.arch }}-py${{ matrix.python-version }}', 'zip', 'dist')"
+
+      - name: Upload distribution archive
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}-py${{ matrix.python-version }}
-          path: ./wheelhouse/*.whl
+          name: sift-py-dist-${{ matrix.os }}-${{ matrix.arch }}-py${{ matrix.python-version }}
+          path: python/dist/sift-py-dist-*.zip
           retention-days: 7
 
-  build_sdist:
-    name: Build source distribution
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.8"
-
-      - name: Install build
-        run: python -m pip install build
-
-      - name: Build sdist
-        run: python -m build --sdist python
-
-      - name: Upload sdist
-        uses: actions/upload-artifact@v4
-        with:
-          name: sdist
-          path: python/dist/*.tar.gz
-          retention-days: 7
-
-  verify_wheels:
-    name: Verify wheels
-    needs: [build_wheels, build_sdist]
+  verify_distributions:
+    name: Verify distributions
+    needs: build_packages
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
         with:
-          pattern: wheels-*
+          pattern: sift-py-dist-*
           path: dist
           merge-multiple: true
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: sdist
-          path: dist
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -116,12 +118,27 @@ jobs:
       - name: Install twine
         run: python -m pip install twine
 
-      - name: Check wheels and test installation
+      - name: Extract and verify distributions
         run: |
-          twine check dist/*
-          # Test installation with different combinations of extras
-          python -m pip install --force-reinstall dist/*.whl
-          python -m pip install --force-reinstall dist/*.whl[openssl]
-          python -m pip install --force-reinstall dist/*.whl[build]
-          python -m pip install --force-reinstall dist/*.whl[dev]
-          python -m pip install --force-reinstall dist/*.whl[openssl,build,dev]
+          # Extract all zip files
+          for zip in dist/*.zip; do
+            unzip -o "$zip" -d "./extracted/$(basename "$zip" .zip)"
+          done
+          
+          # Check all wheels with twine
+          find ./extracted -name "*.whl" -exec twine check {} +
+
+      - name: Test installations
+        run: |
+          # Test installation from each distribution
+          for dist_dir in ./extracted/*; do
+            echo "Testing installation from $dist_dir"
+            # Install the main package wheel with different combinations of extras
+            main_wheel=$(find "$dist_dir" -name "sift_stack_py*.whl")
+            pip install --no-index --find-links="$dist_dir" "$main_wheel"
+            pip install --no-index --find-links="$dist_dir" "$main_wheel[openssl]"
+            pip install --no-index --find-links="$dist_dir" "$main_wheel[build]"
+            pip install --no-index --find-links="$dist_dir" "$main_wheel[dev]"
+            pip install --no-index --find-links="$dist_dir" "$main_wheel[openssl,build,dev]"
+            pip uninstall -y sift_stack_py
+          done

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -91,7 +91,6 @@ jobs:
 
           # Then build wheels for package dependencies
           pip wheel -r requirements-all.txt -w dist \
-            --python-version ${{ matrix.python-version }} \
             --prefer-binary \
             --no-deps
 

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -41,13 +41,15 @@ jobs:
 
   build_and_verify:
     name: Build and verify on ${{ matrix.config.os }} (${{ matrix.config.arch }}) with Python ${{ matrix.python-version }}
-    needs: get-python-versions
+    needs: [get-python-versions, define-platforms]
     runs-on: ${{ matrix.config.runner }}
     env:
       DIST_PLATFORM: ${{ matrix.config.os == 'windows' && format('win_{0}', matrix.config.arch) || format('{0}-{1}', matrix.config.os, matrix.config.arch) }}
     strategy:
       fail-fast: false  # Continue with other builds even if one fails
-      matrix: ${{ fromJson(needs.define-platforms.outputs.matrix) }}
+      matrix:
+        config: ${{ fromJson(needs.define-platforms.outputs.matrix).config }}
+        python-version: ${{fromJson(needs.get-python-versions.outputs.python-versions)}}
     outputs:
       matrix-config: ${{ toJson(matrix.config) }}
 

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -163,11 +163,12 @@ jobs:
           retention-days: 7
 
   merge_platform_archives:
-    name: Merge archives for ${{ matrix.platform.os }} (${{ matrix.platform.arch }})
+    name: Merge archives for ${{ matrix.os }} (${{ matrix.arch }})
     needs: [build_and_verify, get-matrix-config]
     runs-on: ubuntu-latest
     strategy:
-      matrix: ${{ fromJson(needs.get-matrix-config.outputs.platforms) }}
+      matrix:
+        platform: ${{ fromJson(needs.get-matrix-config.outputs.platforms) }}
     steps:
       - name: Download platform archives
         uses: actions/download-artifact@v4

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -23,7 +23,7 @@ jobs:
     needs: get-python-versions
     runs-on: ${{ matrix.runner }}
     env:
-      PIP_PLATFORM: ${{ matrix.os == 'windows' && format('win_{0}', matrix.arch) || format('{0}-{1}', matrix.os, matrix.arch) }}
+      DIST_PLATFORM: ${{ matrix.os == 'windows' && format('win_{0}', matrix.arch) || format('{0}-{1}', matrix.os, matrix.arch) }}
     strategy:
       matrix:
         include:
@@ -78,6 +78,8 @@ jobs:
       - name: Download dependencies
         working-directory: python
         shell: bash
+        env:
+          PIP_PLATFORM: ${{ env.DIST_PLATFORM }}
         run: |
           mkdir -p dist/deps
           # Try to download all packages, preferring wheels but allowing source if wheels aren't available
@@ -129,11 +131,11 @@ jobs:
         working-directory: python
         shell: bash
         run: |
-          python -c "import shutil; shutil.make_archive('dist/sift-py-dist-${{ env.PIP_PLATFORM }}-py${{ matrix.python-version }}', 'zip', 'dist')"
+          python -c "import shutil; shutil.make_archive('dist/sift-py-dist-${{ env.DIST_PLATFORM }}-py${{ matrix.python-version }}', 'zip', 'dist')"
 
       - name: Upload distribution archive
         uses: actions/upload-artifact@v4
         with:
-          name: sift-py-dist-${{ env.PIP_PLATFORM }}-py${{ matrix.python-version }}
+          name: sift-py-dist-${{ env.DIST_PLATFORM }}-py${{ matrix.python-version }}
           path: python/dist/sift-py-dist-*.zip
           retention-days: 7

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -105,14 +105,14 @@ jobs:
         working-directory: python
         shell: bash
         run: |
-          twine check dist/sift-stack-py*.whl
+          twine check dist/sift_stack_py*.whl
 
       - name: Test installations
         working-directory: python
         shell: bash
         run: |
           # Get the wheel file name
-          WHEEL_FILE=$(ls dist/sift-stack-py*.whl)
+          WHEEL_FILE=$(ls dist/sift_stack_py*.whl)
           
           # Test base installation
           python -m venv test_venv_base

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -84,7 +84,13 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist/deps
-          # Download and build packages for the current platform
+          # First download build dependencies
+          pip download -d dist/deps \
+            setuptools wheel Cython \
+            --prefer-binary \
+            --no-deps
+
+          # Then download package dependencies
           pip download -r requirements-all.txt -d dist/deps \
             --python-version ${{ matrix.python-version }} \
             --prefer-binary \
@@ -145,58 +151,52 @@ jobs:
           retention-days: 7
 
   merge_platform_archives:
-    name: Merge archives for ${{ matrix.config.os }} (${{ matrix.config.arch }})
+    name: Merge platform archives
     needs: [build_and_verify]
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        config:
-          # Ubuntu builds (x86_64 and aarch64)
-          - os: ubuntu
-            arch: x86_64
-          - os: ubuntu
-            arch: aarch64
-            
-          # macOS builds (x86_64 and arm64)
-          - os: macos
-            arch: x86_64
-          - os: macos
-            arch: arm64
-            
-          # Windows builds (x64)
-          - os: windows
-            arch: amd64
-    env:
-      DIST_PLATFORM: ${{ matrix.config.os == 'windows' && format('win_{0}', matrix.config.arch) || format('{0}-{1}', matrix.config.os, matrix.config.arch) }}
     steps:
-      - name: Download all Python version archives for platform
+      - name: Download all archives
         uses: actions/download-artifact@v4
         with:
-          pattern: sift-py-dist-${{ env.DIST_PLATFORM }}-py*
+          pattern: sift-py-dist-*-py*
           path: platform_archives
           merge-multiple: false
 
-      - name: Merge archives
+      - name: Merge archives by platform
         shell: bash
         run: |
-          # Create directory for merged wheels
-          mkdir -p merged/dist/deps
-          
-          # Extract all archives and merge unique wheels
-          for zip in platform_archives/*/sift-py-dist-*.zip; do
-            unzip -o "$zip" -d "temp_extract"
-            # Copy all wheels, letting newer ones overwrite older ones
-            cp -r temp_extract/dist/* merged/dist/
-            rm -rf temp_extract
-          done
-          
-          # Create merged archive
-          cd merged
-          zip -r "../sift-py-dist-${{ env.DIST_PLATFORM }}-all-python.zip" dist/
+          # Function to merge archives for a platform
+          merge_platform_archives() {
+            local platform=$1
+            echo "Merging archives for platform: $platform"
+            
+            # Create directory for merged wheels
+            mkdir -p "merged_$platform/dist/deps"
+            
+            # Extract all archives and merge unique wheels
+            for zip in platform_archives/*/sift-py-dist-$platform-py*.zip; do
+              unzip -o "$zip" -d "temp_extract"
+              # Copy all wheels, letting newer ones overwrite older ones
+              cp -r temp_extract/dist/* "merged_$platform/dist/"
+              rm -rf temp_extract
+            done
+            
+            # Create merged archive
+            cd "merged_$platform"
+            zip -r "../sift-py-dist-$platform-all-python.zip" dist/
+            cd ..
+          }
 
-      - name: Upload merged archive
+          # Merge archives for each platform
+          merge_platform_archives "ubuntu-x86_64"
+          merge_platform_archives "ubuntu-aarch64"
+          merge_platform_archives "macos-x86_64"
+          merge_platform_archives "macos-arm64"
+          merge_platform_archives "win_amd64"
+
+      - name: Upload merged archives
         uses: actions/upload-artifact@v4
         with:
-          name: sift-py-dist-${{ env.DIST_PLATFORM }}-all-python
-          path: sift-py-dist-*.zip
+          name: sift-py-dist-all-platforms
+          path: sift-py-dist-*-all-python.zip
           retention-days: 7

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -36,9 +36,17 @@ jobs:
             ];
             core.setOutput('matrix', JSON.stringify(matrix));
       - name: debug 
+        always: true
         run: |
-          echo "${{ steps.set-matrix.outputs.matrix }}" ||
-          echo "${{ fromJson(steps.set-matrix.outputs.matrix) }}" || 
+          echo "${{ steps.set-matrix.outputs.matrix }}"
+            - name: debug 
+      - name: debug 2
+        always: true
+        run: |
+          echo "${{ fromJson(steps.set-matrix.outputs.matrix) }}" 
+      - name: debug 3
+        always: true
+        run: |  
           echo "${{ fromJson(needs.get-matrix-config.outputs.matrix).runner }}" 
 
   build_and_verify:

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -82,13 +82,10 @@ jobs:
       - name: Download dependencies
         working-directory: python
         shell: bash
-        env:
-          PIP_PLATFORM: ${{ env.DIST_PLATFORM }}
         run: |
           mkdir -p dist/deps
-          # Try to download all packages, preferring wheels but allowing source if wheels aren't available
+          # Download and build packages for the current platform
           pip download -r requirements-all.txt -d dist/deps \
-            --platform $PIP_PLATFORM \
             --python-version ${{ matrix.python-version }} \
             --prefer-binary \
             --no-deps

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -149,7 +149,7 @@ jobs:
           python scripts/build_utils.py \
             --dist-dir dist \
             --package-name sift-stack-py \
-            --is-windows ${{ matrix.platform.os == 'windows' }}
+            ${{ matrix.platform.os == 'windows' && '--is-windows' || '' }}
 
       - name: Create distribution archive
         working-directory: python

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -73,7 +73,10 @@ jobs:
         working-directory: python
         shell: bash
         run: |
-          pip-compile pyproject.toml --all-extras -o requirements-all.txt
+          # Generate requirements file with only openssl extras
+          # npTDMS doesn't have wheels for all platforms, 
+          # so we need to build it from source which was causing issues on windows
+          pip-compile pyproject.toml --extra=openssl -o requirements-all.txt
 
       - name: Download dependencies
         working-directory: python
@@ -124,8 +127,7 @@ jobs:
           test_install ""  # no extras
           test_install "openssl"
           test_install "build"
-          test_install "dev"
-          test_install "openssl,build,dev"
+          test_install "openssl,build"
 
       - name: Create distribution archive
         working-directory: python

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Generate requirements
         working-directory: python
         run: |
-          pip-compile pyproject.toml --extra=openssl,build,dev -o requirements-all.txt
+          pip-compile pyproject.toml --all-extras -o requirements-all.txt
 
       - name: Download dependencies
         working-directory: python
@@ -80,7 +80,11 @@ jobs:
           PIP_PLATFORM: ${{ matrix.os == 'windows' && format('{0}_win32', matrix.arch) || format('{0}-{1}', matrix.os, matrix.arch) }}
         run: |
           mkdir -p dist/deps
-          pip download -r requirements-all.txt -d dist/deps --platform $PIP_PLATFORM --only-binary=:all:
+          # Download all wheels
+          pip download -r requirements-all.txt -d dist/deps \
+            --platform $PIP_PLATFORM \
+            --python-version ${{ matrix.python-version }} \
+            --no-deps
 
       - name: Build sift-py wheel
         working-directory: python

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -108,26 +108,30 @@ jobs:
         working-directory: python
         shell: bash
         run: |
-          # Function to create venv and test installation
-          test_install() {
-            local extras=$1
-            echo "Testing installation with extras: ${extras:-none}"
-            python -m venv test_venv
-            source test_venv/bin/activate || source test_venv/Scripts/activate
-            if [ -z "$extras" ]; then
-              pip install --no-index --find-links=dist/deps dist/*.whl
-            else
-              pip install --no-index --find-links=dist/deps "dist/*.whl[$extras]"
-            fi
-            deactivate
-            rm -rf test_venv
-          }
+          # Get the wheel file name
+          WHEEL_FILE=$(ls dist/*.whl)
+          
+          # Test base installation
+          python -m venv test_venv_base
+          if [ "${{ matrix.os }}" = "windows" ]; then
+            source test_venv_base/Scripts/activate
+          else
+            source test_venv_base/bin/activate
+          fi
+          pip install --no-index --find-links=dist/deps "$WHEEL_FILE"
+          deactivate
+          rm -rf test_venv_base
 
-          # Test each combination in a fresh venv
-          test_install ""  # no extras
-          test_install "openssl"
-          test_install "build"
-          test_install "openssl,build"
+          # Test openssl installation
+          python -m venv test_venv_openssl
+          if [ "${{ matrix.os }}" = "windows" ]; then
+            source test_venv_openssl/Scripts/activate
+          else
+            source test_venv_openssl/bin/activate
+          fi
+          pip install --no-index --find-links=dist/deps "$WHEEL_FILE[openssl]"
+          deactivate
+          rm -rf test_venv_openssl
 
       - name: Create distribution archive
         working-directory: python

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Set up QEMU
         if: matrix.arch == 'aarch64'
-       uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
 

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -37,9 +37,9 @@ jobs:
             core.setOutput('matrix', JSON.stringify(matrix));
       - name: debug 
         run: |
-          echo "{{ steps.set-matrix.outputs.matrix }}" ||
-          echo "{{ fromJson(steps.set-matrix.outputs.matrix) }}" || 
-          echo "{{ fromJson(needs.get-matrix-config.outputs.matrix).runner }}" 
+          echo "${{ steps.set-matrix.outputs.matrix }}" ||
+          echo "${{ fromJson(steps.set-matrix.outputs.matrix) }}" || 
+          echo "${{ fromJson(needs.get-matrix-config.outputs.matrix).runner }}" 
 
   build_and_verify:
     name: Build and verify on ${{ matrix.os }} (${{ matrix.arch }}) with Python ${{ matrix.python-version }}

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -139,7 +139,7 @@ jobs:
       - name: Download sift-stack-py wheel
         uses: actions/download-artifact@v4
         with:
-          name: sift-stack-py-wheel
+          name: sift-stack-py-dist
           path: python/dist/
 
       - name: Test installations

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: ${{ fromJson(needs.get-matrix-config.outputs.platforms) }}
-        python-version: ${{fromJson(needs.get-matrix-config.outputs.python-versions)}}
+        python-version: ${{fromJson(needs.get-matrix-config.outputs.supported_python_versions)}}
     outputs:
       matrix-config: ${{ toJson(matrix) }}
 

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -18,6 +18,27 @@ jobs:
           versions=$(grep "Programming Language :: Python :: " python/pyproject.toml | sed 's/.*Python :: \([0-9.]*\).*/\1/' | jq -R -s -c 'split("\n")[:-1]')
           echo "versions=$versions" >> $GITHUB_OUTPUT
 
+  define-platforms:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          matrix=$(cat << 'EOF'
+          {
+            "config": [
+              {"os": "ubuntu", "arch": "x86_64", "runner": "ubuntu-latest"},
+              {"os": "ubuntu", "arch": "aarch64", "runner": "ubuntu-latest"},
+              {"os": "macos", "arch": "x86_64", "runner": "macos-latest"},
+              {"os": "macos", "arch": "arm64", "runner": "macos-14"},
+              {"os": "windows", "arch": "amd64", "runner": "windows-latest"}
+            ]
+          }
+          EOF
+          )
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
   build_and_verify:
     name: Build and verify on ${{ matrix.config.os }} (${{ matrix.config.arch }}) with Python ${{ matrix.python-version }}
     needs: get-python-versions
@@ -26,31 +47,9 @@ jobs:
       DIST_PLATFORM: ${{ matrix.config.os == 'windows' && format('win_{0}', matrix.config.arch) || format('{0}-{1}', matrix.config.os, matrix.config.arch) }}
     strategy:
       fail-fast: false  # Continue with other builds even if one fails
-      matrix:
-        config:
-          # Ubuntu builds (x86_64 and aarch64)
-          - os: ubuntu
-            arch: x86_64
-            runner: ubuntu-latest
-          - os: ubuntu
-            arch: aarch64
-            runner: ubuntu-latest
-            
-          # macOS builds (x86_64 and arm64)
-          - os: macos
-            arch: x86_64
-            runner: macos-latest
-          - os: macos
-            arch: arm64
-            runner: macos-14
-            
-          # Windows builds (x64)
-          - os: windows
-            arch: amd64
-            runner: windows-latest
-        python-version: ${{fromJson(needs.get-python-versions.outputs.python-versions)}}
+      matrix: ${{ fromJson(needs.define-platforms.outputs.matrix) }}
     outputs:
-      platforms: ${{ toJson(matrix.config.*) }}
+      matrix-config: ${{ toJson(matrix.config) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -159,14 +158,14 @@ jobs:
           retention-days: 7
 
   merge_platform_archives:
-    name: Merge archives for ${{ matrix.config.os }} (${{ matrix.config.arch }})
-    needs: [build_and_verify]
+    name: Merge archives for ${{ matrix.platform.os }} (${{ matrix.platform.arch }})
+    needs: [build_and_verify, define-platforms]
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        config: ${{ fromJson(needs.build_and_verify.outputs.platforms) }}
+      matrix: 
+        platform: ${{ fromJson(needs.define-platforms.outputs.matrix).config }}
     env:
-      DIST_PLATFORM: ${{ matrix.config.os == 'windows' && format('win_{0}', matrix.config.arch) || format('{0}-{1}', matrix.config.os, matrix.config.arch) }}
+      DIST_PLATFORM: ${{ matrix.platform.os == 'windows' && format('win_{0}', matrix.platform.arch) || format('{0}-{1}', matrix.platform.os, matrix.platform.arch) }}
     steps:
       - name: Download platform archives
         uses: actions/download-artifact@v4

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -146,7 +146,6 @@ jobs:
         working-directory: python
         shell: bash
         run: |
-          pip install wheel
           python scripts/build_utils.py \
             --dist-dir dist \
             --package-name sift-stack-py \

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -35,10 +35,11 @@ jobs:
               {os: 'windows', arch: 'amd64', runner: 'windows-latest', platform: 'win_amd64'}
             ];
             core.setOutput('matrix', JSON.stringify(matrix));
-    - run: |
-        echo "{{ steps.set-matrix.outputs.matrix }}" ||
-        echo "{{ fromJson(steps.set-matrix.outputs.matrix) }}" || 
-        echo "{{ fromJson(needs.get-matrix-config.outputs.matrix).runner }}" 
+      - name: debug 
+        run: |
+          echo "{{ steps.set-matrix.outputs.matrix }}" ||
+          echo "{{ fromJson(steps.set-matrix.outputs.matrix) }}" || 
+          echo "{{ fromJson(needs.get-matrix-config.outputs.matrix).runner }}" 
 
   build_and_verify:
     name: Build and verify on ${{ matrix.os }} (${{ matrix.arch }}) with Python ${{ matrix.python-version }}

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -42,16 +42,16 @@ jobs:
       - name: debug 2
         if: always()
         run: |
-          echo "${{ toJson(steps.set-matrix.outputs.matrix) }}" 
+          echo "${{ fromJson(steps.set-matrix.outputs.matrix)[0].runner }}" 
       - name: debug 3
         if: always()
         run: |  
-          echo "${{ toJson(needs.get-matrix-config.outputs.matrix).runner }}" 
+          echo "${{ needs.get-matrix-config.outputs.matrix[0].runner }}" 
 
   build_and_verify:
     name: Build and verify on ${{ matrix.os }} (${{ matrix.arch }}) with Python ${{ matrix.python-version }}
     needs: get-matrix-config
-    runs-on: ${{ fromJson(needs.get-matrix-config.outputs.platforms).runner }}
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -42,11 +42,11 @@ jobs:
       - name: debug 2
         if: always()
         run: |
-          echo "${{ fromJson(steps.set-matrix.outputs.matrix) }}" 
+          echo "${{ toJson(steps.set-matrix.outputs.matrix) }}" 
       - name: debug 3
         if: always()
         run: |  
-          echo "${{ fromJson(needs.get-matrix-config.outputs.matrix).runner }}" 
+          echo "${{ toJson(needs.get-matrix-config.outputs.matrix).runner }}" 
 
   build_and_verify:
     name: Build and verify on ${{ matrix.os }} (${{ matrix.arch }}) with Python ${{ matrix.python-version }}

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -20,35 +20,33 @@ jobs:
           versions=$(grep "Programming Language :: Python :: " python/pyproject.toml | sed 's/.*Python :: \([0-9.]*\).*/\1/' | jq -R -s -c 'split("\n")[:-1]')
           echo "versions=$versions" >> $GITHUB_OUTPUT
 
+      # We define the platforms here so we can reuse the matrix in multiple jobs
+      # This is a workaround for the fact that we can't use the same matrix in multiple jobs
       - name: Set platform matrix
         id: set-matrix
         uses: actions/github-script@v7
         with:
           script: |
-            const matrix = {
-              config: [
-                {os: 'ubuntu', arch: 'x86_64', runner: 'ubuntu-latest'},
-                {os: 'ubuntu', arch: 'aarch64', runner: 'ubuntu-latest'},
-                {os: 'macos', arch: 'x86_64', runner: 'macos-latest'},
-                {os: 'macos', arch: 'arm64', runner: 'macos-14'},
-                {os: 'windows', arch: 'amd64', runner: 'windows-latest'}
-              ]
-            };
+            const matrix = [
+              {os: 'ubuntu', arch: 'x86_64', runner: 'ubuntu-latest', platform: 'ubuntu-x86_64'},
+              {os: 'ubuntu', arch: 'aarch64', runner: 'ubuntu-latest', platform: 'ubuntu-aarch64'},
+              {os: 'macos', arch: 'x86_64', runner: 'macos-latest', platform: 'macos-x86_64'},
+              {os: 'macos', arch: 'arm64', runner: 'macos-14', platform: 'macos-arm64'},
+              {os: 'windows', arch: 'amd64', runner: 'windows-latest', platform: 'win_amd64'}
+            ];
             core.setOutput('matrix', JSON.stringify(matrix));
 
   build_and_verify:
-    name: Build and verify on ${{ matrix.config.os }} (${{ matrix.config.arch }}) with Python ${{ matrix.python-version }}
+    name: Build and verify on ${{ matrix.os }} (${{ matrix.arch }}) with Python ${{ matrix.python-version }}
     needs: get-matrix-config
-    runs-on: ${{ matrix.config.runner }}
-    env:
-      DIST_PLATFORM: ${{ matrix.config.os == 'windows' && format('win_{0}', matrix.config.arch) || format('{0}-{1}', matrix.config.os, matrix.config.arch) }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        config: ${{ fromJson(needs.get-matrix-config.outputs.platforms).config }}
+        platform: ${{ fromJson(needs.get-matrix-config.outputs.platforms) }}
         python-version: ${{fromJson(needs.get-matrix-config.outputs.python-versions)}}
     outputs:
-      matrix-config: ${{ toJson(matrix.config) }}
+      matrix-config: ${{ toJson(matrix) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -111,7 +109,7 @@ jobs:
           
           # Test base installation
           python -m venv test_venv_base
-          if [ "${{ matrix.config.os }}" = "windows" ]; then
+          if [ "${{ matrix.os }}" = "windows" ]; then
             source test_venv_base/Scripts/activate
           else
             source test_venv_base/bin/activate
@@ -122,7 +120,7 @@ jobs:
 
           # Test openssl installation
           python -m venv test_venv_openssl
-          if [ "${{ matrix.config.os }}" = "windows" ]; then
+          if [ "${{ matrix.os }}" = "windows" ]; then
             source test_venv_openssl/Scripts/activate
           else
             source test_venv_openssl/bin/activate
@@ -135,37 +133,37 @@ jobs:
         working-directory: python
         shell: bash
         run: |
-          if [ "${{ matrix.config.os }}" = "windows" ]; then
-            # Use PowerShell's Compress-Archive on Windows
-            pwsh -Command "Compress-Archive -Path dist/* -DestinationPath dist/sift-py-dist-${{ env.DIST_PLATFORM }}-py${{ matrix.python-version }}.zip -Force"
+          if [ "${{ matrix.os }}" = "windows" ]; then
+            pwsh -Command "Compress-Archive -Path dist/* -DestinationPath dist/sift-py-dist-py${{ matrix.python-version }}-${{ matrix.platform }}.zip -Force"
           else
-            # Use zip on Unix-like systems
-            cd dist && zip -r "sift-py-dist-${{ env.DIST_PLATFORM }}-py${{ matrix.python-version }}.zip" *
+            cd dist && zip -r "sift-py-dist-py${{ matrix.python-version }}-${{ matrix.platform }}.zip" *
           fi
 
       - name: Upload distribution archive
         uses: actions/upload-artifact@v4
         with:
-          name: sift-py-dist-${{ env.DIST_PLATFORM }}-py${{ matrix.python-version }}
+          name: sift-py-dist-py${{ matrix.python-version }}-${{ matrix.platform }}
           path: python/dist/sift-py-dist-*.zip
           retention-days: 7
 
   merge_platform_archives:
-    name: Merge archives for ${{ matrix.platform.os }} (${{ matrix.platform.arch }})
+    name: Merge archives for ${{ matrix.os }} (${{ matrix.arch }})
     needs: [build_and_verify, get-matrix-config]
     runs-on: ubuntu-latest
     strategy:
-      matrix: 
-        platform: ${{ fromJson(needs.get-matrix-config.outputs.platforms).config }}
-    env:
-      DIST_PLATFORM: ${{ matrix.platform.os == 'windows' && format('win_{0}', matrix.platform.arch) || format('{0}-{1}', matrix.platform.os, matrix.platform.arch) }}
+      matrix: ${{ fromJson(needs.get-matrix-config.outputs.platforms) }}
     steps:
       - name: Download platform archives
         uses: actions/download-artifact@v4
         with:
-          pattern: sift-py-dist-${{ env.DIST_PLATFORM }}-py*
+          pattern: sift-py-dist-py*-${{ matrix.platform }}
           path: platform_archives
           merge-multiple: false
+    
+      - name: debug 
+        run: |
+          echo "{{ needs.build_and_verify.outputs.matrix-config }}"
+          python -c "import sysconfig;import re;print(re.sub(r'[-.]', '_', sysconfig.get_platform()))"
 
       - name: Merge archives
         shell: bash
@@ -174,7 +172,7 @@ jobs:
           mkdir -p merged/dist/deps
           
           # Extract and merge all archives for this platform
-          for zip in platform_archives/*/sift-py-dist-${{ env.DIST_PLATFORM }}-py*.zip; do
+          for zip in platform_archives/*/sift-py-dist-py*-${{ matrix.platform }}.zip; do
             echo "Processing archive: $zip"
             
             # Create fresh temp directory
@@ -198,11 +196,11 @@ jobs:
           
           # Create merged archive
           cd merged
-          zip -r "../sift-py-dist-${{ env.DIST_PLATFORM }}-all-python.zip" dist/
+          zip -r "../sift-py-dist-py3-${{ matrix.platform }}.zip" dist/
 
       - name: Upload merged archive
         uses: actions/upload-artifact@v4
         with:
-          name: sift-py-dist-${{ env.DIST_PLATFORM }}-all-python
-          path: sift-py-dist-*-all-python.zip
+          name: sift-py-dist-py3-${{ matrix.platform }}
+          path: sift-py-dist-py3-*.zip
           retention-days: 7

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -73,10 +73,8 @@ jobs:
         working-directory: python
         shell: bash
         run: |
-          # Generate requirements file with only openssl extras
-          # npTDMS doesn't have wheels for all platforms, 
-          # so we need to build it from source which was causing issues on windows
-          pip-compile pyproject.toml --extra=openssl -o requirements-all.txt
+          # Generate requirements file with all extras
+          pip-compile pyproject.toml --all-extras -o requirements-all.txt
 
       - name: Build dependency wheels
         working-directory: python
@@ -113,27 +111,34 @@ jobs:
           # Get the wheel file name
           WHEEL_FILE=$(ls dist/sift_stack_py*.whl)
           
-          # Test base installation
-          python -m venv test_venv_base
-          if [ "${{ matrix.platform.os }}" = "windows" ]; then
-            source test_venv_base/Scripts/activate
-          else
-            source test_venv_base/bin/activate
-          fi
-          pip install --no-index --find-links=dist/ "$WHEEL_FILE"
-          deactivate
-          rm -rf test_venv_base
-
-          # Test openssl installation
-          python -m venv test_venv_openssl
-          if [ "${{ matrix.platform.os }}" = "windows" ]; then
-            source test_venv_openssl/Scripts/activate
-          else
-            source test_venv_openssl/bin/activate
-          fi
-          pip install --no-index --find-links=dist/ "$WHEEL_FILE[openssl]"
-          deactivate
-          rm -rf test_venv_openssl
+          # Function to test installation with specific extras
+          test_install() {
+            local extras=$1
+            echo "Testing installation with extras: ${extras:-none}"
+            python -m venv "test_venv_${extras:-base}"
+            if [ "${{ matrix.platform.os }}" = "windows" ]; then
+              source "test_venv_${extras:-base}/Scripts/activate"
+            else
+              source "test_venv_${extras:-base}/bin/activate"
+            fi
+            if [ -z "$extras" ]; then
+              pip install --no-index --find-links=dist/ "$WHEEL_FILE"
+            else
+              pip install --no-index --find-links=dist/ "$WHEEL_FILE[$extras]"
+            fi
+            deactivate
+            rm -rf "test_venv_${extras:-base}"
+          }
+          
+          # Test each combination
+          test_install ""  # base installation
+          test_install "openssl"
+          test_install "build"
+          test_install "development"
+          test_install "openssl,build"
+          test_install "openssl,development"
+          test_install "build,development"
+          test_install "openssl,build,development"
 
       - name: Create distribution archive
         working-directory: python

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -218,6 +218,7 @@ jobs:
       - name: Upload merged archives
         uses: actions/upload-artifact@v4
         with:
-          name: sift-py-dist-all-platforms
+          name: sift-py-dist-platform-archives
           path: sift-py-dist-*-all-python.zip
           retention-days: 7
+          separate-files: true

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -78,19 +78,19 @@ jobs:
           # so we need to build it from source which was causing issues on windows
           pip-compile pyproject.toml --extra=openssl -o requirements-all.txt
 
-      - name: Download dependencies
+      - name: Build dependency wheels
         working-directory: python
         shell: bash
         run: |
-          # Download all dependencies directly to dist directory
-          # First download build dependencies
-          pip download -d dist \
+          # Build wheels for all dependencies directly to dist directory
+          # First build wheels for build dependencies
+          pip wheel -w dist \
             setuptools wheel Cython \
             --prefer-binary \
             --no-deps
 
-          # Then download package dependencies
-          pip download -r requirements-all.txt -d dist \
+          # Then build wheels for package dependencies
+          pip wheel -r requirements-all.txt -w dist \
             --python-version ${{ matrix.python-version }} \
             --prefer-binary \
             --no-deps

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -28,11 +28,11 @@ jobs:
         with:
           script: |
             const matrix = [
-              {os: 'ubuntu', arch: 'x86_64', runner: 'ubuntu-latest', platform: 'ubuntu-x86_64'},
-              {os: 'ubuntu', arch: 'aarch64', runner: 'ubuntu-latest', platform: 'ubuntu-aarch64'},
-              {os: 'macos', arch: 'x86_64', runner: 'macos-latest', platform: 'macos-x86_64'},
-              {os: 'macos', arch: 'arm64', runner: 'macos-14', platform: 'macos-arm64'},
-              {os: 'windows', arch: 'amd64', runner: 'windows-latest', platform: 'win_amd64'}
+              {os: 'ubuntu', arch: 'x86_64', runner: 'ubuntu-latest', platform_tag: 'ubuntu-x86_64'},
+              {os: 'ubuntu', arch: 'aarch64', runner: 'ubuntu-latest', platform_tag: 'ubuntu-aarch64'},
+              {os: 'macos', arch: 'x86_64', runner: 'macos-latest', platform_tag: 'macos-x86_64'},
+              {os: 'macos', arch: 'arm64', runner: 'macos-14', platform_tag: 'macos-arm64'},
+              {os: 'windows', arch: 'amd64', runner: 'windows-latest', platform_tag: 'win_amd64'}
             ];
             core.setOutput('matrix', JSON.stringify(matrix));
       - name: debug 
@@ -49,7 +49,7 @@ jobs:
           echo "${{ needs.get-matrix-config.outputs.matrix[0].runner }}" 
 
   build_and_verify:
-    name: Build and verify on ${{ matrix.os }} (${{ matrix.arch }}) with Python ${{ matrix.python-version }}
+    name: Build and verify on ${{ matrix.platform.os }} (${{ matrix.platform.arch }}) with Python ${{ matrix.python-version }}
     needs: get-matrix-config
     runs-on: ${{ matrix.platform.runner }}
     strategy:
@@ -125,7 +125,7 @@ jobs:
           
           # Test base installation
           python -m venv test_venv_base
-          if [ "${{ matrix.os }}" = "windows" ]; then
+          if [ "${{ matrix.platform.os }}" = "windows" ]; then
             source test_venv_base/Scripts/activate
           else
             source test_venv_base/bin/activate
@@ -136,7 +136,7 @@ jobs:
 
           # Test openssl installation
           python -m venv test_venv_openssl
-          if [ "${{ matrix.os }}" = "windows" ]; then
+          if [ "${{ matrix.platform.os }}" = "windows" ]; then
             source test_venv_openssl/Scripts/activate
           else
             source test_venv_openssl/bin/activate
@@ -149,21 +149,21 @@ jobs:
         working-directory: python
         shell: bash
         run: |
-          if [ "${{ matrix.os }}" = "windows" ]; then
-            pwsh -Command "Compress-Archive -Path dist/* -DestinationPath dist/sift-py-dist-py${{ matrix.python-version }}-${{ matrix.platform }}.zip -Force"
+          if [ "${{ matrix.platform.os }}" = "windows" ]; then
+            pwsh -Command "Compress-Archive -Path dist/* -DestinationPath dist/sift-py-dist-py${{ matrix.python-version }}-${{ matrix.platform.platform_tag }}.zip -Force"
           else
-            cd dist && zip -r "sift-py-dist-py${{ matrix.python-version }}-${{ matrix.platform }}.zip" *
+            cd dist && zip -r "sift-py-dist-py${{ matrix.python-version }}-${{ matrix.platform.platform_tag }}.zip" *
           fi
 
       - name: Upload distribution archive
         uses: actions/upload-artifact@v4
         with:
-          name: sift-py-dist-py${{ matrix.python-version }}-${{ matrix.platform }}
+          name: sift-py-dist-py${{ matrix.python-version }}-${{ matrix.platform.platform_tag }}
           path: python/dist/sift-py-dist-*.zip
           retention-days: 7
 
   merge_platform_archives:
-    name: Merge archives for ${{ matrix.os }} (${{ matrix.arch }})
+    name: Merge archives for ${{ matrix.platform.os }} (${{ matrix.platform.arch }})
     needs: [build_and_verify, get-matrix-config]
     runs-on: ubuntu-latest
     strategy:
@@ -172,7 +172,7 @@ jobs:
       - name: Download platform archives
         uses: actions/download-artifact@v4
         with:
-          pattern: sift-py-dist-py*-${{ matrix.platform }}
+          pattern: sift-py-dist-py*-${{ matrix.platform.platform_tag }}
           path: platform_archives
           merge-multiple: false
     
@@ -188,7 +188,7 @@ jobs:
           mkdir -p merged/dist/deps
           
           # Extract and merge all archives for this platform
-          for zip in platform_archives/*/sift-py-dist-py*-${{ matrix.platform }}.zip; do
+          for zip in platform_archives/*/sift-py-dist-py*-${{ matrix.platform.platform_tag }}.zip; do
             echo "Processing archive: $zip"
             
             # Create fresh temp directory
@@ -212,11 +212,11 @@ jobs:
           
           # Create merged archive
           cd merged
-          zip -r "../sift-py-dist-py3-${{ matrix.platform }}.zip" dist/
+          zip -r "../sift-py-dist-py3-${{ matrix.platform.platform_tag }}.zip" dist/
 
       - name: Upload merged archive
         uses: actions/upload-artifact@v4
         with:
-          name: sift-py-dist-py3-${{ matrix.platform }}
+          name: sift-py-dist-py3-${{ matrix.platform.platform_tag }}
           path: sift-py-dist-py3-*.zip
           retention-days: 7

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -43,17 +43,61 @@ jobs:
             ];
             core.setOutput('matrix', JSON.stringify(matrix));
 
+  build_wheel:
+    name: Build sift-stack-py distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.8"  # Use lowest supported version for maximum compatibility
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build distributions
+        working-directory: python
+        run: |
+          python -m build
+
+      - name: Verify distributions
+        working-directory: python
+        shell: bash
+        run: |
+          # Check all distributions with twine
+          twine check dist/*
+
+          # Verify we have a universal wheel
+          # We want to ensure that the wheel is compatible with all Python versions
+          # and all architectures. If this fails, we will need to update our build strategy to
+          # build separate wheels for each Python version and architecture.
+          WHEEL_NAME=$(ls dist/sift_stack_py*.whl)
+          if [[ ! $WHEEL_NAME =~ "py3-none-any.whl" ]]; then
+            echo "Error: Expected a universal wheel (py3-none-any) but got: $WHEEL_NAME"
+            exit 1
+          fi
+          echo "Verified universal wheel: $WHEEL_NAME"
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: sift-stack-py-dist
+          path: python/dist/*
+          retention-days: 14
+
   build_and_verify:
-    name: Build and verify on ${{ matrix.platform.os }} (${{ matrix.platform.arch }}) with Python ${{ matrix.python-version }}
-    needs: get-matrix-config
+    name: Build offline archive for ${{ matrix.platform.os }} (${{ matrix.platform.arch }}) with Python ${{ matrix.python-version }}
+    needs: [get-matrix-config, build_wheel]
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
       matrix:
         platform: ${{ fromJson(needs.get-matrix-config.outputs.platforms) }}
         python-version: ${{fromJson(needs.get-matrix-config.outputs.supported_python_versions)}}
-    outputs:
-      matrix-config: ${{ toJson(matrix) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -92,53 +136,21 @@ jobs:
             --prefer-binary \
             --no-deps
 
-      - name: Build sift-py wheel
-        working-directory: python
-        shell: bash
-        run: |
-          python -m build --wheel
-
-      - name: Verify wheel
-        working-directory: python
-        shell: bash
-        run: |
-          twine check dist/sift_stack_py*.whl
+      - name: Download sift-stack-py wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: sift-stack-py-wheel
+          path: python/dist/
 
       - name: Test installations
         working-directory: python
         shell: bash
         run: |
-          # Get the wheel file name
-          WHEEL_FILE=$(ls dist/sift_stack_py*.whl)
-          
-          # Function to test installation with specific extras
-          test_install() {
-            local extras=$1
-            echo "Testing installation with extras: ${extras:-none}"
-            python -m venv "test_venv_${extras:-base}"
-            if [ "${{ matrix.platform.os }}" = "windows" ]; then
-              source "test_venv_${extras:-base}/Scripts/activate"
-            else
-              source "test_venv_${extras:-base}/bin/activate"
-            fi
-            if [ -z "$extras" ]; then
-              pip install --no-index --find-links=dist/ "$WHEEL_FILE"
-            else
-              pip install --no-index --find-links=dist/ "$WHEEL_FILE[$extras]"
-            fi
-            deactivate
-            rm -rf "test_venv_${extras:-base}"
-          }
-          
-          # Test each combination
-          test_install ""  # base installation
-          test_install "openssl"
-          test_install "build"
-          test_install "development"
-          test_install "openssl,build"
-          test_install "openssl,development"
-          test_install "build,development"
-          test_install "openssl,build,development"
+          pip install wheel
+          python scripts/build_utils.py \
+            --dist-dir dist \
+            --package-name sift-stack-py \
+            --is-windows ${{ matrix.platform.os == 'windows' }}
 
       - name: Create distribution archive
         working-directory: python

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -18,8 +18,8 @@ jobs:
           versions=$(grep "Programming Language :: Python :: " python/pyproject.toml | sed 's/.*Python :: \([0-9.]*\).*/\1/' | jq -R -s -c 'split("\n")[:-1]')
           echo "versions=$versions" >> $GITHUB_OUTPUT
 
-  build_packages:
-    name: Build on ${{ matrix.os }} (${{ matrix.arch }}) with Python ${{ matrix.python-version }}
+  build_and_verify:
+    name: Build and verify on ${{ matrix.os }} (${{ matrix.arch }}) with Python ${{ matrix.python-version }}
     needs: get-python-versions
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -65,22 +65,24 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install build tools
+        shell: bash
         run: |
           python -m pip install --upgrade pip
-          pip install build pip-tools
+          pip install build pip-tools twine
 
       - name: Generate requirements
         working-directory: python
+        shell: bash
         run: |
           pip-compile pyproject.toml --all-extras -o requirements-all.txt
 
       - name: Download dependencies
         working-directory: python
+        shell: bash
         env:
           PIP_PLATFORM: ${{ matrix.os == 'windows' && format('{0}_win32', matrix.arch) || format('{0}-{1}', matrix.os, matrix.arch) }}
         run: |
           mkdir -p dist/deps
-          # Download all wheels
           pip download -r requirements-all.txt -d dist/deps \
             --platform $PIP_PLATFORM \
             --python-version ${{ matrix.python-version }} \
@@ -88,11 +90,45 @@ jobs:
 
       - name: Build sift-py wheel
         working-directory: python
+        shell: bash
         run: |
           python -m build --wheel
 
+      - name: Verify wheel
+        working-directory: python
+        shell: bash
+        run: |
+          twine check dist/*.whl
+
+      - name: Test installations
+        working-directory: python
+        shell: bash
+        run: |
+          # Function to create venv and test installation
+          test_install() {
+            local extras=$1
+            echo "Testing installation with extras: ${extras:-none}"
+            python -m venv test_venv
+            source test_venv/bin/activate || source test_venv/Scripts/activate
+            if [ -z "$extras" ]; then
+              pip install --no-index --find-links=dist/deps dist/*.whl
+            else
+              pip install --no-index --find-links=dist/deps "dist/*.whl[$extras]"
+            fi
+            deactivate
+            rm -rf test_venv
+          }
+
+          # Test each combination in a fresh venv
+          test_install ""  # no extras
+          test_install "openssl"
+          test_install "build"
+          test_install "dev"
+          test_install "openssl,build,dev"
+
       - name: Create distribution archive
         working-directory: python
+        shell: bash
         run: |
           python -c "import shutil; shutil.make_archive('dist/sift-py-dist-${{ matrix.os }}-${{ matrix.arch }}-py${{ matrix.python-version }}', 'zip', 'dist')"
 
@@ -102,47 +138,3 @@ jobs:
           name: sift-py-dist-${{ matrix.os }}-${{ matrix.arch }}-py${{ matrix.python-version }}
           path: python/dist/sift-py-dist-*.zip
           retention-days: 7
-
-  verify_distributions:
-    name: Verify distributions
-    needs: build_packages
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: sift-py-dist-*
-          path: dist
-          merge-multiple: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.8"
-
-      - name: Install twine
-        run: python -m pip install twine
-
-      - name: Extract and verify distributions
-        run: |
-          # Extract all zip files
-          for zip in dist/*.zip; do
-            unzip -o "$zip" -d "./extracted/$(basename "$zip" .zip)"
-          done
-          
-          # Check all wheels with twine
-          find ./extracted -name "*.whl" -exec twine check {} +
-
-      - name: Test installations
-        run: |
-          # Test installation from each distribution
-          for dist_dir in ./extracted/*; do
-            echo "Testing installation from $dist_dir"
-            # Install the main package wheel with different combinations of extras
-            main_wheel=$(find "$dist_dir" -name "sift_stack_py*.whl")
-            pip install --no-index --find-links="$dist_dir" "$main_wheel"
-            pip install --no-index --find-links="$dist_dir" "$main_wheel[openssl]"
-            pip install --no-index --find-links="$dist_dir" "$main_wheel[build]"
-            pip install --no-index --find-links="$dist_dir" "$main_wheel[dev]"
-            pip install --no-index --find-links="$dist_dir" "$main_wheel[openssl,build,dev]"
-            pip uninstall -y sift_stack_py
-          done

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -39,7 +39,7 @@ jobs:
   build_and_verify:
     name: Build and verify on ${{ matrix.os }} (${{ matrix.arch }}) with Python ${{ matrix.python-version }}
     needs: get-matrix-config
-    runs-on: ${{ needs.get-matrix-config.outputs.platforms.runner }}
+    runs-on: ${{ fromJson(needs.get-matrix-config.outputs.platforms).runner }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -5,10 +5,12 @@ on:
   pull_request:
 
 jobs:
-  get-python-versions:
+  get-matrix-config:
+    name: Get matrix configuration
     runs-on: ubuntu-latest
     outputs:
       python-versions: ${{ steps.get-versions.outputs.versions }}
+      platforms: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
       
@@ -18,12 +20,8 @@ jobs:
           versions=$(grep "Programming Language :: Python :: " python/pyproject.toml | sed 's/.*Python :: \([0-9.]*\).*/\1/' | jq -R -s -c 'split("\n")[:-1]')
           echo "versions=$versions" >> $GITHUB_OUTPUT
 
-  define-platforms:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - id: set-matrix
+      - name: Set platform matrix
+        id: set-matrix
         uses: actions/github-script@v7
         with:
           script: |
@@ -40,15 +38,15 @@ jobs:
 
   build_and_verify:
     name: Build and verify on ${{ matrix.config.os }} (${{ matrix.config.arch }}) with Python ${{ matrix.python-version }}
-    needs: [get-python-versions, define-platforms]
+    needs: get-matrix-config
     runs-on: ${{ matrix.config.runner }}
     env:
       DIST_PLATFORM: ${{ matrix.config.os == 'windows' && format('win_{0}', matrix.config.arch) || format('{0}-{1}', matrix.config.os, matrix.config.arch) }}
     strategy:
-      fail-fast: false  # Continue with other builds even if one fails
+      fail-fast: false
       matrix:
-        config: ${{ fromJson(needs.define-platforms.outputs.matrix).config }}
-        python-version: ${{fromJson(needs.get-python-versions.outputs.python-versions)}}
+        config: ${{ fromJson(needs.get-matrix-config.outputs.platforms).config }}
+        python-version: ${{fromJson(needs.get-matrix-config.outputs.python-versions)}}
     outputs:
       matrix-config: ${{ toJson(matrix.config) }}
 
@@ -160,11 +158,11 @@ jobs:
 
   merge_platform_archives:
     name: Merge archives for ${{ matrix.platform.os }} (${{ matrix.platform.arch }})
-    needs: [build_and_verify, define-platforms]
+    needs: [build_and_verify, get-matrix-config]
     runs-on: ubuntu-latest
     strategy:
       matrix: 
-        platform: ${{ fromJson(needs.define-platforms.outputs.matrix).config }}
+        platform: ${{ fromJson(needs.get-matrix-config.outputs.platforms).config }}
     env:
       DIST_PLATFORM: ${{ matrix.platform.os == 'windows' && format('win_{0}', matrix.platform.arch) || format('{0}-{1}', matrix.platform.os, matrix.platform.arch) }}
     steps:
@@ -184,10 +182,25 @@ jobs:
           # Extract and merge all archives for this platform
           for zip in platform_archives/*/sift-py-dist-${{ env.DIST_PLATFORM }}-py*.zip; do
             echo "Processing archive: $zip"
+            
+            # Create fresh temp directory
+            rm -rf temp_extract
+            mkdir -p temp_extract
+            
+            # Extract and show contents
             unzip -o "$zip" -d "temp_extract"
-            cp -r temp_extract/dist/* merged/dist/
+            echo "Contents of temp_extract:"
+            ls -R temp_extract
+            
+            # Find all files recursively and copy them
+            find temp_extract -type f -exec cp {} merged/dist/ \;
+            
+            # Cleanup
             rm -rf temp_extract
           done
+          
+          echo "Contents of merged directory:"
+          ls -R merged/dist/
           
           # Create merged archive
           cd merged

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -9,16 +9,23 @@ jobs:
     name: Get matrix configuration
     runs-on: ubuntu-latest
     outputs:
-      python-versions: ${{ steps.get-versions.outputs.versions }}
+      supported_python_versions: ${{ steps.get-python-versions.outputs.versions }}
       platforms: ${{ steps.set-matrix.outputs.matrix }}
+      sift_package_version: ${{ steps.get-sift-version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
       
-      - name: Get Python versions from pyproject.toml
-        id: get-versions
+      - name: Get supported Python versions from pyproject.toml
+        id: get-python-versions
         run: |
           versions=$(grep "Programming Language :: Python :: " python/pyproject.toml | sed 's/.*Python :: \([0-9.]*\).*/\1/' | jq -R -s -c 'split("\n")[:-1]')
           echo "versions=$versions" >> $GITHUB_OUTPUT
+
+      - name: Get sift-stack-py package version from pyproject.toml
+        id: get-sift-version
+        run: |
+          version=$(grep '^version = ' python/pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "version=$version" >> $GITHUB_OUTPUT
 
       # We define the platforms here so we can reuse the matrix in multiple jobs
       # This is a workaround for the fact that we can't use the same matrix in multiple jobs
@@ -75,15 +82,15 @@ jobs:
         working-directory: python
         shell: bash
         run: |
-          mkdir -p dist/deps
+          # Download all dependencies directly to dist directory
           # First download build dependencies
-          pip download -d dist/deps \
+          pip download -d dist \
             setuptools wheel Cython \
             --prefer-binary \
             --no-deps
 
           # Then download package dependencies
-          pip download -r requirements-all.txt -d dist/deps \
+          pip download -r requirements-all.txt -d dist \
             --python-version ${{ matrix.python-version }} \
             --prefer-binary \
             --no-deps
@@ -98,14 +105,14 @@ jobs:
         working-directory: python
         shell: bash
         run: |
-          twine check dist/*.whl
+          twine check dist/sift-stack-py*.whl
 
       - name: Test installations
         working-directory: python
         shell: bash
         run: |
           # Get the wheel file name
-          WHEEL_FILE=$(ls dist/*.whl)
+          WHEEL_FILE=$(ls dist/sift-stack-py*.whl)
           
           # Test base installation
           python -m venv test_venv_base
@@ -114,7 +121,7 @@ jobs:
           else
             source test_venv_base/bin/activate
           fi
-          pip install --no-index --find-links=dist/deps "$WHEEL_FILE"
+          pip install --no-index --find-links=dist/ "$WHEEL_FILE"
           deactivate
           rm -rf test_venv_base
 
@@ -125,7 +132,7 @@ jobs:
           else
             source test_venv_openssl/bin/activate
           fi
-          pip install --no-index --find-links=dist/deps "$WHEEL_FILE[openssl]"
+          pip install --no-index --find-links=dist/ "$WHEEL_FILE[openssl]"
           deactivate
           rm -rf test_venv_openssl
 
@@ -134,17 +141,17 @@ jobs:
         shell: bash
         run: |
           if [ "${{ matrix.platform.os }}" = "windows" ]; then
-            pwsh -Command "Compress-Archive -Path dist/* -DestinationPath dist/sift-py-dist-py${{ matrix.python-version }}-${{ matrix.platform.platform_tag }}.zip -Force"
+            pwsh -Command "Compress-Archive -Path dist/* -DestinationPath dist/sift-py-dist-${{ needs.get-matrix-config.outputs.sift_package_version }}-py${{ matrix.python-version }}-${{ matrix.platform.platform_tag }}.zip -Force"
           else
-            cd dist && zip -r "sift-py-dist-py${{ matrix.python-version }}-${{ matrix.platform.platform_tag }}.zip" *
+            cd dist && zip -r "sift-py-dist-${{ needs.get-matrix-config.outputs.sift_package_version }}-py${{ matrix.python-version }}-${{ matrix.platform.platform_tag }}.zip" *
           fi
 
       - name: Upload distribution archive
         uses: actions/upload-artifact@v4
         with:
-          name: sift-py-dist-py${{ matrix.python-version }}-${{ matrix.platform.platform_tag }}
+          name: sift-py-dist-${{ needs.get-matrix-config.outputs.sift_package_version }}-py${{ matrix.python-version }}-${{ matrix.platform.platform_tag }}
           path: python/dist/sift-py-dist-*.zip
-          retention-days: 7
+          retention-days: 14
 
   merge_platform_archives:
     name: Merge archives for ${{ matrix.platform.os }} (${{ matrix.platform.arch }})
@@ -157,47 +164,33 @@ jobs:
       - name: Download platform archives
         uses: actions/download-artifact@v4
         with:
-          pattern: sift-py-dist-py*-${{ matrix.platform.platform_tag }}
+          pattern: sift-py-dist-${{ needs.get-matrix-config.outputs.sift_package_version }}-py*-${{ matrix.platform.platform_tag }}
           path: platform_archives
           merge-multiple: false
     
       - name: Merge archives
         shell: bash
         run: |
-          # Create directory for merged wheels
-          mkdir -p merged/dist/deps
+          # Create directory for merged files
+          mkdir -p merged
           
           # Extract and merge all archives for this platform
-          for zip in platform_archives/*/sift-py-dist-py*-${{ matrix.platform.platform_tag }}.zip; do
+          for zip in platform_archives/*/sift-py-dist-${{ needs.get-matrix-config.outputs.sift_package_version }}-py*-${{ matrix.platform.platform_tag }}.zip; do
             echo "Processing archive: $zip"
             
-            # Create fresh temp directory
-            rm -rf temp_extract
-            mkdir -p temp_extract
-            
-            # Extract and show contents
-            unzip -o "$zip" -d "temp_extract"
-            echo "Contents of temp_extract:"
-            ls -R temp_extract
-            
-            # Find all files recursively and copy them
-            find temp_extract -type f -exec cp {} merged/dist/ \;
-            
-            # Cleanup
-            rm -rf temp_extract
+            # Extract directly to merged directory
+            unzip -o "$zip" -d "merged"
+            echo "Contents after extracting $zip:"
+            ls -R merged
           done
-          
-          echo "Contents of merged directory:"
-          ls -R merged/dist/
           
           # Create merged archive
           cd merged
-          rm -rf deps/ # this is now an empty directory
-          zip -r "../sift-py-dist-py3-${{ matrix.platform.platform_tag }}.zip" dist/
+          zip -r "../sift-py-dist-${{ needs.get-matrix-config.outputs.sift_package_version }}-py3-${{ matrix.platform.platform_tag }}.zip" *
 
       - name: Upload merged archive
         uses: actions/upload-artifact@v4
         with:
-          name: sift-py-dist-py3-${{ matrix.platform.platform_tag }}
-          path: sift-py-dist-py3-*.zip
+          name: sift-py-dist-${{ needs.get-matrix-config.outputs.sift_package_version }}-py3-${{ matrix.platform.platform_tag }}
+          path: sift-py-dist-*.zip
           retention-days: 14

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -35,11 +35,15 @@ jobs:
               {os: 'windows', arch: 'amd64', runner: 'windows-latest', platform: 'win_amd64'}
             ];
             core.setOutput('matrix', JSON.stringify(matrix));
+    - run: |
+        echo "{{ needs.get-matrix-config.outputs.platforms }}" ||
+        echo "{{ fromJson(needs.get-matrix-config.outputs.platforms) }}" || 
+        echo "{{ fromJson(needs.get-matrix-config.outputs.platforms).runner }}" 
 
   build_and_verify:
     name: Build and verify on ${{ matrix.os }} (${{ matrix.arch }}) with Python ${{ matrix.python-version }}
     needs: get-matrix-config
-    runs-on: ${{ fromJson(needs.get-matrix-config.outputs.platforms).runner }}
+    runs-on: ${{ fromJson(needs.get-matrix-config.outputs.platforms).runner) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -58,8 +58,6 @@ jobs:
             pytest {project}/tests &&
             pip install {package}[openssl] &&
             pytest {project}/tests
-          # Ensure all extras are included in the wheel
-          CIBW_BUILD_FRONTEND: "pip; args: --config-settings=--build-option=--with-openssl"
         run: |
           python -m cibuildwheel python --output-dir wheelhouse
 

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -8,7 +8,7 @@ jobs:
   # Run ci on workflow_dispatch to ensure we have a clean build.
   # If using workflow_call, we expect the caller (python_release.yaml) to have already run ci.
   python-ci:
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && !github.event.workflow
     uses: ./.github/workflows/python_ci.yaml
 
   get-matrix-config:

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -141,7 +141,7 @@ jobs:
         working-directory: python
         shell: bash
         run: |
-          python -c "import shutil; shutil.make_archive('dist/sift-py-dist-${{ env.DIST_PLATFORM }}-py${{ matrix.python-version }}', 'zip', 'dist')"
+          cd dist && zip -r "sift-py-dist-${{ env.DIST_PLATFORM }}-py${{ matrix.python-version }}.zip" *
 
       - name: Upload distribution archive
         uses: actions/upload-artifact@v4

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -44,7 +44,7 @@ jobs:
   build_and_verify:
     name: Build and verify on ${{ matrix.os }} (${{ matrix.arch }}) with Python ${{ matrix.python-version }}
     needs: get-matrix-config
-    runs-on: ${{ fromJson(needs.get-matrix-config.outputs.platforms).runner) }}
+    runs-on: ${{ fromJson(needs.get-matrix-config.outputs.platforms).runner }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -53,12 +53,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        if: matrix.config.arch == 'aarch64'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -83,9 +83,11 @@ jobs:
           PIP_PLATFORM: ${{ matrix.os == 'windows' && format('{0}_win32', matrix.arch) || format('{0}-{1}', matrix.os, matrix.arch) }}
         run: |
           mkdir -p dist/deps
+          # Try to download all packages, preferring wheels but allowing source if wheels aren't available
           pip download -r requirements-all.txt -d dist/deps \
             --platform $PIP_PLATFORM \
             --python-version ${{ matrix.python-version }} \
+            --prefer-binary \
             --no-deps
 
       - name: Build sift-py wheel

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -28,25 +28,13 @@ jobs:
         with:
           script: |
             const matrix = [
-              {os: 'ubuntu', arch: 'x86_64', runner: 'ubuntu-latest', platform_tag: 'ubuntu-x86_64'},
-              {os: 'ubuntu', arch: 'aarch64', runner: 'ubuntu-latest', platform_tag: 'ubuntu-aarch64'},
-              {os: 'macos', arch: 'x86_64', runner: 'macos-latest', platform_tag: 'macos-x86_64'},
-              {os: 'macos', arch: 'arm64', runner: 'macos-14', platform_tag: 'macos-arm64'},
+              {os: 'ubuntu', arch: 'x86_64', runner: 'ubuntu-latest', platform_tag: 'linux_x86_64'},
+              {os: 'ubuntu', arch: 'aarch64', runner: 'ubuntu-latest', platform_tag: 'linux_aarch64'},
+              {os: 'macos', arch: 'x86_64', runner: 'macos-latest', platform_tag: 'macos_x86_64'},
+              {os: 'macos', arch: 'arm64', runner: 'macos-latest', platform_tag: 'macos_arm64'},
               {os: 'windows', arch: 'amd64', runner: 'windows-latest', platform_tag: 'win_amd64'}
             ];
             core.setOutput('matrix', JSON.stringify(matrix));
-      - name: debug 
-        if: always()
-        run: |
-          echo "${{ steps.set-matrix.outputs.matrix }}"
-      - name: debug 2
-        if: always()
-        run: |
-          echo "${{ fromJson(steps.set-matrix.outputs.matrix)[0].runner }}" 
-      - name: debug 3
-        if: always()
-        run: |  
-          echo "${{ needs.get-matrix-config.outputs.matrix[0].runner }}" 
 
   build_and_verify:
     name: Build and verify on ${{ matrix.platform.os }} (${{ matrix.platform.arch }}) with Python ${{ matrix.python-version }}
@@ -73,10 +61,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install build pip-tools twine
-
-      - name: debug 
-        run: |
-          python -c "import sysconfig;import re;print(re.sub(r'[-.]', '_', sysconfig.get_platform()))"
 
       - name: Generate requirements
         working-directory: python
@@ -163,7 +147,7 @@ jobs:
           retention-days: 7
 
   merge_platform_archives:
-    name: Merge archives for ${{ matrix.os }} (${{ matrix.arch }})
+    name: Merge archives for ${{ matrix.platform.os }} (${{ matrix.platform.arch }})
     needs: [build_and_verify, get-matrix-config]
     runs-on: ubuntu-latest
     strategy:
@@ -177,11 +161,6 @@ jobs:
           path: platform_archives
           merge-multiple: false
     
-      - name: debug 
-        run: |
-          echo "{{ needs.build_and_verify.outputs.matrix-config }}"
-          python -c "import sysconfig;import re;print(re.sub(r'[-.]', '_', sysconfig.get_platform()))"
-
       - name: Merge archives
         shell: bash
         run: |
@@ -213,6 +192,7 @@ jobs:
           
           # Create merged archive
           cd merged
+          rm -rf deps/ # this is now an empty directory
           zip -r "../sift-py-dist-py3-${{ matrix.platform.platform_tag }}.zip" dist/
 
       - name: Upload merged archive
@@ -220,4 +200,4 @@ jobs:
         with:
           name: sift-py-dist-py3-${{ matrix.platform.platform_tag }}
           path: sift-py-dist-py3-*.zip
-          retention-days: 7
+          retention-days: 14

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -19,14 +19,15 @@ jobs:
           echo "versions=$versions" >> $GITHUB_OUTPUT
 
   build_and_verify:
-    name: Build and verify on ${{ matrix.os }} (${{ matrix.arch }}) with Python ${{ matrix.python-version }}
+    name: Build and verify on ${{ matrix.config.os }} (${{ matrix.config.arch }}) with Python ${{ matrix.python-version }}
     needs: get-python-versions
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.config.runner }}
     env:
-      DIST_PLATFORM: ${{ matrix.os == 'windows' && format('win_{0}', matrix.arch) || format('{0}-{1}', matrix.os, matrix.arch) }}
+      DIST_PLATFORM: ${{ matrix.config.os == 'windows' && format('win_{0}', matrix.config.arch) || format('{0}-{1}', matrix.config.os, matrix.config.arch) }}
     strategy:
+      fail-fast: false  # Continue with other builds even if one fails
       matrix:
-        include:
+        config:
           # Ubuntu builds (x86_64 and aarch64)
           - os: ubuntu
             arch: x86_64
@@ -53,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up QEMU
-        if: matrix.arch == 'aarch64'
+        if: matrix.config.arch == 'aarch64'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
@@ -113,7 +114,7 @@ jobs:
           
           # Test base installation
           python -m venv test_venv_base
-          if [ "${{ matrix.os }}" = "windows" ]; then
+          if [ "${{ matrix.config.os }}" = "windows" ]; then
             source test_venv_base/Scripts/activate
           else
             source test_venv_base/bin/activate
@@ -124,7 +125,7 @@ jobs:
 
           # Test openssl installation
           python -m venv test_venv_openssl
-          if [ "${{ matrix.os }}" = "windows" ]; then
+          if [ "${{ matrix.config.os }}" = "windows" ]; then
             source test_venv_openssl/Scripts/activate
           else
             source test_venv_openssl/bin/activate

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -141,7 +141,13 @@ jobs:
         working-directory: python
         shell: bash
         run: |
-          cd dist && zip -r "sift-py-dist-${{ env.DIST_PLATFORM }}-py${{ matrix.python-version }}.zip" *
+          if [ "${{ matrix.config.os }}" = "windows" ]; then
+            # Use PowerShell's Compress-Archive on Windows
+            pwsh -Command "Compress-Archive -Path dist/* -DestinationPath dist/sift-py-dist-${{ env.DIST_PLATFORM }}-py${{ matrix.python-version }}.zip -Force"
+          else
+            # Use zip on Unix-like systems
+            cd dist && zip -r "sift-py-dist-${{ env.DIST_PLATFORM }}-py${{ matrix.python-version }}.zip" *
+          fi
 
       - name: Upload distribution archive
         uses: actions/upload-artifact@v4

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -181,11 +181,26 @@ jobs:
             
             # Extract all archives and merge unique wheels
             for zip in platform_archives/*/sift-py-dist-$platform-py*.zip; do
+              echo "Processing archive: $zip"
+              
+              # Create fresh temp directory
+              rm -rf temp_extract
+              mkdir -p temp_extract
+              
+              # Extract and show contents
               unzip -o "$zip" -d "temp_extract"
-              # Copy all wheels, letting newer ones overwrite older ones
-              cp -r temp_extract/dist/* "merged_$platform/dist/"
+              echo "Contents of temp_extract:"
+              ls -R temp_extract
+              
+              # Find and copy all files from dist directory
+              find temp_extract -type f -exec cp {} "merged_$platform/dist/" \;
+              
+              # Cleanup
               rm -rf temp_extract
             done
+            
+            echo "Contents of merged directory:"
+            ls -R "merged_$platform/dist/"
             
             # Create merged archive
             cd "merged_$platform"

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -143,3 +143,60 @@ jobs:
           name: sift-py-dist-${{ env.DIST_PLATFORM }}-py${{ matrix.python-version }}
           path: python/dist/sift-py-dist-*.zip
           retention-days: 7
+
+  merge_platform_archives:
+    name: Merge archives for ${{ matrix.config.os }} (${{ matrix.config.arch }})
+    needs: [build_and_verify]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config:
+          # Ubuntu builds (x86_64 and aarch64)
+          - os: ubuntu
+            arch: x86_64
+          - os: ubuntu
+            arch: aarch64
+            
+          # macOS builds (x86_64 and arm64)
+          - os: macos
+            arch: x86_64
+          - os: macos
+            arch: arm64
+            
+          # Windows builds (x64)
+          - os: windows
+            arch: amd64
+    env:
+      DIST_PLATFORM: ${{ matrix.config.os == 'windows' && format('win_{0}', matrix.config.arch) || format('{0}-{1}', matrix.config.os, matrix.config.arch) }}
+    steps:
+      - name: Download all Python version archives for platform
+        uses: actions/download-artifact@v4
+        with:
+          pattern: sift-py-dist-${{ env.DIST_PLATFORM }}-py*
+          path: platform_archives
+          merge-multiple: false
+
+      - name: Merge archives
+        shell: bash
+        run: |
+          # Create directory for merged wheels
+          mkdir -p merged/dist/deps
+          
+          # Extract all archives and merge unique wheels
+          for zip in platform_archives/*/sift-py-dist-*.zip; do
+            unzip -o "$zip" -d "temp_extract"
+            # Copy all wheels, letting newer ones overwrite older ones
+            cp -r temp_extract/dist/* merged/dist/
+            rm -rf temp_extract
+          done
+          
+          # Create merged archive
+          cd merged
+          zip -r "../sift-py-dist-${{ env.DIST_PLATFORM }}-all-python.zip" dist/
+
+      - name: Upload merged archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: sift-py-dist-${{ env.DIST_PLATFORM }}-all-python
+          path: sift-py-dist-*.zip
+          retention-days: 7

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -36,16 +36,15 @@ jobs:
             ];
             core.setOutput('matrix', JSON.stringify(matrix));
       - name: debug 
-        always: true
+        if: always()
         run: |
           echo "${{ steps.set-matrix.outputs.matrix }}"
-            - name: debug 
       - name: debug 2
-        always: true
+        if: always()
         run: |
           echo "${{ fromJson(steps.set-matrix.outputs.matrix) }}" 
       - name: debug 3
-        always: true
+        if: always()
         run: |  
           echo "${{ fromJson(needs.get-matrix-config.outputs.matrix).runner }}" 
 

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -24,20 +24,19 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - id: set-matrix
-        run: |
-          matrix=$(cat << 'EOF'
-          {
-            "config": [
-              {"os": "ubuntu", "arch": "x86_64", "runner": "ubuntu-latest"},
-              {"os": "ubuntu", "arch": "aarch64", "runner": "ubuntu-latest"},
-              {"os": "macos", "arch": "x86_64", "runner": "macos-latest"},
-              {"os": "macos", "arch": "arm64", "runner": "macos-14"},
-              {"os": "windows", "arch": "amd64", "runner": "windows-latest"}
-            ]
-          }
-          EOF
-          )
-          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const matrix = {
+              config: [
+                {os: 'ubuntu', arch: 'x86_64', runner: 'ubuntu-latest'},
+                {os: 'ubuntu', arch: 'aarch64', runner: 'ubuntu-latest'},
+                {os: 'macos', arch: 'x86_64', runner: 'macos-latest'},
+                {os: 'macos', arch: 'arm64', runner: 'macos-14'},
+                {os: 'windows', arch: 'amd64', runner: 'windows-latest'}
+              ]
+            };
+            core.setOutput('matrix', JSON.stringify(matrix));
 
   build_and_verify:
     name: Build and verify on ${{ matrix.config.os }} (${{ matrix.config.arch }}) with Python ${{ matrix.python-version }}

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -36,9 +36,9 @@ jobs:
             ];
             core.setOutput('matrix', JSON.stringify(matrix));
     - run: |
-        echo "{{ needs.get-matrix-config.outputs.platforms }}" ||
-        echo "{{ fromJson(needs.get-matrix-config.outputs.platforms) }}" || 
-        echo "{{ fromJson(needs.get-matrix-config.outputs.platforms).runner }}" 
+        echo "{{ steps.set-matrix.outputs.matrix }}" ||
+        echo "{{ fromJson(steps.set-matrix.outputs.matrix) }}" || 
+        echo "{{ fromJson(needs.get-matrix-config.outputs.matrix).runner }}" 
 
   build_and_verify:
     name: Build and verify on ${{ matrix.os }} (${{ matrix.arch }}) with Python ${{ matrix.python-version }}

--- a/.github/workflows/python_release.yaml
+++ b/.github/workflows/python_release.yaml
@@ -17,38 +17,22 @@ jobs:
     name: Upload release to PyPI
     needs: [python-ci, build-offline-archives]
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: python
     environment:
       name: pypi
       url: https://pypi.org/p/sift_py
     permissions:
       id-token: write  
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - name: Download distributions
+        uses: actions/download-artifact@v4
         with:
-          python-version: "3.8"
-
-      - name: Pip install
-        run: |
-          python -m pip install --upgrade pip
-          pip install '.[build]'
-          pip install .
-
-      - name: Build distributions
-        working-directory: python
-        run: |
-          python -m build
+          name: sift-stack-py-dist
+          path: python/dist/
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: ./python/dist/
+          packages-dir: python/dist/
 
   create-github-release:
     name: Create GitHub Release
@@ -59,6 +43,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: sift-stack-py-dist
+          path: python/dist/
 
       - name: Download all platform archives
         uses: actions/download-artifact@v4
@@ -86,10 +76,15 @@ jobs:
             --title "sift-stack-py $TAG_NAME" \
             --notes-file release_notes.md
 
-          # Upload each platform archive
+          # Upload Python package distributions
+          for dist in python/dist/*; do
+            echo "Uploading distribution: $dist"
+            gh release upload "$TAG_NAME" "$dist" --clobber
+          done
+
+          # Upload platform archives
           for archive in platform_archives/*/sift-py-dist-*-py3-*.zip; do
-            echo "Uploading $archive to release $TAG_NAME"
-            gh release upload "$TAG_NAME" "$archive" \
-              --clobber
+            echo "Uploading archive: $archive"
+            gh release upload "$TAG_NAME" "$archive" --clobber
           done
           

--- a/.github/workflows/python_release.yaml
+++ b/.github/workflows/python_release.yaml
@@ -57,6 +57,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Download all platform archives
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/python_release.yaml
+++ b/.github/workflows/python_release.yaml
@@ -45,10 +45,10 @@ jobs:
         run: |
           python -m build
 
-      # - name: Publish package distributions to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     packages-dir: ./python/dist/
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: ./python/dist/
 
   create-github-release:
     name: Create GitHub Release

--- a/.github/workflows/python_release.yaml
+++ b/.github/workflows/python_release.yaml
@@ -8,9 +8,14 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags')
     uses: ./.github/workflows/python_ci.yaml
 
+  build-offline-archives:
+    if: github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags')
+    needs: python-ci
+    uses: ./.github/workflows/python_build.yaml
+
   publish-to-pypi:
     name: Upload release to PyPI
-    needs: python-ci
+    needs: [python-ci, build-offline-archives]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -44,3 +49,44 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: ./python/dist/
+
+  create-github-release:
+    name: Create GitHub Release
+    needs: [build-offline-archives]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all platform archives
+        uses: actions/download-artifact@v4
+        with:
+          pattern: sift-py-dist-*-py3-*
+          path: platform_archives
+          merge-multiple: false
+
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          # Create release notes
+          cat > release_notes.md << 'EOL'
+          See [CHANGELOG.md](https://github.com/sift-stack/sift/blob/main/python/CHANGELOG.md) for details.
+
+          Offline archives are available for download for multiple platforms. Offline archives include wheels for all dependencies including build extras, e.g. openssl, development, and build.
+
+          Use `pip install sift-stack-py --find-links={path/to/archive} --no-index` to install.
+          EOL
+
+          # Create the release
+          gh release create "$TAG_NAME" \
+            --title "sift-stack-py $TAG_NAME" \
+            --notes-file release_notes.md
+
+          # Upload each platform archive
+          for archive in platform_archives/*/sift-py-dist-*-py3-*.zip; do
+            echo "Uploading $archive to release $TAG_NAME"
+            gh release upload "$TAG_NAME" "$archive" \
+              --clobber
+          done
+          

--- a/.github/workflows/python_release.yaml
+++ b/.github/workflows/python_release.yaml
@@ -29,10 +29,10 @@ jobs:
           name: sift-stack-py-dist
           path: python/dist/
 
-      # - name: Publish package distributions to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     packages-dir: python/dist/
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: python/dist/
 
   create-github-release:
     name: Create GitHub Release

--- a/.github/workflows/python_release.yaml
+++ b/.github/workflows/python_release.yaml
@@ -29,10 +29,10 @@ jobs:
           name: sift-stack-py-dist
           path: python/dist/
 
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: python/dist/
+      # - name: Publish package distributions to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     packages-dir: python/dist/
 
   create-github-release:
     name: Create GitHub Release

--- a/.github/workflows/python_release.yaml
+++ b/.github/workflows/python_release.yaml
@@ -82,8 +82,8 @@ jobs:
             gh release upload "$TAG_NAME" "$dist" --clobber
           done
 
-          # Upload platform archives
-          for archive in platform_archives/*/sift-py-dist-*-py3-*.zip; do
+          # Upload platform archives (both .zip and .tar.gz)
+          for archive in platform_archives/*/sift-py-dist-*-py3-*.{zip,tar.gz}; do
             echo "Uploading archive: $archive"
             gh release upload "$TAG_NAME" "$archive" --clobber
           done

--- a/.github/workflows/python_release.yaml
+++ b/.github/workflows/python_release.yaml
@@ -45,10 +45,10 @@ jobs:
         run: |
           python -m build
 
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: ./python/dist/
+      # - name: Publish package distributions to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     packages-dir: ./python/dist/
 
   create-github-release:
     name: Create GitHub Release

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,6 +22,7 @@ keywords = [
 ]
 dependencies = [
   "grpcio~=1.13",
+  "npTDMS~=1.9",
   "PyYAML~=6.0",
   "pandas~=2.0",
   "protobuf>=4.0",
@@ -47,7 +48,6 @@ Changelog = "https://github.com/sift-stack/sift/tree/main/python/CHANGELOG.md"
 [project.optional-dependencies]
 development = [
   "grpcio-testing~=1.13",
-  "npTDMS~=1.9",
   "mypy==1.10.0",
   "pyright==1.1.386",
   "pytest==8.2.2",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -46,7 +46,7 @@ Changelog = "https://github.com/sift-stack/sift/tree/main/python/CHANGELOG.md"
 
 [project.optional-dependencies]
 development = [
-  "grpcio-testing==1.13",
+  "grpcio-testing~=1.13",
   "npTDMS~=1.9",
   "mypy==1.10.0",
   "pyright==1.1.386",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sift_stack_py"
-version = "0.3.0-rc.6"
+version = "0.3.0-rc.7"
 description = "Python client library for the Sift API"
 requires-python = ">=3.8"
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sift_stack_py"
-version = "0.3.0-rc.7"
+version = "0.3.0-rc.6"
 description = "Python client library for the Sift API"
 requires-python = ">=3.8"
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/python/scripts/build_utils.py
+++ b/python/scripts/build_utils.py
@@ -66,21 +66,22 @@ def test_install(
     # Create and activate venv
     venv.create(venv_dir, with_pip=True)
 
-    # Build activation command based on OS
-    if is_windows:
-        activate_script = os.path.join(venv_dir, "Scripts", "activate")
-    else:
-        activate_script = os.path.join(venv_dir, "bin", "activate")
-
     # Build installation command
     if extras:
         install_cmd = f'pip install --no-index --find-links="{dist_dir}" "{package_name}[{extras}]"'
     else:
         install_cmd = f'pip install --no-index --find-links="{dist_dir}" {package_name}'
 
-    # Run installation in the venv
-    full_cmd = f'source "{activate_script}" && {install_cmd} && deactivate'
-    subprocess.run(full_cmd, shell=True, check=True, executable="/bin/bash")
+    if is_windows:
+        # Windows uses different activation and command syntax
+        activate_script = os.path.join(venv_dir, "Scripts", "activate.bat")
+        full_cmd = f'"{activate_script}" && {install_cmd} && deactivate'
+        subprocess.run(full_cmd, shell=True, check=True)
+    else:
+        # Unix systems use bash
+        activate_script = os.path.join(venv_dir, "bin", "activate")
+        full_cmd = f'source "{activate_script}" && {install_cmd} && deactivate'
+        subprocess.run(full_cmd, shell=True, check=True, executable="/bin/bash")
 
 
 def main():

--- a/python/scripts/build_utils.py
+++ b/python/scripts/build_utils.py
@@ -7,8 +7,9 @@ import venv
 from itertools import combinations
 from pathlib import Path
 from typing import List, Optional
-from wheel.pkginfo import read_pkg_info_bytes
 from zipfile import ZipFile
+
+from wheel.pkginfo import read_pkg_info_bytes
 
 
 def get_extras_from_wheel(wheel_path: str) -> List[str]:
@@ -22,11 +23,10 @@ def get_extras_from_wheel(wheel_path: str) -> List[str]:
     """
     with ZipFile(wheel_path) as wheel:
         for name in wheel.namelist():
-            if name.endswith('.dist-info/METADATA'):
+            if name.endswith(".dist-info/METADATA"):
                 metadata = read_pkg_info_bytes(wheel.read(name))
                 return [
-                    line.split(':')[1].strip()
-                    for line in metadata.get_all('Provides-Extra') or []
+                    line.split(":")[1].strip() for line in metadata.get_all("Provides-Extra") or []
                 ]
     return []
 
@@ -42,16 +42,12 @@ def get_extra_combinations(extras: List[str]) -> List[str]:
     """
     all_combinations = []
     for r in range(len(extras) + 1):
-        all_combinations.extend(','.join(c) for c in combinations(extras, r))
+        all_combinations.extend(",".join(c) for c in combinations(extras, r))
     return all_combinations
 
 
 def test_install(
-    package_name: str,
-    extras: Optional[str],
-    dist_dir: str,
-    venv_dir: str,
-    is_windows: bool
+    package_name: str, extras: Optional[str], dist_dir: str, venv_dir: str, is_windows: bool
 ) -> None:
     """Test package installation with given extras in a fresh venv.
 
@@ -63,10 +59,10 @@ def test_install(
         is_windows: Whether running on Windows platform.
     """
     print(f"Testing installation with extras: {extras or 'none'}")
-    
+
     # Create and activate venv
     venv.create(venv_dir, with_pip=True)
-    
+
     # Build activation command based on OS
     if is_windows:
         activate_script = os.path.join(venv_dir, "Scripts", "activate")
@@ -81,30 +77,34 @@ def test_install(
 
     # Run installation in the venv
     full_cmd = f'source "{activate_script}" && {install_cmd} && deactivate'
-    subprocess.run(full_cmd, shell=True, check=True, executable='/bin/bash')
+    subprocess.run(full_cmd, shell=True, check=True, executable="/bin/bash")
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Test package installation with all extra combinations')
-    parser.add_argument('--dist-dir', required=True, help='Directory containing wheel and dependencies')
-    parser.add_argument('--package-name', required=True, help='Name of the package to install')
-    parser.add_argument('--is-windows', action='store_true', help='Whether running on Windows')
+    parser = argparse.ArgumentParser(
+        description="Test package installation with all extra combinations"
+    )
+    parser.add_argument(
+        "--dist-dir", required=True, help="Directory containing wheel and dependencies"
+    )
+    parser.add_argument("--package-name", required=True, help="Name of the package to install")
+    parser.add_argument("--is-windows", action="store_true", help="Whether running on Windows")
     args = parser.parse_args()
 
     dist_dir = Path(args.dist_dir)
     wheel_file = next(dist_dir.glob(f"{args.package_name.replace('-', '_')}*.whl"))
-    
+
     # Get all extras from the wheel
     extras = get_extras_from_wheel(str(wheel_file))
     combinations = get_extra_combinations(extras)
-    
+
     # Test base installation first
     test_install(
         package_name=args.package_name,
         extras=None,
         dist_dir=str(dist_dir),
-        venv_dir='test_venv_base',
-        is_windows=args.is_windows
+        venv_dir="test_venv_base",
+        is_windows=args.is_windows,
     )
 
     # Test each combination of extras
@@ -115,9 +115,9 @@ def main():
                 extras=combo,
                 dist_dir=str(dist_dir),
                 venv_dir=f'test_venv_{combo.replace(",", "_")}',
-                is_windows=args.is_windows
+                is_windows=args.is_windows,
             )
 
 
-if __name__ == '__main__':
-    main() 
+if __name__ == "__main__":
+    main()

--- a/python/scripts/build_utils.py
+++ b/python/scripts/build_utils.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import subprocess
+import venv
+from itertools import combinations
+from pathlib import Path
+from typing import List, Optional
+from wheel.pkginfo import read_pkg_info_bytes
+from zipfile import ZipFile
+
+
+def get_extras_from_wheel(wheel_path: str) -> List[str]:
+    """Extract the list of extras from a wheel's metadata.
+
+    Args:
+        wheel_path: Path to the wheel file to inspect.
+
+    Returns:
+        List of extra names declared in the wheel metadata.
+    """
+    with ZipFile(wheel_path) as wheel:
+        for name in wheel.namelist():
+            if name.endswith('.dist-info/METADATA'):
+                metadata = read_pkg_info_bytes(wheel.read(name))
+                return [
+                    line.split(':')[1].strip()
+                    for line in metadata.get_all('Provides-Extra') or []
+                ]
+    return []
+
+
+def get_extra_combinations(extras: List[str]) -> List[str]:
+    """Generate all possible combinations of extras.
+
+    Args:
+        extras: List of extra names to generate combinations from.
+
+    Returns:
+        List of comma-separated strings representing each combination of extras.
+    """
+    all_combinations = []
+    for r in range(len(extras) + 1):
+        all_combinations.extend(','.join(c) for c in combinations(extras, r))
+    return all_combinations
+
+
+def test_install(
+    package_name: str,
+    extras: Optional[str],
+    dist_dir: str,
+    venv_dir: str,
+    is_windows: bool
+) -> None:
+    """Test package installation with given extras in a fresh venv.
+
+    Args:
+        package_name: Name of the package to install.
+        extras: Optional comma-separated string of extras to install.
+        dist_dir: Directory containing wheel and dependencies.
+        venv_dir: Directory to create virtual environment in.
+        is_windows: Whether running on Windows platform.
+    """
+    print(f"Testing installation with extras: {extras or 'none'}")
+    
+    # Create and activate venv
+    venv.create(venv_dir, with_pip=True)
+    
+    # Build activation command based on OS
+    if is_windows:
+        activate_script = os.path.join(venv_dir, "Scripts", "activate")
+    else:
+        activate_script = os.path.join(venv_dir, "bin", "activate")
+
+    # Build installation command
+    if extras:
+        install_cmd = f'pip install --no-index --find-links="{dist_dir}" "{package_name}[{extras}]"'
+    else:
+        install_cmd = f'pip install --no-index --find-links="{dist_dir}" {package_name}'
+
+    # Run installation in the venv
+    full_cmd = f'source "{activate_script}" && {install_cmd} && deactivate'
+    subprocess.run(full_cmd, shell=True, check=True, executable='/bin/bash')
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Test package installation with all extra combinations')
+    parser.add_argument('--dist-dir', required=True, help='Directory containing wheel and dependencies')
+    parser.add_argument('--package-name', required=True, help='Name of the package to install')
+    parser.add_argument('--is-windows', action='store_true', help='Whether running on Windows')
+    args = parser.parse_args()
+
+    dist_dir = Path(args.dist_dir)
+    wheel_file = next(dist_dir.glob(f"{args.package_name.replace('-', '_')}*.whl"))
+    
+    # Get all extras from the wheel
+    extras = get_extras_from_wheel(str(wheel_file))
+    combinations = get_extra_combinations(extras)
+    
+    # Test base installation first
+    test_install(
+        package_name=args.package_name,
+        extras=None,
+        dist_dir=str(dist_dir),
+        venv_dir='test_venv_base',
+        is_windows=args.is_windows
+    )
+
+    # Test each combination of extras
+    for combo in combinations:
+        if combo:  # Skip empty string from base combination
+            test_install(
+                package_name=args.package_name,
+                extras=combo,
+                dist_dir=str(dist_dir),
+                venv_dir=f'test_venv_{combo.replace(",", "_")}',
+                is_windows=args.is_windows
+            )
+
+
+if __name__ == '__main__':
+    main() 

--- a/python/scripts/build_utils.py
+++ b/python/scripts/build_utils.py
@@ -22,16 +22,15 @@ def get_extras_from_wheel(wheel_path: str) -> List[str]:
     with ZipFile(wheel_path) as wheel:
         # Find the METADATA file in the .dist-info directory
         metadata_file = next(
-            name for name in wheel.namelist() 
-            if name.endswith('.dist-info/METADATA')
+            name for name in wheel.namelist() if name.endswith(".dist-info/METADATA")
         )
-        metadata = wheel.read(metadata_file).decode('utf-8')
-        
+        metadata = wheel.read(metadata_file).decode("utf-8")
+
         # Parse Provides-Extra lines from metadata
         extras = []
         for line in metadata.splitlines():
-            if line.startswith('Provides-Extra:'):
-                extras.append(line.split(':', 1)[1].strip())
+            if line.startswith("Provides-Extra:"):
+                extras.append(line.split(":", 1)[1].strip())
         return extras
 
 


### PR DESCRIPTION
### Context
Some users wish to install `sift-stack-py` without access to pypi. 

### Description
This PR adds a new workflow `python_build.yaml` that builds offline installation archives (wheels for each dependency) that target all supported python versions and various platforms (linux, mac, windows) and architectures (e.g. x86_64/arm64).

Users will be able to install `sift-py-stack` by running `pip install sift-py-stack --no-index --find-links {path/to/offline-installation-archive}`. 


### Verification

Ran `python_release.yaml` workflow which calls the new `python_build.yaml` on a dev tag and successfully created a release

https://github.com/sift-stack/sift/actions/runs/12273019715

<img width="1064" alt="image" src="https://github.com/user-attachments/assets/41885104-dac5-4e4f-b9e0-d1dfb43e23b7">

Manually downloaded and inspected archives as well as installing locally on my mac.