### PR TITLE
python(bugfix): fix tempfile issues on windows

### DIFF
--- a/python/examples/ingestion_with_csv/single_csv/main.py
+++ b/python/examples/ingestion_with_csv/single_csv/main.py
@@ -26,9 +26,9 @@ def parse_csv(
 
         for row in reader:
             timestamp_str, values = row[0], row[1:]
-            assert len(values) == len(
-                flow.channels
-            ), "number of channels don't match number of data points in row"
+            assert len(values) == len(flow.channels), (
+                "number of channels don't match number of data points in row"
+            )
 
             flows.append(
                 {

--- a/python/lib/sift_py/data_import/ch10.py
+++ b/python/lib/sift_py/data_import/ch10.py
@@ -88,9 +88,9 @@ class Ch10UploadService(CsvUploadService):
         """
         ch10_file.initialize_csv_data_columns()
 
-        assert getattr(
-            ch10_file, "csv_config_data_columns"
-        ), "`csv_config_data_columns` was not set correctly on the first iteration"
+        assert getattr(ch10_file, "csv_config_data_columns"), (
+            "`csv_config_data_columns` was not set correctly on the first iteration"
+        )
 
         config_info: Dict[str, Any] = {
             "asset_name": asset_name,

--- a/python/lib/sift_py/data_import/csv.py
+++ b/python/lib/sift_py/data_import/csv.py
@@ -198,7 +198,7 @@ class CsvUploadService:
             data_type = ChannelDataType.from_str(raw_dtype)
             if data_type is None:
                 raise Exception(
-                    f"Unable to upload data type in column {i+1} {header}: Type: {raw_dtype}."
+                    f"Unable to upload data type in column {i + 1} {header}: Type: {raw_dtype}."
                 )
             data_config[i + 1] = {"name": header, "data_type": data_type}
 

--- a/python/lib/sift_py/data_import/tdms.py
+++ b/python/lib/sift_py/data_import/tdms.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from tempfile import NamedTemporaryFile
 from typing import Dict, List, Optional, Union
 
 try:
@@ -21,6 +20,7 @@ from sift_py.data_import._config import DataColumn, TimeColumn
 from sift_py.data_import.config import CsvConfig
 from sift_py.data_import.csv import CsvUploadService
 from sift_py.data_import.status import DataImportService
+from sift_py.data_import.tempfile import NamedTemporaryFile
 from sift_py.data_import.time_format import TimeFormatType
 from sift_py.ingestion.channel import ChannelDataType
 from sift_py.rest import SiftRestConfig

--- a/python/lib/sift_py/data_import/tempfile.py
+++ b/python/lib/sift_py/data_import/tempfile.py
@@ -1,0 +1,30 @@
+import os
+import tempfile
+from pathlib import Path
+
+
+class NamedTemporaryFile:
+    """
+    Created a named temporary file.
+
+    Works on both Windows and Unix systems.
+
+    See https://stackoverflow.com/questions/23212435/permission-denied-to-write-to-my-temporary-file
+    for more information on Windows compatibility.
+    """
+
+    def __init__(self, mode, suffix=""):
+        self.temp_dir = tempfile.mkdtemp()
+        self.name = Path(self.temp_dir) / f"tempfile{suffix}"
+        self.file = open(self.name, mode)
+
+    def __enter__(self):
+        return self.file
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.file.close()
+        try:
+            os.remove(self.name)
+            os.rmdir(self.temp_dir)
+        except FileNotFoundError:
+            pass

--- a/python/scripts/build_utils.py
+++ b/python/scripts/build_utils.py
@@ -118,7 +118,7 @@ def main():
                 package_name=args.package_name,
                 extras=combo,
                 dist_dir=str(dist_dir),
-                venv_dir=f'test_venv_{combo.replace(",", "_")}',
+                venv_dir=f"test_venv_{combo.replace(',', '_')}",
                 is_windows=args.is_windows,
             )
 


### PR DESCRIPTION
Use custom NamedTemporaryFile that is windows compatible.

Before:
```
marc@marc-windows MINGW64 ~/code/sift/python/examples/data_import/tdms (python/fix-windows-imports)
$ python  main.py
Traceback (most recent call last):
  File "C:\Users\marc\code\sift\python\examples\data_import\tdms\main.py", line 29, in <module>
    import_service = tdms_upload_service.upload(
        "sample_data.tdms", asset_name, group_into_components=True
    )
  File "C:\Users\marc\code\sift\python\lib\sift_py\data_import\tdms.py", line 81, in upload
    valid_channels = self._convert_to_csv(path, temp_file.name, ignore_errors)
  File "C:\Users\marc\code\sift\python\lib\sift_py\data_import\tdms.py", line 140, in _convert_to_csv
    with TdmsWriter(f.name) as tdms_writer:
         ~~~~~~~~~~^^^^^^^^
  File "C:\Users\marc\venvs\venv\Lib\site-packages\nptdms\writer.py", line 161, in __enter__
    self.open()
    ~~~~~~~~~^^
  File "C:\Users\marc\venvs\venv\Lib\site-packages\nptdms\writer.py", line 110, in open
    self._file = open(self._file_path, self._file_mode + 'b')
                 ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: 'C:\\Users\\marc\\AppData\\Local\\Temp\\tmp59mb6wjj'
```

After:
```
$ python  main.py
...
Upload example complete!

```