### PR TITLE
python(enhancement): improved error message for wrong asset for data download

### DIFF
--- a/python/lib/sift_py/data/service.py
+++ b/python/lib/sift_py/data/service.py
@@ -110,7 +110,7 @@ class DataService:
 
                 if not targets:
                     raise SiftError(
-                        f"An unexpected error occurred. Expected channel '{fqn}' to have been loaded."
+                        f"An unexpected error occurred. Expected channel '{fqn}' to have been loaded. Are you sure the asset '{asset.name}' has the channel '{fqn}'?"
                     )
                 cqueries = [ChannelQueryPb(channel_id=channel.channel_id) for channel in targets]
 


### PR DESCRIPTION
# Changes

When a user specifies the incorrect asset for the channel they wish to download data for, our error message doesn't indicate to the user that the asset is possibly incorrect. This PR improves the error message.