### PR TITLE
python: Fix rule config `from_annotation_type`

### DIFF
--- a/python/lib/sift_py/rule/config.py
+++ b/python/lib/sift_py/rule/config.py
@@ -192,7 +192,7 @@ class RuleActionAnnotationKind(Enum):
     def from_annotation_type(cls, annotation_type: AnnotationType) -> "RuleActionAnnotationKind":
         if annotation_type == AnnotationType.ANNOTATION_TYPE_PHASE:
             return cls.PHASE
-        return cls.PHASE
+        return cls.REVIEW
 
     @classmethod
     def from_str(cls, val: str) -> "RuleActionAnnotationKind":


### PR DESCRIPTION
Fix bug where RuleActionAnnotationKind.from_annotation_type() only returns a PHASE type.