### PR TITLE
protos(feature): protobuf desc compatibility check

### DIFF
--- a/protos/sift/protobuf_descriptors/v2/protobuf_descriptors.proto
+++ b/protos/sift/protobuf_descriptors/v2/protobuf_descriptors.proto
@@ -6,7 +6,7 @@ import "google/api/annotations.proto";
 import "google/api/field_behavior.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
-option go_package = "azimuth/gen/protos/go/sift/protobuf_descriptors/v2;protobufdescriptorsv2pb";
+
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   info: {title: "Protobuf Descriptor Service"}
 };

--- a/protos/sift/protobuf_descriptors/v2/protobuf_descriptors.proto
+++ b/protos/sift/protobuf_descriptors/v2/protobuf_descriptors.proto
@@ -6,7 +6,7 @@ import "google/api/annotations.proto";
 import "google/api/field_behavior.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
-
+option go_package = "azimuth/gen/protos/go/sift/protobuf_descriptors/v2;protobufdescriptorsv2pb";
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   info: {title: "Protobuf Descriptor Service"}
 };
@@ -27,6 +27,16 @@ service ProtobufDescriptorService {
       summary: "AddProtobufDescriptor"
       description: "Used to register a protobuf message to be ingested."
       operation_id: "ProtobufDescriptorService_AddProtobufDescriptorV2"
+    };
+  }
+
+  // Used to check if a protobuf descriptor is compatible with the existing descriptors.
+  rpc CheckProtobufDescriptorCompatibility(CheckProtobufDescriptorCompatibilityRequest) returns (CheckProtobufDescriptorCompatibilityResponse) {
+    option (google.api.http) = {post: "/api/v2/protobuf-descriptors:check-compatibility"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "CheckProtobufDescriptorCompatibility"
+      description: "Used to check if a protobuf descriptor is compatible with the existing descriptors."
+      operation_id: "ProtobufDescriptorService_CheckProtobufDescriptorCompatibilityV2"
     };
   }
 
@@ -70,6 +80,25 @@ message AddProtobufDescriptorRequest {
 
 message AddProtobufDescriptorResponse {
   ProtobufDescriptor protobuf_descriptor = 1;
+}
+
+message CheckProtobufDescriptorCompatibilityRequest {
+  ProtobufDescriptor protobuf_descriptor = 1;
+}
+
+message IncompatibleProtobufField {
+  string protobuf_descriptor_id = 1;
+  string message_full_name = 2;
+  string desired_field_name = 3;
+  string current_field_name = 4;
+  string field_number = 5;
+  string reason = 6;
+  string details = 7;
+} 
+
+message CheckProtobufDescriptorCompatibilityResponse {
+  bool is_valid = 1;
+  repeated IncompatibleProtobufField incompatible_protobuf_descriptor_fields = 2;
 }
 
 message ProtobufDescriptor {


### PR DESCRIPTION
# Summary

Add new endpoint to the `ProtobufDescriptorService` that allows users to check protobuf descriptor compatibility. 