### PR TITLE
protos: add BytesValues to GetDataResponse

### DIFF
--- a/protos/sift/data/v1/data.proto
+++ b/protos/sift/data/v1/data.proto
@@ -111,6 +111,7 @@ message GetDataResponse {
   //   sift.data.v1.Int64Values
   //   sift.data.v1.Uint32Values
   //   sift.data.v1.Uint64Values
+  //   sift.data.v1.BytesValues
   repeated google.protobuf.Any data = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
@@ -254,4 +255,14 @@ message Uint64Value {
 message Uint64Values {
   Metadata metadata = 1 [(google.api.field_behavior) = REQUIRED];
   repeated Uint64Value values = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+message BytesValue {
+  google.protobuf.Timestamp timestamp = 1 [(google.api.field_behavior) = REQUIRED];
+  bytes value = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+message BytesValues {
+  Metadata metadata = 1 [(google.api.field_behavior) = REQUIRED];
+  repeated BytesValue values = 2 [(google.api.field_behavior) = REQUIRED];
 }

--- a/protos/sift/data/v2/data.proto
+++ b/protos/sift/data/v2/data.proto
@@ -112,6 +112,7 @@ message GetDataResponse {
   //   sift.data.v2.Int64Values
   //   sift.data.v2.Uint32Values
   //   sift.data.v2.Uint64Values
+  //   sift.data.v2.BytesValues
   repeated google.protobuf.Any data = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
@@ -254,4 +255,14 @@ message Uint64Value {
 message Uint64Values {
   Metadata metadata = 1 [(google.api.field_behavior) = REQUIRED];
   repeated Uint64Value values = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+message BytesValue {
+  google.protobuf.Timestamp timestamp = 1 [(google.api.field_behavior) = REQUIRED];
+  bytes value = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+message BytesValues {
+  Metadata metadata = 1 [(google.api.field_behavior) = REQUIRED];
+  repeated BytesValue values = 2 [(google.api.field_behavior) = REQUIRED];
 }

--- a/protos/sift/protobuf_descriptors/v2/channel_parsing_options.proto
+++ b/protos/sift/protobuf_descriptors/v2/channel_parsing_options.proto
@@ -121,7 +121,8 @@ extend google.protobuf.FieldOptions {
 
   // Adding the store_message_as_bytes FieldOption to a message field indicates that the message should be stored as serialized
   // protobuf. When enabled, instead of creating channels for each field in the message, a single bytes channel will be created
-  // for the entire message. This tag will cause a validation error if the field is not a non-repeated message type.
+  // for the entire message. This tag will cause a validation error if the field is not a message type, or is a repeated/map of
+  // a message.
   optional bool store_message_as_bytes = 50010;
 }
 


### PR DESCRIPTION
Changes:
* add BytesValues to GetDataResponse
* re-word store_message_as_bytes for clarity