### PR TITLE
fix(python): RuleService adds annotation type

### DIFF
--- a/python/lib/sift_py/rule/service.py
+++ b/python/lib/sift_py/rule/service.py
@@ -308,6 +308,7 @@ class RuleService:
                     configuration=RuleActionConfiguration(
                         annotation=AnnotationActionConfiguration(
                             assigned_to_user_id=user_id,
+                            annotation_type=AnnotationType.ANNOTATION_TYPE_DATA_REVIEW,
                             # tag_ids=config.action.tags,  # TODO: Requires TagService
                         )
                     ),
@@ -318,6 +319,7 @@ class RuleService:
                     action_type=ANNOTATION,
                     configuration=RuleActionConfiguration(
                         annotation=AnnotationActionConfiguration(
+                            annotation_type=AnnotationType.ANNOTATION_TYPE_PHASE,
                             # tag_ids=config.action.tags,  # TODO: Requires TagService
                         )
                     ),


### PR DESCRIPTION
Fixes the issue where rules created by the RuleService had an unknown annotation type.