### PR TITLE
python(bug): Add threaded and generator ingestion example

### DIFF
--- a/python/examples/ingestion_with_no_buffering/.env-example
+++ b/python/examples/ingestion_with_no_buffering/.env-example
@@ -1,0 +1,8 @@
+# Retrieve the BASE_URI from the Sift team
+# Be sure to exclude "https://" from the BASE_URI
+#
+# BASE URIs and further details can be found here:
+#   https://docs.siftstack.com/docs/api/authentication
+BASE_URI=""
+
+SIFT_API_KEY=""

--- a/python/examples/ingestion_with_no_buffering/main.py
+++ b/python/examples/ingestion_with_no_buffering/main.py
@@ -1,0 +1,115 @@
+import logging
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from queue import Queue
+from typing import Iterable
+
+import grpc
+from dotenv import load_dotenv
+from sift.ingest.v1.ingest_pb2 import IngestWithConfigDataStreamRequest
+from sift.ingest.v1.ingest_pb2_grpc import IngestServiceStub
+from sift_py.grpc.transport import SiftChannelConfig, use_sift_channel
+from sift_py.ingestion.service import IngestionService
+from simulator import Simulator
+from telemetry_config import nostromos_lv_426
+
+
+def ingestion_thread(sift_channel_config: SiftChannelConfig, data_queue: Queue):
+    """
+    This thread will use a generator to stream data to Sift with no buffering/little latency.
+    """
+    logger = logging.getLogger(__name__)
+    stop = threading.Event()
+    backup_queue = []
+
+    def data_generator() -> Iterable[IngestWithConfigDataStreamRequest]:
+        # Yield data for 60s
+        connection_duration = 60
+        start_time = time.time()
+        while time.time() - start_time < connection_duration:
+            item = data_queue.get()
+            # None signals the Simulator thread is done.
+            if item is None:
+                stop.set()
+                logger.info("Simulation thread completed.")
+                return
+            # Store each item in a backup queue in case we lose the connection.
+            backup_queue.append(item)
+            yield item
+
+    with use_sift_channel(sift_channel_config) as channel:
+        # Use the raw grpc Stub to stream data with without buffering.
+        ingestion_service = IngestServiceStub(channel)
+
+        while True:
+            try:
+                logger.info("Opening connection and streaming for 60s")
+                ingestion_service.IngestWithConfigDataStream(data_generator())
+                logger.info("Connection closed. Data streamed successfully")
+                backup_queue.clear()
+            except grpc.RpcError as e:
+                logger.warning(e)
+                #  Add the data back to the queue so that we can stream it again.
+                for item in backup_queue:
+                    data_queue.put(item)
+
+            if stop.is_set():
+                return
+
+
+if __name__ == "__main__":
+    """
+    Threaded example of telemetering data for the asset of name 'NostromoLV426' with various channels
+    and rules with no buffering and little latency. The simulator will be generating data.
+    The ingestion_thread will ingest this data into Sift.
+    """
+
+    load_dotenv()
+
+    apikey = os.getenv("SIFT_API_KEY")
+
+    if apikey is None:
+        raise Exception("Missing 'SIFT_API_KEY' environment variable.")
+
+    base_uri = os.getenv("BASE_URI")
+
+    if base_uri is None:
+        raise Exception("Missing 'BASE_URI' environment variable.")
+
+    # Load your telemetry config
+    telemetry_config = nostromos_lv_426()
+
+    # Create a gRPC transport channel configured specifically for the Sift API
+    sift_channel_config = SiftChannelConfig(uri=base_uri, apikey=apikey)
+
+    with use_sift_channel(sift_channel_config) as channel:
+        # Create ingestion service using the telemetry config we loaded in.
+        ingestion_service = IngestionService(
+            channel,
+            telemetry_config,
+        )
+
+        # Create an optional run as part of this ingestion
+        current_ts = datetime.now(timezone.utc)
+        run_name = f"[{telemetry_config.asset_name}].{current_ts.timestamp()}"
+        ingestion_service.attach_run(channel, run_name, "Run simulation")
+
+    # Start the ingestion thread
+    data_queue = Queue()
+    thread = threading.Thread(
+        target=ingestion_thread,
+        args=(
+            sift_channel_config,
+            data_queue,
+        ),
+    )
+    thread.start()
+
+    # Create our simulator
+    simulator = Simulator(ingestion_service, data_queue)
+
+    # Run it
+    simulator.run()
+    thread.join()

--- a/python/examples/ingestion_with_no_buffering/requirements.txt
+++ b/python/examples/ingestion_with_no_buffering/requirements.txt
@@ -1,0 +1,2 @@
+python-dotenv
+sift-stack-py

--- a/python/examples/ingestion_with_no_buffering/rule_modules/velocity.yml
+++ b/python/examples/ingestion_with_no_buffering/rule_modules/velocity.yml
@@ -1,0 +1,12 @@
+namespace: velocity
+
+rules:
+  - name: vehicle_stuck
+    description: Triggers if the vehicle velocity is not 0 for 5s after entering accelerating state
+    expression: $1 == "Accelerating" && persistence($2 == 0, 5)
+    type: review
+
+  - name: vehicle_not_stopped
+    description: Triggers if the vehicle velocity does not remain 0 while stopped
+    expression: $1 == "Stopped" && $2 > 0
+    type: review

--- a/python/examples/ingestion_with_no_buffering/rule_modules/voltage.yml
+++ b/python/examples/ingestion_with_no_buffering/rule_modules/voltage.yml
@@ -1,0 +1,12 @@
+namespace: voltage
+
+rules:
+  - name: overvoltage
+    description: Checks for overvoltage while accelerating
+    expression: $1 == "Accelerating" && $2 > 80
+    type: review
+
+  - name: undervoltage
+    description: Checks for undervoltage while accelerating
+    expression: $1 == "Accelerating" && $2 < 40
+    type: review

--- a/python/examples/ingestion_with_no_buffering/simulator.py
+++ b/python/examples/ingestion_with_no_buffering/simulator.py
@@ -1,0 +1,93 @@
+import logging
+import random
+import time
+from datetime import datetime, timezone
+from queue import Queue
+from typing import List
+
+from google.protobuf.timestamp_pb2 import Timestamp
+from sift.ingest.v1.ingest_pb2 import IngestWithConfigDataStreamRequest
+from sift_py.ingestion.channel import (
+    bit_field_value,
+    double_value,
+    enum_value,
+    int32_value,
+)
+from sift_py.ingestion.service import IngestionService
+
+READINGS_FREQUENCY_HZ = 100
+
+
+class Simulator:
+    """
+    Generates data for 60 seconds.
+    """
+
+    ingestion_service: IngestionService
+    data_queue: Queue
+    sample_bit_field_values: List[bytes]
+    logger: logging.Logger
+
+    def __init__(self, ingestion_service: IngestionService, data_queue: Queue):
+        self.ingestion_service = ingestion_service
+        self.data_queue = data_queue
+
+        logging.basicConfig(level=logging.DEBUG)
+        self.logger = logging.getLogger(__name__)
+
+        sample_bit_field_values = ["00001001", "00100011", "00001101", "11000001"]
+        self.sample_bit_field_values = [bytes([int(byte, 2)]) for byte in sample_bit_field_values]
+
+    def run(self):
+        """
+        Generate data.
+        """
+        asset_name = self.ingestion_service.asset_name
+        run_id = self.ingestion_service.run_id
+
+        if run_id is not None:
+            self.logger.info(f"Beginning simulation for '{asset_name}' with run ({run_id})")
+        else:
+            self.logger.info(f"Beginning simulation for '{asset_name}'")
+
+        start_time = time.time()
+        end_time = start_time + 90
+
+        last_reading_time = start_time
+        readings_interval_s = 1 / READINGS_FREQUENCY_HZ
+
+        while time.time() < end_time:
+            current_time = time.time()
+
+            if current_time - last_reading_time >= readings_interval_s:
+                timestamp_pb = Timestamp()
+                timestamp_pb.FromDatetime(datetime.now(timezone.utc))
+
+                data = {
+                    "mainmotor.velocity": double_value(random.randint(1, 10)),
+                    "voltage": int32_value(random.randint(1, 50)),
+                    "vehicle_state": enum_value(random.randint(0, 2)),
+                    "gpio": bit_field_value(random.choice(self.sample_bit_field_values)),
+                }
+
+                # channel_values must be in the same order as channels in the telemetry config
+                channel_values = []
+                for channel in self.ingestion_service.flow_configs_by_name["readings"].channels:
+                    channel_values.append(data[channel.name])
+
+                self.data_queue.put(
+                    IngestWithConfigDataStreamRequest(
+                        ingestion_config_id=self.ingestion_service.ingestion_config.ingestion_config_id,
+                        flow="readings",
+                        timestamp=timestamp_pb,
+                        run_id=self.ingestion_service.run_id or "",
+                        channel_values=channel_values,
+                        end_stream_on_validation_error=self.ingestion_service.end_stream_on_error,
+                    )
+                )
+
+                last_reading_time = current_time
+
+        # Signal ingest thread we are done.
+        self.data_queue.put(None)
+        self.logger.info("Completed simulation.")

--- a/python/examples/ingestion_with_no_buffering/telemetry_config.py
+++ b/python/examples/ingestion_with_no_buffering/telemetry_config.py
@@ -1,0 +1,145 @@
+from pathlib import Path
+
+from sift_py.ingestion.channel import (
+    ChannelBitFieldElement,
+    ChannelConfig,
+    ChannelDataType,
+    ChannelEnumType,
+)
+from sift_py.ingestion.config.telemetry import FlowConfig, TelemetryConfig
+from sift_py.ingestion.rule.config import (
+    RuleActionCreateDataReviewAnnotation,
+    RuleConfig,
+)
+
+RULE_NAMESPACES_DIR = Path().joinpath("rule_modules")
+
+
+def nostromos_lv_426() -> TelemetryConfig:
+    log_channel = ChannelConfig(
+        name="log",
+        data_type=ChannelDataType.STRING,
+        description="asset logs",
+    )
+    velocity_channel = ChannelConfig(
+        name="mainmotor.velocity",
+        data_type=ChannelDataType.DOUBLE,
+        description="speed",
+        unit="Miles Per Hour",
+    )
+    voltage_channel = ChannelConfig(
+        name="voltage",
+        data_type=ChannelDataType.INT_32,
+        description="voltage at source",
+        unit="Volts",
+    )
+    vehicle_state_channel = ChannelConfig(
+        name="vehicle_state",
+        data_type=ChannelDataType.ENUM,
+        description="vehicle state",
+        enum_types=[
+            ChannelEnumType(name="Accelerating", key=0),
+            ChannelEnumType(name="Decelerating", key=1),
+            ChannelEnumType(name="Stopped", key=2),
+        ],
+    )
+    gpio_channel = ChannelConfig(
+        name="gpio",
+        data_type=ChannelDataType.BIT_FIELD,
+        description="on/off values for pins on gpio",
+        bit_field_elements=[
+            ChannelBitFieldElement(name="12v", index=0, bit_count=1),
+            ChannelBitFieldElement(name="charge", index=1, bit_count=2),
+            ChannelBitFieldElement(name="led", index=3, bit_count=4),
+            ChannelBitFieldElement(name="heater", index=7, bit_count=1),
+        ],
+    )
+
+    return TelemetryConfig(
+        asset_name="NostromoLV426",
+        ingestion_client_key="nostromo_lv_426",
+        flows=[
+            FlowConfig(
+                name="readings",
+                channels=[
+                    velocity_channel,
+                    voltage_channel,
+                    vehicle_state_channel,
+                    gpio_channel,
+                ],
+            ),
+            FlowConfig(
+                name="voltage",
+                channels=[voltage_channel],
+            ),
+            FlowConfig(
+                name="gpio_channel",
+                channels=[gpio_channel],
+            ),
+            FlowConfig(name="logs", channels=[log_channel]),
+        ],
+        rules=[
+            RuleConfig(
+                name="overheating",
+                description="Checks for vehicle overheating",
+                expression='$1 == "Accelerating" && $2 > 80',
+                rule_client_key="overheating-rule",
+                asset_names=["NostromoLV426"],
+                channel_references=[
+                    # INFO: Can use either a channel idenfier string or a ChannelConfig
+                    {
+                        "channel_reference": "$1",
+                        "channel_identifier": vehicle_state_channel.identifier,
+                    },
+                    {
+                        "channel_reference": "$2",
+                        "channel_config": voltage_channel,
+                    },
+                ],
+                action=RuleActionCreateDataReviewAnnotation(),
+            ),
+            RuleConfig(
+                name="kinetic_energy",
+                description="Tracks high energy output while in motion",
+                expression="0.5 * $mass * $1 * $1 > $threshold",
+                rule_client_key="kinetic-energy-rule",
+                asset_names=["NostromoLV426"],
+                channel_references=[
+                    {
+                        "channel_reference": "$1",
+                        "channel_config": voltage_channel,
+                    },
+                ],
+                sub_expressions={
+                    "$mass": 10,
+                    "$threshold": 470,
+                },
+                action=RuleActionCreateDataReviewAnnotation(
+                    # User in your organization to notify
+                    # assignee="ellen.ripley@weylandcorp.com",
+                    tags=["nostromo"],
+                ),
+            ),
+            RuleConfig(
+                name="failure",
+                description="Checks for failures reported by logs",
+                expression="contains($1, $sub_string)",
+                rule_client_key="failure-rule",
+                asset_names=["NostromoLV426"],
+                channel_references=[
+                    {
+                        "channel_reference": "$1",
+                        "channel_config": log_channel,
+                    },
+                ],
+                sub_expressions={
+                    "$sub_string": "failure",
+                },
+                action=RuleActionCreateDataReviewAnnotation(
+                    # User in your organization to notify
+                    # assignee="ellen.ripley@weylandcorp.com",
+                    tags=["nostromo", "failure"],
+                ),
+            ),
+        ],
+    )

--- a/python/examples/ingestion_with_threading/main.py
+++ b/python/examples/ingestion_with_threading/main.py
@@ -1,0 +1,78 @@
+import os
+import threading
+from datetime import datetime, timezone
+from queue import Empty, Queue
+
+from dotenv import load_dotenv
+from sift_py.grpc.transport import SiftChannelConfig, use_sift_channel
+from sift_py.ingestion.service import IngestionService
+from simulator import Simulator
+from telemetry_config import nostromos_lv_426
+
+
+def ingestion_thread(data_queue: Queue):
+    """
+    This thread is responsible for consuming data from the queue and sending
+    it to Sift.
+    """
+    # Can tune ingestion performance with buffer_size and flush_interval_sec
+    with ingestion_service.buffered_ingestion() as buffered_ingestion:
+        while True:
+            try:
+                item = data_queue.get(timeout=1)
+                # None signals the Simulator thread is done.
+                if item is None:
+                    return
+            except Empty:
+                continue
+            buffered_ingestion.try_ingest_flows(item)
+
+
+if __name__ == "__main__":
+    """
+    Threaded example of telemetering data for the asset of name 'NostromoLV426' with various channels
+    and rules. The simulator will be generating data for various flows at various frequencies.
+    The ingestion_thread will ingest this data into Sift.
+    """
+
+    load_dotenv()
+
+    apikey = os.getenv("SIFT_API_KEY")
+
+    if apikey is None:
+        raise Exception("Missing 'SIFT_API_KEY' environment variable.")
+
+    base_uri = os.getenv("BASE_URI")
+
+    if base_uri is None:
+        raise Exception("Missing 'BASE_URI' environment variable.")
+
+    # Load your telemetry config
+    telemetry_config = nostromos_lv_426()
+
+    # Create a gRPC transport channel configured specifically for the Sift API
+    sift_channel_config = SiftChannelConfig(uri=base_uri, apikey=apikey)
+
+    with use_sift_channel(sift_channel_config) as channel:
+        # Create ingestion service using the telemetry config we loaded in
+        ingestion_service = IngestionService(
+            channel,
+            telemetry_config,
+            end_stream_on_error=True,  # End stream if errors occur API-side.
+        )
+
+        # Create an optional run as part of this ingestion
+        current_ts = datetime.now(timezone.utc)
+        run_name = f"[{telemetry_config.asset_name}].{current_ts.timestamp()} (Threaded)"
+        ingestion_service.attach_run(channel, run_name, "Run simulation")
+
+        data_queue = Queue()
+        thread = threading.Thread(target=ingestion_thread, args=(data_queue,))
+        thread.start()
+
+        # Create our simulator
+        simulator = Simulator(data_queue, ingestion_service.asset_name, ingestion_service.run_id)
+
+        # Run it
+        simulator.run()
+        thread.join()

--- a/python/examples/ingestion_with_threading/requirements.txt
+++ b/python/examples/ingestion_with_threading/requirements.txt
@@ -1,0 +1,2 @@
+python-dotenv
+sift-stack-py

--- a/python/examples/ingestion_with_threading/rule_modules/velocity.yml
+++ b/python/examples/ingestion_with_threading/rule_modules/velocity.yml
@@ -1,0 +1,12 @@
+namespace: velocity
+
+rules:
+  - name: vehicle_stuck
+    description: Triggers if the vehicle velocity is not 0 for 5s after entering accelerating state
+    expression: $1 == "Accelerating" && persistence($2 == 0, 5)
+    type: review
+
+  - name: vehicle_not_stopped
+    description: Triggers if the vehicle velocity does not remain 0 while stopped
+    expression: $1 == "Stopped" && $2 > 0
+    type: review

--- a/python/examples/ingestion_with_threading/rule_modules/voltage.yml
+++ b/python/examples/ingestion_with_threading/rule_modules/voltage.yml
@@ -1,0 +1,12 @@
+namespace: voltage
+
+rules:
+  - name: overvoltage
+    description: Checks for overvoltage while accelerating
+    expression: $1 == "Accelerating" && $2 > 80
+    type: review
+
+  - name: undervoltage
+    description: Checks for undervoltage while accelerating
+    expression: $1 == "Accelerating" && $2 < 40
+    type: review

--- a/python/examples/ingestion_with_threading/simulator.py
+++ b/python/examples/ingestion_with_threading/simulator.py
@@ -1,0 +1,111 @@
+import logging
+import random
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from queue import Queue
+from typing import List, Optional
+
+from sift_py.ingestion.channel import (
+    bit_field_value,
+    double_value,
+    enum_value,
+    int32_value,
+)
+
+READINGS_FREQUENCY_HZ = 100
+
+
+class Simulator:
+    """
+    Generates data for 60 seconds.
+    """
+
+    data_queue: Queue
+    asset_name: str
+    run_id: Optional[str]
+    sample_bit_field_values: List[bytes]
+    sample_logs: List[str]
+    logger: logging.Logger
+
+    def __init__(self, data_queue: Queue, asset_name: str, run_id: Optional[str]):
+        self.data_queue = data_queue
+        self.asset_name = asset_name
+        self.run_id = run_id
+
+        logging.basicConfig(level=logging.DEBUG)
+        self.logger = logging.getLogger(__name__)
+
+        sample_bit_field_values = ["00001001", "00100011", "00001101", "11000001"]
+        self.sample_bit_field_values = [bytes([int(byte, 2)]) for byte in sample_bit_field_values]
+
+        sample_logs = Path().joinpath("sample_data").joinpath("sample_logs.txt")
+
+        with open(sample_logs, "r") as file:
+            self.sample_logs = file.readlines()
+
+    def run(self):
+        """
+        Generate data.
+        """
+        if self.run_id is not None:
+            self.logger.info(
+                f"Beginning simulation for '{self.asset_name}' with run ({self.run_id})"
+            )
+        else:
+            self.logger.info(f"Beginning simulation for '{self.asset_name}'")
+
+        start_time = time.time()
+        end_time = start_time + 60
+
+        last_reading_time = start_time
+        readings_interval_s = 1 / READINGS_FREQUENCY_HZ
+
+        last_reporting_time = start_time
+        reporting_interval_1 = 1
+
+        n = 0
+        while time.time() < end_time:
+            current_time = time.time()
+
+            # Send date for readings flow
+            timestamp = datetime.now(timezone.utc)
+            if current_time - last_reading_time >= readings_interval_s:
+                n += 1
+                self.data_queue.put(
+                    {
+                        "flow_name": "readings",
+                        "timestamp": timestamp,
+                        "channel_values": [
+                            {
+                                "channel_name": "velocity",
+                                "component": "mainmotor",
+                                "value": double_value(random.randint(1, 10)),
+                            },
+                            {
+                                "channel_name": "voltage",
+                                "value": int32_value(random.randint(1, 10)),
+                            },
+                            {
+                                "channel_name": "vehicle_state",
+                                "value": enum_value(random.randint(0, 2)),
+                            },
+                            {
+                                "channel_name": "gpio",
+                                "value": bit_field_value(
+                                    random.choice(self.sample_bit_field_values)
+                                ),
+                            },
+                        ],
+                    }
+                )
+                last_reading_time = current_time
+
+            if current_time - last_reporting_time >= reporting_interval_1:
+                logging.info(f"{timestamp} Pushed {n} data points for 'readings' flow")
+                last_reporting_time = current_time
+                n = 0
+
+        # Signal ingest thread we are done.
+        self.data_queue.put(None)
+        self.logger.info("Completed simulation.")

--- a/python/examples/ingestion_with_threading/telemetry_config.py
+++ b/python/examples/ingestion_with_threading/telemetry_config.py
@@ -1,0 +1,146 @@
+from pathlib import Path
+
+from sift_py.ingestion.channel import (
+    ChannelBitFieldElement,
+    ChannelConfig,
+    ChannelDataType,
+    ChannelEnumType,
+)
+from sift_py.ingestion.config.telemetry import FlowConfig, TelemetryConfig
+from sift_py.ingestion.rule.config import (
+    RuleActionCreateDataReviewAnnotation,
+    RuleConfig,
+)
+
+RULE_NAMESPACES_DIR = Path().joinpath("rule_modules")
+
+
+def nostromos_lv_426() -> TelemetryConfig:
+    log_channel = ChannelConfig(
+        name="log",
+        data_type=ChannelDataType.STRING,
+        description="asset logs",
+    )
+    velocity_channel = ChannelConfig(
+        name="velocity",
+        data_type=ChannelDataType.DOUBLE,
+        description="speed",
+        unit="Miles Per Hour",
+        component="mainmotor",
+    )
+    voltage_channel = ChannelConfig(
+        name="voltage",
+        data_type=ChannelDataType.INT_32,
+        description="voltage at source",
+        unit="Volts",
+    )
+    vehicle_state_channel = ChannelConfig(
+        name="vehicle_state",
+        data_type=ChannelDataType.ENUM,
+        description="vehicle state",
+        enum_types=[
+            ChannelEnumType(name="Accelerating", key=0),
+            ChannelEnumType(name="Decelerating", key=1),
+            ChannelEnumType(name="Stopped", key=2),
+        ],
+    )
+    gpio_channel = ChannelConfig(
+        name="gpio",
+        data_type=ChannelDataType.BIT_FIELD,
+        description="on/off values for pins on gpio",
+        bit_field_elements=[
+            ChannelBitFieldElement(name="12v", index=0, bit_count=1),
+            ChannelBitFieldElement(name="charge", index=1, bit_count=2),
+            ChannelBitFieldElement(name="led", index=3, bit_count=4),
+            ChannelBitFieldElement(name="heater", index=7, bit_count=1),
+        ],
+    )
+
+    return TelemetryConfig(
+        asset_name="NostromoLV426",
+        ingestion_client_key="nostromo_lv_426",
+        flows=[
+            FlowConfig(
+                name="readings",
+                channels=[
+                    velocity_channel,
+                    voltage_channel,
+                    vehicle_state_channel,
+                    gpio_channel,
+                ],
+            ),
+            FlowConfig(
+                name="voltage",
+                channels=[voltage_channel],
+            ),
+            FlowConfig(
+                name="gpio_channel",
+                channels=[gpio_channel],
+            ),
+            FlowConfig(name="logs", channels=[log_channel]),
+        ],
+        rules=[
+            RuleConfig(
+                name="overheating",
+                description="Checks for vehicle overheating",
+                expression='$1 == "Accelerating" && $2 > 80',
+                rule_client_key="overheating-rule",
+                asset_names=["NostromoLV426"],
+                channel_references=[
+                    # INFO: Can use either a channel idenfier string or a ChannelConfig
+                    {
+                        "channel_reference": "$1",
+                        "channel_identifier": vehicle_state_channel.identifier,
+                    },
+                    {
+                        "channel_reference": "$2",
+                        "channel_config": voltage_channel,
+                    },
+                ],
+                action=RuleActionCreateDataReviewAnnotation(),
+            ),
+            RuleConfig(
+                name="kinetic_energy",
+                description="Tracks high energy output while in motion",
+                expression="0.5 * $mass * $1 * $1 > $threshold",
+                rule_client_key="kinetic-energy-rule",
+                asset_names=["NostromoLV426"],
+                channel_references=[
+                    {
+                        "channel_reference": "$1",
+                        "channel_config": voltage_channel,
+                    },
+                ],
+                sub_expressions={
+                    "$mass": 10,
+                    "$threshold": 470,
+                },
+                action=RuleActionCreateDataReviewAnnotation(
+                    # User in your organization to notify
+                    # assignee="ellen.ripley@weylandcorp.com",
+                    tags=["nostromo"],
+                ),
+            ),
+            RuleConfig(
+                name="failure",
+                description="Checks for failures reported by logs",
+                expression="contains($1, $sub_string)",
+                rule_client_key="failure-rule",
+                asset_names=["NostromoLV426"],
+                channel_references=[
+                    {
+                        "channel_reference": "$1",
+                        "channel_config": log_channel,
+                    },
+                ],
+                sub_expressions={
+                    "$sub_string": "failure",
+                },
+                action=RuleActionCreateDataReviewAnnotation(
+                    # User in your organization to notify
+                    # assignee="ellen.ripley@weylandcorp.com",
+                    tags=["nostromo", "failure"],
+                ),
+            ),
+        ],
+    )

--- a/python/lib/sift_py/ingestion/buffer.py
+++ b/python/lib/sift_py/ingestion/buffer.py
@@ -104,7 +104,7 @@ class BufferedIngestionService(Generic[T]):
                     self._buffer.append(req)
 
                 if len(self._buffer) >= self._buffer_size:
-                    self._flush(self._buffer)
+                    self._flush()
 
                 lhs_cursor = rhs_cursor
                 rhs_cursor = min(
@@ -139,7 +139,7 @@ class BufferedIngestionService(Generic[T]):
                     self._buffer.append(req)
 
                 if len(self._buffer) >= self._buffer_size:
-                    self._flush(self._buffer)
+                    self._flush()
 
                 lhs_cursor = rhs_cursor
                 rhs_cursor = min(
@@ -154,18 +154,15 @@ class BufferedIngestionService(Generic[T]):
 
         if self._flush_timer and self._lock:
             with self._lock:
-                # Save off the buffer so we don't need to hold onto the lock
-                buffer = self._buffer
-                self._buffer = []
-            self._flush(buffer)
+                self._flush()
             self._restart_flush_timer()
         else:
-            self._flush(self._buffer)
+            self._flush()
 
-    def _flush(self, buffer: List[IngestWithConfigDataStreamRequest]):
-        if len(buffer) > 0:
-            self._ingestion_service.ingest(*buffer)
-            buffer.clear()
+    def _flush(self):
+        if len(self._buffer) > 0:
+            self._ingestion_service.ingest(*self._buffer)
+            self._buffer.clear()
 
     def _start_flush_timer(self):
         if self._flush_interval_sec:


### PR DESCRIPTION
Added an example that handles ingestion in a separate thread to prevent data generating from being blocked.
This example is a copy/paste of the `ingestion_with_python_config`. Changes were made to main.py and some small changes to simulator.py.

Also added an example that does true streaming using a generator. This example is a copy/paste of the `ingestion_with_python_config`. Changes were made to main.py and some small changes to simulator.py.
Example output:
```
$ python main.py
INFO:simulator:Beginning simulation for 'NostromoLV426' with run (7adb1d3a-79c6-43ab-95b1-bbc08c4f9d56)
INFO:__main__:Opening connection and streaming for 60s
INFO:__main__:Connection closed. Data streamed successfully
INFO:__main__:Opening connection and streaming for 60s
INFO:simulator:Completed simulation.
INFO:__main__:Simulation thread completed.
INFO:__main__:Connection closed. Data streamed successfully
```