### PR TITLE
python(chore): Make npTDMS an optional dep

### DIFF
--- a/.github/workflows/python_ci.yaml
+++ b/.github/workflows/python_ci.yaml
@@ -29,6 +29,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install '.[development]'
           pip install '.[openssl]'
+          pip install '.[tdms]'
           pip install .
 
       - name: Lint

--- a/python/examples/data_import/tdms/requirements.txt
+++ b/python/examples/data_import/tdms/requirements.txt
@@ -1,2 +1,3 @@
 python-dotenv
 sift-stack-py
+sift-stack-py[tdms]

--- a/python/examples/data_import/tdms/requirements.txt
+++ b/python/examples/data_import/tdms/requirements.txt
@@ -1,3 +1,2 @@
 python-dotenv
-sift-stack-py
 sift-stack-py[tdms]

--- a/python/lib/sift_py/data_import/__init__.py
+++ b/python/lib/sift_py/data_import/__init__.py
@@ -34,6 +34,7 @@ contains datetime formatted time stamps. See docstring for `simple_upload` to se
 
 ## TDMS Upload
 
+Specify `sift-stack-py[tdms]` in your dependencies to use the TDMS upload service.
 TDMS files can be uploaded like so:
 ```python
 from sift_py.data_import.csv import TdmsUploadService

--- a/python/lib/sift_py/data_import/tdms.py
+++ b/python/lib/sift_py/data_import/tdms.py
@@ -13,7 +13,7 @@ try:
     )
 except ImportError as e:
     raise RuntimeError(
-        "The nptdms package is required to use the TDMS upload service. "
+        "The npTDMS package is required to use the TDMS upload service. "
         "Please include this dependency in your project by specifying `sift-stack-py[tdms]`."
     ) from e
 

--- a/python/lib/sift_py/data_import/tdms.py
+++ b/python/lib/sift_py/data_import/tdms.py
@@ -2,14 +2,20 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Dict, List, Optional, Union
 
-from nptdms import (  # type: ignore
-    ChannelObject,
-    RootObject,
-    TdmsChannel,
-    TdmsFile,
-    TdmsWriter,
-    types,
-)
+try:
+    from nptdms import (  # type: ignore
+        ChannelObject,
+        RootObject,
+        TdmsChannel,
+        TdmsFile,
+        TdmsWriter,
+        types,
+    )
+except ImportError as e:
+    raise RuntimeError(
+        "The nptdms package is required to use the TDMS upload service. "
+        "Please include this dependency in your project by specifying `sift-stack-py[tdms]`."
+    ) from e
 
 from sift_py.data_import._config import DataColumn, TimeColumn
 from sift_py.data_import.config import CsvConfig

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
   "requests-toolbelt~=1.0",
 
   # May move these to optional dependencies in the future.
-  "npTDMS~=1.9",
   "pandas-stubs~=2.0",
   "types-PyYAML~=6.0",
   "types-protobuf>=4.0",
@@ -55,6 +54,7 @@ development = [
 ]
 build = ["pdoc==14.5.0", "build==1.2.1"]
 openssl = ["pyOpenSSL<24.0.0", "types-pyOpenSSL<24.0.0", "cffi~=1.14"]
+tdms = ["npTDMS~=1.9"]
 
 [build-system]
 requires = ["setuptools"]


### PR DESCRIPTION
The `npTDMS` arg should not be required for the standard lib, but included as an optional dep for users who do use the lib to manage TDMS data. Users can include `sift-stack-py[tdms]` in their project dependencies if TDMS is required.