### PR TITLE
rust(build): update GHA release workflows + changelog

### DIFF
--- a/.github/workflows/rust_release.yaml
+++ b/.github/workflows/rust_release.yaml
@@ -8,12 +8,12 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags')
     uses: ./.github/workflows/rust_ci.yaml
 
-  publish-to-crate-io:
+  publish-to-crate-io-sift_rs:
     runs-on: ubuntu-latest
-    name: Publish to crates.io
+    name: Publish to crates.io for sift_rs
     needs: rust-ci
     environment:
-      name: crates.io
+      name: crates.io (dry run)
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -23,4 +23,55 @@ jobs:
       - uses: katyo/publish-crates@v2
         with:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          path: './rust'
+          path: './rust/crates/sift_rs'
+
+  publish-to-crate-io-sift_error:
+    runs-on: ubuntu-latest
+    name: Publish to crates.io for sift_error
+    needs: rust-ci
+    environment:
+      name: crates.io (dry run)
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          path: './rust/crates/sift_error'
+
+  publish-to-crate-io-sift_connect:
+    runs-on: ubuntu-latest
+    name: Publish to crates.io for sift_connect
+    needs: rust-ci
+    environment:
+      name: crates.io (dry run)
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          path: './rust/crates/sift_connect'
+
+  publish-to-crate-io-sift_stream:
+    runs-on: ubuntu-latest
+    name: Publish to crates.io for sift_stream
+    needs: rust-ci
+    environment:
+      name: crates.io (dry run)
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          path: './rust/crates/sift_stream'

--- a/.github/workflows/rust_release.yaml
+++ b/.github/workflows/rust_release.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Publish to crates.io for sift_rs
     needs: rust-ci
     environment:
-      name: crates.io (dry run)
+      name: crates.io
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -30,7 +30,7 @@ jobs:
     name: Publish to crates.io for sift_error
     needs: rust-ci
     environment:
-      name: crates.io (dry run)
+      name: crates.io
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -47,7 +47,7 @@ jobs:
     name: Publish to crates.io for sift_connect
     needs: rust-ci
     environment:
-      name: crates.io (dry run)
+      name: crates.io
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -64,7 +64,7 @@ jobs:
     name: Publish to crates.io for sift_stream
     needs: rust-ci
     environment:
-      name: crates.io (dry run)
+      name: crates.io
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust_release.yaml
+++ b/.github/workflows/rust_release.yaml
@@ -8,7 +8,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags')
     uses: ./.github/workflows/rust_ci.yaml
 
-  publish-to-crate-io-sift_rs:
+  publish-to-crates-io-sift_rs:
     runs-on: ubuntu-latest
     name: Publish to crates.io for sift_rs
     needs: rust-ci
@@ -25,7 +25,7 @@ jobs:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           path: './rust/crates/sift_rs'
 
-  publish-to-crate-io-sift_error:
+  publish-to-crates-io-sift_error:
     runs-on: ubuntu-latest
     name: Publish to crates.io for sift_error
     needs: rust-ci
@@ -42,7 +42,7 @@ jobs:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           path: './rust/crates/sift_error'
 
-  publish-to-crate-io-sift_connect:
+  publish-to-crates-io-sift_connect:
     runs-on: ubuntu-latest
     name: Publish to crates.io for sift_connect
     needs: rust-ci
@@ -59,7 +59,7 @@ jobs:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           path: './rust/crates/sift_connect'
 
-  publish-to-crate-io-sift_stream:
+  publish-to-crates-io-sift_stream:
     runs-on: ubuntu-latest
     name: Publish to crates.io for sift_stream
     needs: rust-ci

--- a/.github/workflows/rust_release_dry_run.yaml
+++ b/.github/workflows/rust_release_dry_run.yaml
@@ -9,7 +9,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/rust_ci.yaml
 
-  publish-to-crate-io-dry-run-sift_rs:
+  publish-to-crates-io-dry-run-sift_rs:
     runs-on: ubuntu-latest
     name: Do a dry run publish to crates.io for sift_rs
     needs: rust-ci
@@ -27,7 +27,7 @@ jobs:
           path: './rust/crates/sift_rs'
           dry-run: true
 
-  publish-to-crate-io-dry-run-sift_error:
+  publish-to-crates-io-dry-run-sift_error:
     runs-on: ubuntu-latest
     name: Do a dry run publish to crates.io for sift_error
     needs: rust-ci
@@ -45,7 +45,7 @@ jobs:
           path: './rust/crates/sift_error'
           dry-run: true
 
-  publish-to-crate-io-dry-run-sift_connect:
+  publish-to-crates-io-dry-run-sift_connect:
     runs-on: ubuntu-latest
     name: Do a dry run publish to crates.io for sift_connect
     needs: rust-ci
@@ -63,7 +63,7 @@ jobs:
           path: './rust/crates/sift_connect'
           dry-run: true
 
-  publish-to-crate-io-dry-run-sift_stream:
+  publish-to-crates-io-dry-run-sift_stream:
     runs-on: ubuntu-latest
     name: Do a dry run publish to crates.io for sift_stream
     needs: rust-ci

--- a/.github/workflows/rust_release_dry_run.yaml
+++ b/.github/workflows/rust_release_dry_run.yaml
@@ -9,9 +9,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/rust_ci.yaml
 
-  publish-to-crate-io-dry-run:
+  publish-to-crate-io-dry-run-sift_rs:
     runs-on: ubuntu-latest
-    name: Do a dry run publish to crates.io
+    name: Do a dry run publish to crates.io for sift_rs
     needs: rust-ci
     environment:
       name: crates.io (dry run)
@@ -24,5 +24,59 @@ jobs:
       - uses: katyo/publish-crates@v2
         with:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          path: './rust'
+          path: './rust/crates/sift_rs'
+          dry-run: true
+
+  publish-to-crate-io-dry-run-sift_error:
+    runs-on: ubuntu-latest
+    name: Do a dry run publish to crates.io for sift_error
+    needs: rust-ci
+    environment:
+      name: crates.io (dry run)
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          path: './rust/crates/sift_error'
+          dry-run: true
+
+  publish-to-crate-io-dry-run-sift_connect:
+    runs-on: ubuntu-latest
+    name: Do a dry run publish to crates.io for sift_connect
+    needs: rust-ci
+    environment:
+      name: crates.io (dry run)
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          path: './rust/crates/sift_connect'
+          dry-run: true
+
+  publish-to-crate-io-dry-run-sift_stream:
+    runs-on: ubuntu-latest
+    name: Do a dry run publish to crates.io for sift_stream
+    needs: rust-ci
+    environment:
+      name: crates.io (dry run)
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          path: './rust/crates/sift_stream'
           dry-run: true

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Build status](https://github.com/sift-stack/sift/actions/workflows/protos_ci.yaml/badge.svg)](https://github.com/sift-stack/sift/actions)
 [![pypi](https://img.shields.io/pypi/v/sift-stack-py)](https://pypi.org/project/sift-stack-py/)
 [![Crates.io](https://img.shields.io/crates/v/sift_rs.svg)](https://crates.io/crates/sift_rs)
+[![Crates.io](https://img.shields.io/crates/v/sift_stream.svg)](https://crates.io/crates/sift_stream)
 [![PkgGoDev](https://pkg.go.dev/badge/mod/github.com/sif-stack/sift/go)](https://pkg.go.dev/github.com/sift-stack/sift/go) 
 
 This repository contains client libraries and protocol buffers to interact with Sift's API in various languages. Each client library contains pre-compiled protocol buffers, but should you wish
@@ -39,7 +40,7 @@ $ pip install sift-stack-py
 #### Rust
 
 ```
-$ cargo add sift_rs
+$ cargo add sift_rs sift_stream
 ```
 
 #### Go

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -3,6 +3,56 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v0.1.0] - April 1, 2025
+
+Official `v0.1.0` release of the following crates:
+- [sift_rs](https://github.com/sift-stack/sift/tree/main/rust/crates/sift_rs)
+- [sift_stream](https://github.com/sift-stack/sift/tree/main/rust/crates/sift_stream)
+- [sift_connect](https://github.com/sift-stack/sift/tree/main/rust/crates/sift_connect)
+- [sift_error](https://github.com/sift-stack/sift/tree/main/rust/crates/sift_error)
+
+Users who were originally using `sift_rs@v0.1.0-rc.2` will need to migrate how they establish gRPC connections
+to Sift.
+
+Originally, the way you would establish a gRPC connection to Sift would look something like this:
+
+```rust
+use sift_rs::{
+    gen::sift::ping::v1::{ping_service_client::PingServiceClient, PingRequest},
+    grpc::{use_sift_channel, SiftChannelConfig},
+};
+use std::{env, error::Error};
+
+#[tokio::main]
+async fn main() {
+    let uri = env::var("SIFT_URI").unwrap();
+    let apikey = env::var("SIFT_API_KEY").unwrap();
+    let grpc_channel = use_sift_channel(SiftChannelConfig { uri, apikey })?;
+    todo!("use grpc_channel");
+```
+
+Now you would do the following:
+
+```rust
+use sift_rs::{
+    Credentials, SiftChannelBuilder,
+    ping::v1::{PingRequest, ping_service_client::PingServiceClient},
+};
+use std::env;
+
+#[tokio::main]
+async fn main() {
+    let credentials = Credentials::Config {
+        apikey: env::var("SIFT_API_KEY").unwrap(),
+        uri: env::var("SIFT_URI").unwrap(),
+    };
+    let grpc_channel = SiftChannelBuilder::new(credentials).build().unwrap();
+    todo!("use grpc_channel");
+}
+```
+
+See the [sift_connect](https://docs.rs/sift_connect/latest/sift_connect/) documentation for more details.
+
 ## [v0.1.0-rc.2] - November 12, 2024
 
 Official release candidate for `v0.1.0` of `sift_rs` which contains compiled protocol buffers


### PR DESCRIPTION
## Changes

Updated the existing GHA workflows to publish our new Rust crates. Also updated the CHANGELOG for our Rust crates with advice on how to migrate from the previous `sift_rs` release candidate to the new minor version we're about to release.