### PR TITLE
go(chore): Fix workflow file

### DIFF
--- a/.github/workflows/go_release.yaml
+++ b/.github/workflows/go_release.yaml
@@ -25,7 +25,7 @@ jobs:
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           VERSION="${TAG#go/}"
-          echo "version=$VERSION" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Publish Go module
         run: |


### PR DESCRIPTION
I couldn't figure out how to get `act` to use a different tag, but with the tag that it was using I can see that the variable is being set correctly unlike before:

Before:
```
...
[Go Module Publish/publish-to-pkg-go-dev]   🐳  docker exec cmd=[bash -e /var/run/act/workflow/3] user= workdir=
| go: github.com/sift-stack/sift/go@: invalid version: disallowed version string
...
```

After:
```
...
[Go Module Publish/publish-to-pkg-go-dev]   🐳  docker exec cmd=[bash -e /var/run/act/workflow/3] user= workdir=
| go: github.com/sift-stack/sift/go@sift_proxy/v1.0.0: invalid version: version "sift_proxy/v1.0.0" invalid: disallowed version string
...
```