### PR TITLE
rust(docs): update link in README

### DIFF
--- a/rust/crates/sift_stream/README.md
+++ b/rust/crates/sift_stream/README.md
@@ -14,5 +14,5 @@ Here are some features highlights:
 - Optional tracing/logging to monitor the health of your stream and view various ingestion
   performance metrics.
 
-See the [examples](./examples/) directory for demonstrations on how to stream data to Sift using
+See the [examples](https://github.com/sift-stack/sift/tree/main/rust/crates/sift_stream/examples/) directory for demonstrations on how to stream data to Sift using
 `sift_stream`.


### PR DESCRIPTION
## Changes

- Updates a link in the `sift_stream` README to use the full link rather than a relative path. The former works well on Github but [docs.rs](https://docs.rs/crate/sift_stream/0.1.0) doesn't know how to handle that which results in a broken link.