### PR TITLE
python(feat): remove overwrite_rules argument from ingestion service

### DIFF
--- a/python/examples/ingestion_with_python_config/main.py
+++ b/python/examples/ingestion_with_python_config/main.py
@@ -36,7 +36,6 @@ if __name__ == "__main__":
         ingestion_service = IngestionService(
             channel,
             telemetry_config,
-            overwrite_rules=True,  # Overwrite any rules created in the Sift UI that isn't in the config
             end_stream_on_error=True,  # End stream if errors occur API-side.
         )
 

--- a/python/lib/sift_py/ingestion/_internal/ingest.py
+++ b/python/lib/sift_py/ingestion/_internal/ingest.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Callable
 from datetime import datetime
 from typing import Dict, List, Optional
-from warnings import warn
 
 from google.protobuf.timestamp_pb2 import Timestamp
 from sift.ingest.v1.ingest_pb2 import (
@@ -54,15 +53,9 @@ class _IngestionServiceImpl:
         channel: SiftChannel,
         config: TelemetryConfig,
         run_id: Optional[str] = None,
-        overwrite_rules: bool = False,
         end_stream_on_error: bool = False,
     ):
         ingestion_config = self.__class__._get_or_create_ingestion_config(channel, config)
-
-        if overwrite_rules:
-            warn(
-                "The 'overwrite_rules' argument is deprecated and will be removed in release 0.4.0."
-            )
 
         self.rule_service = RuleService(channel)
         if config.rules:

--- a/python/lib/sift_py/ingestion/service.py
+++ b/python/lib/sift_py/ingestion/service.py
@@ -27,11 +27,6 @@ class IngestionService(_IngestionServiceImpl):
     - `flow_configs_by_name`: A mapping of flow config name to the actual flow config.
     - `run_id`: The ID of the optional run to associated ingested data with.
     - `organization_id`: ID of the organization of the user.
-    - `overwrite_rules`:
-        If there are rules in Sift that aren't found in the local telemetry config, then initializing
-        an `IngestionService` will raise an exception advising the user to update their telemetry config
-        with the missing rule before proceeding. Setting this field to `True` replace all rules currently
-        in Sift with the rules in the telemetry config.
     - `end_stream_on_error`:
         By default any errors that may occur during ingestion API-side are produced asynchronously and ingestion
         won't be interrupted. The errors produced are surfaced on the user errors page. Setting this field to `True`
@@ -52,10 +47,11 @@ class IngestionService(_IngestionServiceImpl):
         channel: SiftChannel,
         config: TelemetryConfig,
         run_id: Optional[str] = None,
-        overwrite_rules: bool = False,
         end_stream_on_error: bool = False,
     ):
-        super().__init__(channel, config, run_id, overwrite_rules, end_stream_on_error)
+        super().__init__(
+            channel=channel, config=config, run_id=run_id, end_stream_on_error=end_stream_on_error
+        )
 
     def ingest(self, *requests: IngestWithConfigDataStreamRequest):
         """


### PR DESCRIPTION
Removes the previously deprecated argument `overwrite_rules` from the `IngestionService`.