### PR TITLE
fix: ReportTemplate updates provide FieldMask keys based on what needs to be updated

### DIFF
--- a/python/examples/report_templates/report_template_with_python_config/main.py
+++ b/python/examples/report_templates/report_template_with_python_config/main.py
@@ -3,6 +3,7 @@ import os
 from dotenv import load_dotenv
 from report_template_config import load_rules, nostromos_report_template
 from sift_py.grpc.transport import SiftChannelConfig, use_sift_channel
+from sift_py.report_templates.config import ReportTemplateUpdate
 from sift_py.report_templates.service import ReportTemplateService
 from sift_py.rule.service import RuleService
 
@@ -39,10 +40,10 @@ if __name__ == "__main__":
             client_key=report_template.template_client_key
         )
         if report_template_to_update:  # Make some other changes
-            report_template_to_update.rule_client_keys = [
-                rule.rule_client_key for rule in rules if rule.rule_client_key
-            ]
-            report_template_to_update.description = (
-                "A report template for the Nostromo without overheating rule"
+            updates = ReportTemplateUpdate(
+                rule_client_keys=[rule.rule_client_key for rule in rules if rule.rule_client_key],
+                description="A report template for the Nostromo without overheating rule",
             )
-            report_template_service.create_or_update_report_template(report_template_to_update)
+            report_template_service.create_or_update_report_template(
+                report_template_to_update, updates=updates
+            )

--- a/python/examples/report_templates/report_template_with_python_config/report_template_config.py
+++ b/python/examples/report_templates/report_template_with_python_config/report_template_config.py
@@ -107,8 +107,8 @@ def load_rules() -> List[RuleConfig]:
 
 def nostromos_report_template() -> ReportTemplateConfig:
     return ReportTemplateConfig(
-        name="Nostromo Report Template",
-        template_client_key="report-template-test",
+        name="Nostromo Report Template for PR test",
+        template_client_key="report-template-test-1001",
         description="A report template for the Nostromo",
         rule_client_keys=[],
     )

--- a/python/examples/report_templates/report_template_with_python_config/report_template_config.py
+++ b/python/examples/report_templates/report_template_with_python_config/report_template_config.py
@@ -107,8 +107,8 @@ def load_rules() -> List[RuleConfig]:
 
 def nostromos_report_template() -> ReportTemplateConfig:
     return ReportTemplateConfig(
-        name="Nostromo Report Template for PR test",
-        template_client_key="report-template-test-1001",
+        name="Nostromo Report Template",
+        template_client_key="report-template-test",
         description="A report template for the Nostromo",
         rule_client_keys=[],
     )

--- a/python/examples/report_templates/report_template_with_yaml_config/main.py
+++ b/python/examples/report_templates/report_template_with_yaml_config/main.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 from sift_py.grpc.transport import SiftChannelConfig, use_sift_channel
+from sift_py.report_templates.config import ReportTemplateUpdate
 from sift_py.report_templates.service import ReportTemplateService
 from sift_py.rule.service import RuleService
 
@@ -43,5 +44,7 @@ if __name__ == "__main__":
             client_key="nostromo-report-template-1"
         )
         if report_template_to_update:
-            report_template_to_update.archived_date = datetime.now()
-            report_template_service.create_or_update_report_template(report_template_to_update)
+            updates = ReportTemplateUpdate(archived_date=datetime.now())
+            report_template_service.create_or_update_report_template(
+                report_template_to_update, updates=updates
+            )

--- a/python/examples/report_templates/report_template_with_yaml_config/main.py
+++ b/python/examples/report_templates/report_template_with_yaml_config/main.py
@@ -1,5 +1,4 @@
 import os
-from datetime import datetime
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -44,7 +43,7 @@ if __name__ == "__main__":
             client_key="nostromo-report-template-1"
         )
         if report_template_to_update:
-            updates = ReportTemplateUpdate(archived_date=datetime.now())
+            updates = ReportTemplateUpdate(archived_date=True)
             report_template_service.create_or_update_report_template(
                 report_template_to_update, updates=updates
             )

--- a/python/lib/sift_py/calculated_channels/config.py
+++ b/python/lib/sift_py/calculated_channels/config.py
@@ -37,7 +37,7 @@ class CalculatedChannelConfig(BaseModel):
         Union[ExpressionChannelReference, ExpressionChannelReferenceChannelConfig]
     ]
     units: Optional[str] = None
-    calculated_channel_id: Optional[str] = None  # read only
+    calculated_channel_id: Optional[str] = None
     client_key: Optional[str] = None
     asset_names: Optional[List[str]] = None
     tag_names: Optional[List[str]] = None

--- a/python/lib/sift_py/report_templates/_config_test.py
+++ b/python/lib/sift_py/report_templates/_config_test.py
@@ -16,7 +16,6 @@ def test_report_template_config(report_template_dict):
     report_template_config = ReportTemplateConfig(**report_template_dict)
     assert report_template_config.name == "report-template"
     assert report_template_config.template_client_key == "template-client-key"
-    assert report_template_config.organization_id == ""
     assert report_template_config.tags is None
     assert report_template_config.description is None
     assert report_template_config.rule_client_keys == []
@@ -25,10 +24,5 @@ def test_report_template_config(report_template_dict):
 
 def test_report_template_config_validation(report_template_dict):
     report_template_dict.pop("name")
-    with pytest.raises(ValidationError, match="Field required"):
-        ReportTemplateConfig(**report_template_dict)
-
-    report_template_dict["name"] = "report-template"
-    report_template_dict.pop("template_client_key")
     with pytest.raises(ValidationError, match="Field required"):
         ReportTemplateConfig(**report_template_dict)

--- a/python/lib/sift_py/report_templates/_service_test.py
+++ b/python/lib/sift_py/report_templates/_service_test.py
@@ -4,7 +4,7 @@ import pytest
 from sift.report_templates.v1.report_templates_pb2 import ReportTemplate
 
 from sift_py._internal.test_util.channel import MockChannel
-from sift_py.report_templates.config import ReportTemplateConfig
+from sift_py.report_templates.config import ReportTemplateConfig, ReportTemplateUpdate
 from sift_py.report_templates.service import ReportTemplateService
 
 
@@ -63,10 +63,7 @@ def test_report_template_service_update_report_template(report_template_service)
         template_client_key="template-client-key",
     )
 
-    report_template_config_update = ReportTemplateConfig(
-        name="report-template-updated",
-        template_client_key="template-client-key",
-    )
+    updates = ReportTemplateUpdate(name="report-template-updated")
 
     with mock.patch.object(
         ReportTemplateService, "_update_report_template"
@@ -75,10 +72,10 @@ def test_report_template_service_update_report_template(report_template_service)
             ReportTemplateService, "_get_report_template_by_client_key"
         ) as mock_get_report_template_by_client_key:
             mock_get_report_template_by_client_key.return_value = report_template_config
-            report_template_service.create_or_update_report_template(report_template_config_update)
-            mock_update_report_template.assert_called_once_with(
-                report_template_config_update, report_template_config
+            report_template_service.create_or_update_report_template(
+                report_template_config, updates=updates
             )
+            mock_update_report_template.assert_called_once_with(report_template_config, updates)
 
 
 def test_report_template_service_missing_template_client_key(report_template_service):

--- a/python/lib/sift_py/report_templates/config.py
+++ b/python/lib/sift_py/report_templates/config.py
@@ -27,6 +27,7 @@ class ReportTemplateConfig(BaseModel, AsJson):
 
     name: str
     template_client_key: str
+    template_id: Optional[str] = None  # read only
     organization_id: str = ""
     tags: Optional[List[str]] = None
     description: Optional[str] = None

--- a/python/lib/sift_py/report_templates/config.py
+++ b/python/lib/sift_py/report_templates/config.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Any, List, Optional
 
 from pydantic import BaseModel, ConfigDict
@@ -26,13 +25,12 @@ class ReportTemplateConfig(BaseModel, AsJson):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     name: str
-    template_client_key: str
-    template_id: Optional[str] = None  # read only
-    organization_id: str = ""
+    template_client_key: Optional[str] = None
+    template_id: Optional[str] = None
     tags: Optional[List[str]] = None
     description: Optional[str] = None
     rule_client_keys: List[str] = []
-    archived_date: Optional[datetime] = None
+    archived_date: Optional[bool] = False
 
     def as_json(self) -> Any:
         return self.model_dump_json()
@@ -54,8 +52,7 @@ class ReportTemplateUpdate(TypedDict):
 
     name: NotRequired[str]
     template_client_key: NotRequired[str]
-    organization_id: NotRequired[str]
     tags: NotRequired[List[str]]
     description: NotRequired[str]
     rule_client_keys: NotRequired[List[str]]
-    archived_date: NotRequired[datetime]
+    archived_date: NotRequired[bool]

--- a/python/lib/sift_py/report_templates/config.py
+++ b/python/lib/sift_py/report_templates/config.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Any, List, Optional
 
 from pydantic import BaseModel, ConfigDict
+from typing_extensions import NotRequired, TypedDict
 
 from sift_py._internal.convert.json import AsJson
 
@@ -34,3 +35,26 @@ class ReportTemplateConfig(BaseModel, AsJson):
 
     def as_json(self) -> Any:
         return self.model_dump_json()
+
+
+class ReportTemplateUpdate(TypedDict):
+    """
+    Represents a dictionary for updating properties of a report template. All fields are optional
+    and only the provided fields will be updated.
+
+    - `name`: Updated name of the report template.
+    - `template_client_key`: Updated unique client key to identify the report template.
+    - `organization_id`: Updated organization ID that the report template belongs to.
+    - `tags`: Updated tags to associate with the report template.
+    - `description`: Updated description of the report template.
+    - `rule_client_keys`: Updated list of rule client keys associated with the report template.
+    - `archived_date`: Updated date when the report template was archived.
+    """
+
+    name: NotRequired[str]
+    template_client_key: NotRequired[str]
+    organization_id: NotRequired[str]
+    tags: NotRequired[List[str]]
+    description: NotRequired[str]
+    rule_client_keys: NotRequired[List[str]]
+    archived_date: NotRequired[datetime]

--- a/python/lib/sift_py/report_templates/config.py
+++ b/python/lib/sift_py/report_templates/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any, List, Optional
 
 from pydantic import BaseModel, ConfigDict
@@ -20,6 +21,7 @@ class ReportTemplateConfig(BaseModel, AsJson):
     - `rule_client_keys`: List of rule client keys associated with the report template.
     - `archived_date`: Date when the report template was archived. Setting this field
         will archive the report template, and unsetting it will unarchive the report template.
+    - `archived`: True if the report template is archived, False otherwise.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -30,7 +32,8 @@ class ReportTemplateConfig(BaseModel, AsJson):
     tags: Optional[List[str]] = None
     description: Optional[str] = None
     rule_client_keys: List[str] = []
-    archived_date: Optional[bool] = False
+    archived_date: Optional[datetime] = None
+    archived: bool = False
 
     def as_json(self) -> Any:
         return self.model_dump_json()
@@ -47,7 +50,7 @@ class ReportTemplateUpdate(TypedDict):
     - `tags`: Updated tags to associate with the report template.
     - `description`: Updated description of the report template.
     - `rule_client_keys`: Updated list of rule client keys associated with the report template.
-    - `archived_date`: Updated date when the report template was archived.
+    - `archived`: True if the report template is archived, False otherwise.
     """
 
     name: NotRequired[str]
@@ -55,4 +58,4 @@ class ReportTemplateUpdate(TypedDict):
     tags: NotRequired[List[str]]
     description: NotRequired[str]
     rule_client_keys: NotRequired[List[str]]
-    archived_date: NotRequired[bool]
+    archived: NotRequired[bool]

--- a/python/lib/sift_py/report_templates/service.py
+++ b/python/lib/sift_py/report_templates/service.py
@@ -75,11 +75,13 @@ class ReportTemplateService:
                 name=report_template.name,
                 template_id=report_template.report_template_id,
                 template_client_key=report_template.client_key,
-                organization_id=report_template.organization_id,
                 tags=[tag.tag_name for tag in report_template.tags],
                 description=report_template.description,
                 rule_client_keys=[rule.client_key for rule in report_template.rules],
-                archived_date=True if report_template.archived_date else False,
+                archived_date=report_template.archived_date.ToDatetime()
+                if report_template.archived_date
+                else None,
+                archived=True if report_template.archived_date else False,
             )
             if report_template
             else None
@@ -129,7 +131,6 @@ class ReportTemplateService:
             client_key=config.template_client_key,
             description=config.description,
             tag_names=config.tags,
-            organization_id=config.organization_id,
             rule_client_keys=client_keys_req,
         )
         self._report_template_service_stub.CreateReportTemplate(req)
@@ -151,14 +152,13 @@ class ReportTemplateService:
                 ReportTemplateRule(client_key=client_key)
                 for client_key in updates["rule_client_keys"]
             ]
-        if "archived_date" in updates:
+        if "archived" in updates:
             update_map["archived_date"] = (
-                to_timestamp_pb(datetime.now()) if updates["archived_date"] else None
+                to_timestamp_pb(datetime.now()) if updates["archived"] else None
             )
 
         updated_report_template = ReportTemplate(
             report_template_id=config.template_id or "",
-            organization_id=config.organization_id,
             client_key=config.template_client_key,
             name=update_map.get("name", config.name),
             description=update_map.get("description", config.description),

--- a/python/lib/sift_py/report_templates/service.py
+++ b/python/lib/sift_py/report_templates/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 
@@ -43,12 +44,11 @@ class ReportTemplateService:
         See `sift_py.report_templates.config.ReportTemplateConfig` for more information on available
         fields to configure.
         """
-        if not config.template_client_key and not config.template_id:
-            raise Exception(
-                f"Report template {config.name} requires either a template_client_key or report_template_id"
-            )
-
         if updates:
+            if not config.template_client_key and not config.template_id:
+                raise Exception(
+                    f"Report template {config.name} requires either a template_client_key or report_template_id to update."
+                )
             self._update_report_template(config, updates)
         else:
             self._create_report_template(config)
@@ -79,9 +79,7 @@ class ReportTemplateService:
                 tags=[tag.tag_name for tag in report_template.tags],
                 description=report_template.description,
                 rule_client_keys=[rule.client_key for rule in report_template.rules],
-                archived_date=report_template.archived_date.ToDatetime()
-                if report_template.archived_date
-                else None,
+                archived_date=True if report_template.archived_date else False,
             )
             if report_template
             else None
@@ -155,7 +153,7 @@ class ReportTemplateService:
             ]
         if "archived_date" in updates:
             update_map["archived_date"] = (
-                to_timestamp_pb(updates["archived_date"]) if updates["archived_date"] else None
+                to_timestamp_pb(datetime.now()) if updates["archived_date"] else None
             )
 
         updated_report_template = ReportTemplate(


### PR DESCRIPTION
This PR adds:
- A `ReportTemplateUpdate` class to allow users to easily specify update fields
- Updates the `ReportTemplateService` to specify only the fields actually being updated in the `FieldMask` passed back to the API
- Updates the ReportTemplate examples accordingly
- Updates the relevant unit tests