### PR TITLE
rust(enhancements): public backup decoding, specify run by ID, selective run field updates, allow raw ingest request

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v0.2.0] - April 22, 2025
+
+This change introduces various enhancements from this [pull request](https://github.com/sift-stack/azimuth).
+
+- Method to decode backup file is now public, giving users the ability to write a program that can reingest their backup files manually.
+- `SiftStreamBuilder` can now specify a run by run ID.
+- When attaching a run using RunForm, Optional fields that are None will not cause corresponding fields to zero out in Sift.
+
 ## [v0.1.0] - April 1, 2025
 
 Official `v0.1.0` release of the following crates:

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `SiftStreamBuilder` can now specify a run by run ID.
 - When attaching a run using RunForm, Optional fields that are None will not cause corresponding fields to zero out in Sift.
 - Users can now send raw protobuf ingestion requests through `SiftStream`.
+- Allows users to get a reference to the underlying run attached to `SiftStream` if it exists.
 
 ## [v0.1.0] - April 1, 2025
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -5,8 +5,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [v0.2.0] - April 22, 2025
 
-This change introduces various enhancements from this [pull request](https://github.com/sift-stack/azimuth).
-
 - Method to decode backup file is now public, giving users the ability to write a program that can reingest their backup files manually.
 - `SiftStreamBuilder` can now specify a run by run ID.
 - When attaching a run using RunForm, Optional fields that are None will not cause corresponding fields to zero out in Sift.

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Method to decode backup file is now public, giving users the ability to write a program that can reingest their backup files manually.
 - `SiftStreamBuilder` can now specify a run by run ID.
 - When attaching a run using RunForm, Optional fields that are None will not cause corresponding fields to zero out in Sift.
+- Users can now send raw protobuf ingestion requests through `SiftStream`.
 
 ## [v0.1.0] - April 1, 2025
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1257,7 +1257,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sift_connect"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "dirs",
  "sift_error",
@@ -1268,14 +1268,14 @@ dependencies = [
 
 [[package]]
 name = "sift_error"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "indoc",
 ]
 
 [[package]]
 name = "sift_rs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "sift_stream"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bytesize",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,3 +18,9 @@ repository = "https://github.com/sift-stack/sift/tree/main/rust"
 keywords = ["sift", "siftstack", "sift-stack", "sift_rs", "telemetry"]
 readme = "README.md"
 license = "MIT"
+
+[workspace.dependencies]
+sift_connect = { version = "0.2.0", path = "crates/sift_connect" }
+sift_rs = { version = "0.2.0", path = "crates/sift_rs" }
+sift_error = { version = "0.2.0", path = "crates/sift_error" }
+sift_stream = { version = "0.2.0", path = "crates/sift_stream" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,6 +10,7 @@ members = [
 
 [workspace.package]
 authors = ["Sift Software Engineers <engineering@siftstack.com>"]
+version = "0.2.0"
 edition = "2024"
 categories = ["aerospace", "science::robotics"]
 homepage = "https://github.com/sift-stack/sift/tree/main/rust"

--- a/rust/crates/sift_connect/Cargo.toml
+++ b/rust/crates/sift_connect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sift_connect"
-version = "0.1.0"
+version = { workspace = true }
 description = "A convenient and opinionated way to connect to the Sift API"
 edition = { workspace = true }
 authors = { workspace = true }

--- a/rust/crates/sift_connect/Cargo.toml
+++ b/rust/crates/sift_connect/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 dirs = "6.0.0"
-sift_error = { version = "0.1.0", path = "../sift_error" }
+sift_error = { workspace = true }
 toml = "0.8.20"
 tonic = { version = "^0.12", features = ["tls-native-roots", "tls", "tls-roots", "tls-webpki-roots"] }
 tower = "^0.4"

--- a/rust/crates/sift_error/Cargo.toml
+++ b/rust/crates/sift_error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sift_error"
-version = "0.1.0"
+version = { workspace = true }
 description = "Crate-specific Sift errors"
 edition = { workspace = true }
 authors = { workspace = true }

--- a/rust/crates/sift_rs/Cargo.toml
+++ b/rust/crates/sift_rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sift_rs"
-version = "0.1.0"
+version = { workspace = true }
 description = "General Rust client library for the Sift API"
 edition = { workspace = true }
 authors = { workspace = true }

--- a/rust/crates/sift_rs/Cargo.toml
+++ b/rust/crates/sift_rs/Cargo.toml
@@ -18,8 +18,8 @@ pbjson-types = "^0.7"
 prost = "^0.13"
 prost-types = "^0.13"
 serde = { version = "^1.0" }
-sift_connect = { version = "0.1.0", path = "../sift_connect" }
-sift_error = { version = "0.1.0", path = "../sift_error" }
+sift_connect = { workspace = true }
+sift_error = { workspace = true }
 tonic = { version = "^0.12" }
 
 [dev-dependencies]

--- a/rust/crates/sift_stream/Cargo.toml
+++ b/rust/crates/sift_stream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sift_stream"
-version = "0.1.0"
+version = { workspace = true }
 description = "A robust Sift telemetry streaming library"
 edition = { workspace = true }
 authors = { workspace = true }

--- a/rust/crates/sift_stream/Cargo.toml
+++ b/rust/crates/sift_stream/Cargo.toml
@@ -12,9 +12,9 @@ categories = { workspace = true }
 readme = "README.md"
 
 [dependencies]
-sift_connect = { version = "0.1.0", path = "../sift_connect" }
-sift_error = { version = "0.1.0", path = "../sift_error" }
-sift_rs = { version = "0.1.0", path = "../sift_rs" }
+sift_connect = { workspace = true }
+sift_error = { workspace = true }
+sift_rs = { workspace = true }
 tracing = { version = "0.1.41", optional = true }
 bytesize = { version = "2", optional = true }
 pbjson-types = "^0.7"

--- a/rust/crates/sift_stream/src/stream/builder.rs
+++ b/rust/crates/sift_stream/src/stream/builder.rs
@@ -196,7 +196,7 @@ where
     /// if the `run_form` has changed since the last time it was used.
     async fn load_run_by_form(grpc_channel: SiftChannel, run_form: RunForm) -> Result<Run> {
         #[cfg(feature = "tracing")]
-        let _info_span = tracing::info_span!("load_run_by_form");
+        tracing::info_span!("load_run_by_form");
 
         let mut run_service = new_run_service(grpc_channel);
 

--- a/rust/crates/sift_stream/src/stream/builder.rs
+++ b/rust/crates/sift_stream/src/stream/builder.rs
@@ -418,7 +418,7 @@ impl SiftStreamBuilder<IngestionConfigMode> {
         ingestion_config: IngestionConfigForm,
     ) -> Result<(IngestionConfigPb, Vec<FlowConfig>)> {
         #[cfg(feature = "tracing")]
-        let _info_span = tracing::info_span!("load_ingestion_config");
+        tracing::info_span!("load_ingestion_config");
 
         let mut ingestion_config_service = new_ingestion_config_service(grpc_channel);
 

--- a/rust/crates/sift_stream/src/stream/builder.rs
+++ b/rust/crates/sift_stream/src/stream/builder.rs
@@ -40,12 +40,15 @@ pub const DEFAULT_CHECKPOINT_INTERVAL: Duration = Duration::from_secs(60);
 /// attempts to call [SiftStreamBuilder::build] will panic.
 pub struct SiftStreamBuilder<C> {
     credentials: Credentials,
-    run: Option<RunForm>,
     recovery_strategy: Option<RecoveryStrategy>,
     checkpoint_interval: Duration,
     ingestion_config: Option<IngestionConfigForm>,
     enable_tls: bool,
     kind: PhantomData<C>,
+
+    // Either `run` or `run_id`. If both are provided then the `run_id` will be prioritized.
+    run: Option<RunForm>,
+    run_id: Option<String>,
 }
 
 /// Various recovery strategies users can enable for [SiftStream] when constructing it via
@@ -99,7 +102,10 @@ pub struct IngestionConfigForm {
     pub flows: Vec<FlowConfig>,
 }
 
-/// A form to create a new run or retrieve an existing run based on the `client_key` provided.
+/// A form to create a new run or retrieve an existing run based on the `client_key` provided. This
+/// is used in [SiftStreamBuilder::attach_run]. Note that if there is an existing run with the
+/// given `client_key`, any other fields that are updated in this [RunForm] will be updated in
+/// Sift, with the exception of `Option` fields that are `None`.
 #[derive(Debug)]
 pub struct RunForm {
     pub name: String,
@@ -148,9 +154,20 @@ where
 
     /// Sets the run to use for this period of streaming. Any data sent will be associated with
     /// this run. If the `run` used is an existing run, then any fields that have been updated will
-    /// also be updated in Sift.
+    /// also be updated in Sift. Optional fields that are `None` will be ignored when determining
+    /// which fields to update. This method should not be used if [SiftStreamBuilder::attach_run_id]
+    /// is used. If for whatever reason both are used, [SiftStreamBuilder::attach_run_id] will take
+    /// precedent.
     pub fn attach_run(mut self, run: RunForm) -> SiftStreamBuilder<C> {
         self.run = Some(run);
+        self
+    }
+
+    // Sets the run based on run ID for this period of streaming. Any data sent will be associated
+    // with this run. This method should not be used if [SiftStreamBuilder::attach_run] is used. If
+    // for whatever reason both are used, this will take precedent.
+    pub fn attach_run_id(mut self, run_id: &str) -> SiftStreamBuilder<C> {
+        self.run_id = Some(run_id.into());
         self
     }
 
@@ -160,11 +177,26 @@ where
         self
     }
 
+    /// Retrieves a run by run ID.
+    async fn load_run_by_id(grpc_channel: SiftChannel, run_id: &str) -> Result<Run> {
+        let mut run_service = new_run_service(grpc_channel);
+        let run = run_service.try_get_run_by_id(run_id).await?;
+
+        #[cfg(feature = "tracing")]
+        tracing::info!(
+            run_id = run.run_id,
+            run_name = run.name,
+            "successfully retrieve run by ID",
+        );
+
+        Ok(run)
+    }
+
     /// Retrieves a run or creates a run. If the run exists, this method will also update the run
     /// if the `run_form` has changed since the last time it was used.
-    async fn load_run(grpc_channel: SiftChannel, run_form: RunForm) -> Result<Run> {
+    async fn load_run_by_form(grpc_channel: SiftChannel, run_form: RunForm) -> Result<Run> {
         #[cfg(feature = "tracing")]
-        let _info_span = tracing::info_span!("load_run");
+        let _info_span = tracing::info_span!("load_run_by_form");
 
         let mut run_service = new_run_service(grpc_channel);
 
@@ -197,6 +229,7 @@ where
                 #[cfg(feature = "tracing")]
                 tracing::info!(
                     run_id = run.run_id,
+                    run_name = run.name,
                     "an existing run was found with the provided client-key"
                 );
 
@@ -207,7 +240,8 @@ where
                     update_mask.push("name".to_string());
                     run.name = name;
                 }
-                if description.as_ref() != Some(&run.description) {
+
+                if description.as_ref().is_some_and(|d| d != &run.description) {
                     update_mask.push("description".to_string());
                     run.description = description.unwrap_or_default();
                 }
@@ -225,10 +259,6 @@ where
                             update_mask.push("tags".to_string());
                             run.tags = new_tags;
                         }
-                    }
-                    None if !run.tags.is_empty() => {
-                        update_mask.push("tags".to_string());
-                        run.tags = Vec::new();
                     }
                     _ => (),
                 }
@@ -263,6 +293,7 @@ impl SiftStreamBuilder<IngestionConfigMode> {
             enable_tls: true,
             ingestion_config: None,
             run: None,
+            run_id: None,
             kind: PhantomData,
             checkpoint_interval: DEFAULT_CHECKPOINT_INTERVAL,
             recovery_strategy: None,
@@ -277,6 +308,7 @@ impl SiftStreamBuilder<IngestionConfigMode> {
             checkpoint_interval,
             ingestion_config,
             run,
+            run_id,
             recovery_strategy,
             enable_tls,
             ..
@@ -304,10 +336,14 @@ impl SiftStreamBuilder<IngestionConfigMode> {
         let (ingestion_config, flows) =
             Self::load_ingestion_config(channel.clone(), ingestion_config).await?;
 
-        let run = if let Some(selector) = run {
-            Some(Self::load_run(channel.clone(), selector).await?)
-        } else {
-            None
+        let run = {
+            if let Some(run_id) = run_id.as_ref() {
+                Some(Self::load_run_by_id(channel.clone(), run_id).await?)
+            } else if let Some(selector) = run {
+                Some(Self::load_run_by_form(channel.clone(), selector).await?)
+            } else {
+                None
+            }
         };
 
         let mut backups_manager = None;

--- a/rust/crates/sift_stream/src/stream/mod.rs
+++ b/rust/crates/sift_stream/src/stream/mod.rs
@@ -1,4 +1,5 @@
 use sift_connect::SiftChannel;
+use sift_rs::runs::v2::Run;
 
 /// Concerned with building and configuring and instance of [SiftStream].
 pub mod builder;
@@ -8,6 +9,7 @@ pub mod channel;
 
 /// Implementations for different modes of streaming.
 pub mod mode;
+use mode::ingestion_config::IngestionConfigMode;
 
 /// Concerned with gRPC retries.
 pub mod retry;
@@ -36,3 +38,10 @@ pub struct SiftStream<M: SiftStreamMode> {
 
 /// A trait that defines a particular mode of streaming. Only one more is currently supported.
 pub trait SiftStreamMode {}
+
+impl SiftStream<IngestionConfigMode> {
+    /// Retrieves the attached run if if it exists.
+    pub fn run(&self) -> Option<&Run> {
+        self.mode.run.as_ref()
+    }
+}

--- a/rust/crates/sift_stream/src/stream/mode/ingestion_config.rs
+++ b/rust/crates/sift_stream/src/stream/mode/ingestion_config.rs
@@ -44,9 +44,9 @@ const DATA_BUFFER_CAPACITY: usize = 10_000;
 /// Dependencies specifically for ingestion-config based streaming. Users shouldn't have to
 /// interact with this directly.
 pub struct IngestionConfigMode {
+    pub(crate) run: Option<Run>,
     ingestion_config: IngestionConfig,
     flows_by_name: HashMap<String, Vec<FlowConfig>>,
-    run: Option<Run>,
     checkpoint_interval: Duration,
     streaming_task: Option<JoinHandle<Result<IngestWithConfigDataStreamResponse>>>,
     retry_policy: Option<RetryPolicy>,

--- a/rust/crates/sift_stream/src/stream/mode/ingestion_config.rs
+++ b/rust/crates/sift_stream/src/stream/mode/ingestion_config.rs
@@ -194,7 +194,6 @@ impl SiftStream<IngestionConfigMode> {
                 .with_context(|| format!("unknown flow provided: {message:?}"))
                 .help("try adding this flow to your ingestion config");
         };
-
         let Some(req) = Self::message_to_ingest_req(
             &message,
             &self.mode.ingestion_config.ingestion_config_id,
@@ -206,7 +205,32 @@ impl SiftStream<IngestionConfigMode> {
                 "failed to turn provided flow into a valid ingestion request",
             ));
         };
+        self.send_impl(req).await
+    }
 
+    /// This method offers a way to send data in a manner that's identical to the raw
+    /// [`gRPC service`] for ingestion-config based streaming. Users are expected to handle
+    /// channel value ordering as well as empty values correctly.
+    ///
+    /// ### Important
+    ///
+    /// Note that most users should prefer to use [SiftStream::send]. This method primarily exists
+    /// to make is easier for existing integrations to utilize `sift-stream`.
+    ///
+    /// [`gRPC service`]: https://github.com/sift-stack/sift/blob/main/protos/sift/ingest/v1/ingest.proto#L11
+    pub async fn send_requests<I>(&mut self, requests: I) -> Result<()>
+    where
+        I: IntoIterator<Item = IngestWithConfigDataStreamRequest>,
+    {
+        for req in requests {
+            self.send_impl(req).await?;
+        }
+        Ok(())
+    }
+
+    /// Concerned with sending the actual ingest request to [DataStream] which will then write it
+    /// to the gRPC stream. If backups are enabled, the request will be backed up as well.
+    async fn send_impl(&mut self, req: IngestWithConfigDataStreamRequest) -> Result<()> {
         if self
             .backup_data(&req)
             .await
@@ -242,13 +266,13 @@ impl SiftStream<IngestionConfigMode> {
             Err(SendError(_)) => match self.mode.streaming_task.take() {
                 None => {
                     self.restart_stream_and_backups_manager(false).await?;
-                    Box::pin(self.send(message)).await
+                    Box::pin(self.send_impl(req)).await
                 }
 
                 Some(streaming_task) => match streaming_task.await {
                     Ok(Ok(_)) => {
                         self.restart_stream_and_backups_manager(false).await?;
-                        Box::pin(self.send(message)).await
+                        Box::pin(self.send_impl(req)).await
                     }
                     Ok(Err(err)) => {
                         #[cfg(feature = "tracing")]

--- a/rust/crates/sift_stream/src/stream/mode/test.rs
+++ b/rust/crates/sift_stream/src/stream/mode/test.rs
@@ -265,7 +265,7 @@ fn validate_handling_message_against_multiple_flows_with_same_name_with_atleast_
     assert_eq!(
         Some(Type::Uint32(12)),
         channel_values.next().unwrap().r#type,
-        "quuz should be 12_u32"
+        "quux should be 12_u32"
     );
 }
 

--- a/rust/crates/sift_stream/tests/test_ingestion_config_streaming_ingestion.rs
+++ b/rust/crates/sift_stream/tests/test_ingestion_config_streaming_ingestion.rs
@@ -1,0 +1,145 @@
+use sift_rs::{
+    common::r#type::v1::ChannelDataType,
+    ingest::v1::{
+        IngestWithConfigDataChannelValue,
+        ingest_with_config_data_channel_value::Type as ChannelValue,
+    },
+    ingestion_configs::v2::{ChannelConfig, FlowConfig, IngestionConfig},
+};
+use sift_stream::{IngestionConfigMode, SiftStream};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicU32, Ordering},
+    },
+    time::Duration,
+};
+use tokio_stream::StreamExt;
+
+mod common;
+use common::prelude::*;
+
+struct IngestServiceMock {
+    num_message_received: Arc<AtomicU32>,
+}
+
+#[async_trait]
+impl IngestService for IngestServiceMock {
+    async fn ingest_with_config_data_stream(
+        &self,
+        request: Request<Streaming<IngestWithConfigDataStreamRequest>>,
+    ) -> Result<Response<IngestWithConfigDataStreamResponse>, Status> {
+        let mut data_stream = request.into_inner();
+
+        loop {
+            match data_stream.try_next().await {
+                Ok(Some(_msg)) => {
+                    self.num_message_received.fetch_add(1, Ordering::Relaxed);
+                }
+                // Client has ended the stream and is requesting a checkpoint
+                Ok(None) => {
+                    break;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+
+        Ok(Response::new(IngestWithConfigDataStreamResponse {}))
+    }
+    async fn ingest_arbitrary_protobuf_data_stream(
+        &self,
+        _request: Request<Streaming<IngestArbitraryProtobufDataStreamRequest>>,
+    ) -> Result<Response<IngestArbitraryProtobufDataStreamResponse>, Status> {
+        unimplemented!("not relevant to this test")
+    }
+}
+
+#[tokio::test]
+async fn test_sending_raw_ingest_request() {
+    let messages_received = Arc::new(AtomicU32::default());
+
+    let ingest_service = IngestServiceMock {
+        num_message_received: messages_received.clone(),
+    };
+
+    let (client, server) = common::start_test_ingest_server(ingest_service).await;
+
+    let ingestion_config_id = "ingestion-config-id";
+
+    let ingestion_config = IngestionConfig {
+        ingestion_config_id: ingestion_config_id.into(),
+        client_key: "ingestion-config-client-key".into(),
+        asset_id: "asset-id".into(),
+    };
+
+    let flow_name = "wheel";
+    let angular_velocity = "angular_velocity";
+    let torque = "torque";
+    let log = "log";
+
+    let flows = vec![FlowConfig {
+        name: "wheel".into(),
+        channels: vec![
+            ChannelConfig {
+                name: angular_velocity.into(),
+                data_type: ChannelDataType::Double.into(),
+                ..Default::default()
+            },
+            ChannelConfig {
+                name: torque.into(),
+                data_type: ChannelDataType::Double.into(),
+                ..Default::default()
+            },
+            ChannelConfig {
+                name: log.into(),
+                data_type: ChannelDataType::String.into(),
+                ..Default::default()
+            },
+        ],
+    }];
+
+    let mut sift_stream = SiftStream::<IngestionConfigMode>::new(
+        client,
+        ingestion_config,
+        flows,
+        None,
+        Duration::from_secs(30),
+        None,
+        None,
+    );
+
+    let num_messages = 100;
+
+    let requests = (0..num_messages).map(|i| IngestWithConfigDataStreamRequest {
+        ingestion_config_id: ingestion_config_id.into(),
+        flow: flow_name.into(),
+        timestamp: Some(pbjson_types::Timestamp::default()),
+        channel_values: vec![
+            IngestWithConfigDataChannelValue {
+                r#type: Some(ChannelValue::Double(i as f64)),
+            },
+            IngestWithConfigDataChannelValue {
+                r#type: Some(ChannelValue::Empty(pbjson_types::Empty {})),
+            },
+            IngestWithConfigDataChannelValue {
+                r#type: Some(ChannelValue::String("value".into())),
+            },
+        ],
+        ..Default::default()
+    });
+
+    sift_stream
+        .send_requests(requests)
+        .await
+        .expect("failed to send requests");
+    sift_stream.finish().await.expect("finish call failed");
+
+    assert_eq!(
+        num_messages,
+        messages_received.load(Ordering::Relaxed),
+        "messages sent and received don't match",
+    );
+    server
+        .await
+        .expect("test server shutdown failed unexpectedly");
+}


### PR DESCRIPTION
## Changes

This PR introduces a few small changes:

- [The method to decode a backup is now public](https://github.com/sift-stack/sift/commit/4926ec02b9fc6ca40f503107aa586ffcab18a7ee). This is so that users can write their own programs to re-ingest backup files.
- `SiftStreamBuilder` can now attach runs by run ID.
- When attaching a run using `RunForm`, `Optional` fields that are `None` will not cause corresponding fields to zero out in Sift.
- Allows users to use raw protobuf ingestion requests to send to `SiftStream`
- Allows users to access attached run via `SiftStream`

Additional changes:
- All crates will inherit the work space version
- All crates that depend on one another will reference the workspace dependency definition.

This PR also bumps crates from `v0.1.0` -> `v0.2.0`. Once this is merged We will kick off a new release and publish to crates.io.

## Verification evidence

Existing tests pass.