### PR TITLE
python(bug): Don't upload tdms channel properties

### DIFF
--- a/python/lib/sift_py/data_import/_tdms_test.py
+++ b/python/lib/sift_py/data_import/_tdms_test.py
@@ -149,7 +149,7 @@ def test_tdms_upload_success(mocker: MockFixture, mock_tdms_file: MockTdmsFile):
                 "data_type": "CHANNEL_DATA_TYPE_INT_32",
                 "component": "",
                 "units": "",
-                "description": "None\nwf_start_time: 0\nwf_increment: 0.1\nwf_start_offset: 0\nextra: info\n",
+                "description": "",
                 "enum_types": [],
                 "bit_field_elements": [],
             }

--- a/python/lib/sift_py/data_import/tdms.py
+++ b/python/lib/sift_py/data_import/tdms.py
@@ -166,20 +166,10 @@ class TdmsUploadService:
             if data_type is None:
                 raise Exception(f"{channel.name} data type not supported: {channel.data_type}")
 
-            extra_info = ""
-            for k, v in channel.properties.items():
-                # Skip these since the csv config has dedicated fields for them.
-                if k in ["description", "unit_string"]:
-                    continue
-                # Must convert datetime to a string
-                elif k == "wf_start_time":
-                    v = str(v)
-                extra_info += f"{k}: {v}\n"
-
             channel_config = DataColumn(
                 name=channel.name,
                 data_type=data_type,
-                description=f"{channel.properties.get('description')}\n{extra_info}",
+                description=channel.properties.get("description", ""),
                 units=channel.properties.get("unit_string") or "",
             )
             if group_into_components and channel.group_name:


### PR DESCRIPTION
TDMS example ran without uploading parameters in the description:
```
$ python main.py
data_import_id='21eea37a-140f-44d1-85b0-92cea35553c2' created_date=datetime.datetime(2025, 1, 24, 20, 16, 56, 234293, tzinfo=TzInfo(UTC)) 
...
'description': 'Description for channel channel_0',  
...
Upload example complete!
```