### PR TITLE
rust(build): downgrade chrono due to arrow crate function name conflict

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v0.2.1] - April 28, 2025
+
+- Downgraded `chrono` from `0.4.40` to `0.4.39` due to function naming collisions introduced
+  in [arrow](https://github.com/apache/arrow-rs/issues/7196).
+
 ## [v0.2.0] - April 22, 2025
 
 - Method to decode backup file is now public, giving users the ability to write a program that can reingest their backup files manually.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -219,9 +219,7 @@ checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
- "wasm-bindgen",
  "windows-link",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 
 [workspace.package]
 authors = ["Sift Software Engineers <engineering@siftstack.com>"]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 categories = ["aerospace", "science::robotics"]
 homepage = "https://github.com/sift-stack/sift/tree/main/rust"
@@ -20,6 +20,10 @@ readme = "README.md"
 license = "MIT"
 
 [workspace.dependencies]
+chrono = { version = "0.4.39", default-features = false, features = ["clock"] }
+pbjson-types = "^0.7"
+tonic = { version = "^0.12" }
+
 sift_connect = { version = "0.2.0", path = "crates/sift_connect" }
 sift_rs = { version = "0.2.0", path = "crates/sift_rs" }
 sift_error = { version = "0.2.0", path = "crates/sift_error" }

--- a/rust/crates/sift_rs/Cargo.toml
+++ b/rust/crates/sift_rs/Cargo.toml
@@ -14,16 +14,16 @@ readme = "README.md"
 [dependencies]
 async-trait = "^0.1"
 pbjson = "^0.7"
-pbjson-types = "^0.7"
+pbjson-types = { workspace = true }
 prost = "^0.13"
 prost-types = "^0.13"
 serde = { version = "^1.0" }
 sift_connect = { workspace = true }
 sift_error = { workspace = true }
-tonic = { version = "^0.12" }
+tonic = { workspace = true }
 
 [dev-dependencies]
-chrono = "0.4.38"
+chrono = { workspace = true }
 rand = "0.8.5"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1.16"

--- a/rust/crates/sift_stream/Cargo.toml
+++ b/rust/crates/sift_stream/Cargo.toml
@@ -17,9 +17,9 @@ sift_error = { workspace = true }
 sift_rs = { workspace = true }
 tracing = { version = "0.1.41", optional = true }
 bytesize = { version = "2", optional = true }
-pbjson-types = "^0.7"
+pbjson-types = { workspace = true }
 tokio = { version = "1.43.0", features = ["rt", "sync", "time", "macros"] }
-chrono = { version = "0.4.40", default-features = false, features = ["clock"] }
+chrono = { workspace = true }
 futures-core = "0.3.31"
 tokio-stream = "0.1.17"
 prost = "^0.13"
@@ -35,7 +35,7 @@ async-trait = "^0.1"
 hyper-util = "0.1.10"
 tempdir = "0.3.7"
 tokio-stream = "0.1.17"
-tonic = "^0.12"
+tonic = { workspace = true }
 tower = { version = "0.5.2", features = ["util"] }
 tracing-subscriber = { version = "0.3.19", features = ["fmt", "env-filter"] }
 tokio = { version = "1.43.0", features = ["rt", "rt-multi-thread", "sync", "time"] }


### PR DESCRIPTION
## Changes

This PR downgrades `chrono` from `0.4.40` to `0.4.39` due to function name collisions between `chrono` and the `arrow` crate. The recommendation right now is for folks to pin to `0.4.39`. See this issue for further details: https://github.com/apache/arrow-rs/issues/7196

Once this is merged, we do a patch bump and release `0.2.1`.

