### PR TITLE
python(fix): Buffered ingestion try_create_ingestion_request handles FlowOrderedChannelValues

### DIFF
--- a/python/lib/sift_py/ingestion/_internal/ingest.py
+++ b/python/lib/sift_py/ingestion/_internal/ingest.py
@@ -174,12 +174,14 @@ class _IngestionServiceImpl:
                     channel_values_by_fqn[fqn] = channel_value
                 else:
                     raise IngestionValidationError(f"Encountered multiple values for {fqn}")
-        except KeyError as e:
-            logger.debug(f"Encountered KeyError, but continuing: {e}")
+        except KeyError:
+            logger.debug(
+                "Encountered KeyError, assuming this is a FlowOrderedChannelValues object and continuing."
+            )
 
         values: List[IngestWithConfigDataChannelValue] = []
 
-        if channel_values_by_fqn:
+        if channel_values_by_fqn:  # Validate data types by channel name
             for channel in flow_config.channels:
                 fqn = channel_fqn(channel)
                 channel_val: Optional[ChannelValue] = channel_values_by_fqn.pop(fqn, None)
@@ -202,7 +204,7 @@ class _IngestionServiceImpl:
                     raise IngestionValidationError(
                         f"Unexpected channel(s) for flow '{flow_name}': {unexpected_channels}"
                     )
-        else:
+        else:  # Validate data types by index, the order of the channels in a FlowOrderedChannelValues object should match the flow config
             for i in range(len(channel_values)):
                 value = channel_values[i]
 

--- a/python/lib/sift_py/ingestion/_internal/ingest.py
+++ b/python/lib/sift_py/ingestion/_internal/ingest.py
@@ -206,19 +206,19 @@ class _IngestionServiceImpl:
                     )
         else:  # Validate data types by index, the order of the channels in a FlowOrderedChannelValues object should match the flow config
             for i in range(len(channel_values)):
-                value = channel_values[i]
+                channel_dict = channel_values[i]
 
-                channel_type = list(value.keys())
+                channel_type = list(channel_dict.keys())
                 if len(channel_type) != 1:
                     raise ValueError(
                         f"Expected exactly one key in flow value, got keys: {channel_type}"
                     )
-                channel_type = channel_type[0]
+                channel_type_key = channel_type[0]
 
                 channel_config = flow_config.channels[i]
-                channel_value = channel_config.try_value_from(value[channel_type])
-                if is_data_type(channel_value, channel_config.data_type):
-                    values.append(channel_value)
+                chan_value = channel_config.try_value_from(channel_dict[channel_type_key])  # type: ignore
+                if is_data_type(chan_value, channel_config.data_type):
+                    values.append(chan_value)
                 else:
                     raise IngestionValidationError(
                         f"Expected value for `{flow_config.channels[i].name}` to be a '{flow_config.channels[i].data_type}'. Instead found {channel_type} in flow {flow_name}."

--- a/python/lib/sift_py/ingestion/_internal/ingest.py
+++ b/python/lib/sift_py/ingestion/_internal/ingest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union, cast
 
 from google.protobuf.timestamp_pb2 import Timestamp
 from sift.ingest.v1.ingest_pb2 import (
@@ -147,92 +147,157 @@ class _IngestionServiceImpl:
         """
         self.run_id = None
 
+    def try_create_ingestion_request_ordered_values(
+        self,
+        flow_name: str,
+        flow_config: FlowConfig,
+        timestamp: datetime,
+        channel_values: List[IngestWithConfigDataChannelValue],
+    ) -> List[IngestWithConfigDataChannelValue]:
+        values: List[IngestWithConfigDataChannelValue] = []
+
+        if len(channel_values) != len(flow_config.channels):
+            raise IngestionValidationError(
+                f"Expected {len(flow_config.channels)} channel values, got {len(channel_values)}."
+            )
+        for i in range(len(channel_values)):
+            channel_dict = channel_values[i]
+
+            channel_type = list(channel_dict.keys())  # type: ignore
+            if len(channel_type) != 1:
+                raise ValueError(
+                    f"Expected exactly one key in flow value, got keys: {channel_type}"
+                )
+            channel_type_key = channel_type[0]
+
+            channel_config = flow_config.channels[i]
+            try:
+                chan_value = channel_config.try_value_from(channel_dict[channel_type_key])  # type: ignore
+                if is_data_type(chan_value, channel_config.data_type):
+                    values.append(chan_value)
+            except ValueError:
+                raise IngestionValidationError(
+                    f"Expected value for `{flow_config.channels[i].name}` to be a '{flow_config.channels[i].data_type}'. Instead found {channel_type} in flow {flow_name}."
+                )
+
+        return values
+
+    def try_create_ingestion_request_channel_values(
+        self,
+        flow_name: str,
+        flow_config: FlowConfig,
+        timestamp: datetime,
+        channel_values: List[ChannelValue],
+    ) -> List[IngestWithConfigDataChannelValue]:
+        channel_values_by_fqn: Dict[str, ChannelValue] = {}
+
+        for channel_value in channel_values:
+            fqn = channel_fqn(channel_value)
+
+            if channel_values_by_fqn.get(fqn, None) is None:
+                channel_values_by_fqn[fqn] = channel_value
+            else:
+                raise IngestionValidationError(f"Encountered multiple values for {fqn}")
+
+        values: List[IngestWithConfigDataChannelValue] = []
+
+        for channel in flow_config.channels:
+            fqn = channel_fqn(channel)
+            channel_val: Optional[ChannelValue] = channel_values_by_fqn.pop(fqn, None)
+
+            if channel_val is None:
+                values.append(empty_value())
+                continue
+
+            value = channel_val["value"]
+
+            if is_data_type(value, channel.data_type):
+                values.append(value)
+            else:
+                raise IngestionValidationError(
+                    f"Expected value for `{channel.name}` to be a '{channel.data_type}'."
+                )
+
+        if len(channel_values_by_fqn) > 0:
+            unexpected_channels = [name for name in channel_values_by_fqn.keys()]
+            raise IngestionValidationError(
+                f"Unexpected channel(s) for flow '{flow_name}': {unexpected_channels}"
+            )
+
+        return values
+
+    def _is_channel_value(self, value: Any) -> bool:
+        """
+        Check if a value is a ChannelValue.
+        ChannelValue has a "value" field and either a "name" or "channel_name" field.
+        """
+        return (
+            isinstance(value, dict)
+            and "value" in value
+            and ("name" in value or "channel_name" in value)
+        )
+
+    def _is_ingest_channel_value(self, value: Any) -> bool:
+        """
+        Check if a value is an IngestWithConfigDataChannelValue.
+        This is a protobuf message with specific fields.
+        """
+        return isinstance(value, IngestWithConfigDataChannelValue) or (
+            isinstance(value, dict)
+            and any(
+                field in value
+                for field in [
+                    "double",
+                    "string",
+                    "int32",
+                    "int64",
+                    "bool",
+                ]
+            )
+        )
+
     def try_create_ingestion_request(
         self,
         flow_name: str,
         timestamp: datetime,
-        channel_values: List[ChannelValue],
+        channel_values: Union[List[ChannelValue], List[IngestWithConfigDataChannelValue]],
     ) -> IngestWithConfigDataStreamRequest:
         """
         Creates an ingestion request for a flow that must exist in `flow_configs_by_name`. This method
         performs a series of client-side validations and will return a `IngestionValidationError` if any validations fail.
+        Channel values can be provided as a list of `sift_py.ingestion.channel.ChannelValue` or a list of values from a
+        `sift_py.ingestion.flow.FlowOrderedChannelValues`.
         """
         flow_config = self.flow_configs_by_name.get(flow_name)
-
         if flow_config is None:
             raise IngestionValidationError(
                 f"A flow config of name '{flow_name}' could not be found."
             )
 
-        channel_values_by_fqn: Dict[str, ChannelValue] = {}
+        if not channel_values:
+            raise IngestionValidationError("Channel values list cannot be empty")
 
-        try:
-            for channel_value in channel_values:
-                fqn = channel_fqn(channel_value)
-
-                if channel_values_by_fqn.get(fqn, None) is None:
-                    channel_values_by_fqn[fqn] = channel_value
-                else:
-                    raise IngestionValidationError(f"Encountered multiple values for {fqn}")
-        except KeyError:
-            logger.debug(
-                "Encountered KeyError, assuming this is a FlowOrderedChannelValues object and continuing."
-            )
-
+        first_value = channel_values[0]
         values: List[IngestWithConfigDataChannelValue] = []
 
-        if channel_values_by_fqn:  # Validate data types by channel name
-            unexpected_channels = [
-                name
-                for name in channel_values_by_fqn.keys()
-                if not any(name == channel_fqn(channel) for channel in flow_config.channels)
-            ]
-            if unexpected_channels:
-                raise IngestionValidationError(
-                    f"Unexpected channel(s) for flow '{flow_name}': {unexpected_channels}"
-                )
-
-            for channel in flow_config.channels:
-                fqn = channel_fqn(channel)
-                channel_val: Optional[ChannelValue] = channel_values_by_fqn.pop(fqn, None)
-
-                if channel_val is None:
-                    values.append(empty_value())
-                    continue
-
-                value = channel_val["value"]
-
-                if is_data_type(value, channel.data_type):
-                    values.append(value)
-                else:
-                    raise IngestionValidationError(
-                        f"Expected value for `{channel.name}` to be a '{channel.data_type}'."
-                    )
-
-        else:  # Validate data types by index, the order of the channels in a FlowOrderedChannelValues object should match the flow config
-            if len(channel_values) != len(flow_config.channels):
-                raise IngestionValidationError(
-                    f"Expected {len(flow_config.channels)} channel values, got {len(channel_values)}."
-                )
-            for i in range(len(channel_values)):
-                channel_dict = channel_values[i]
-
-                channel_type = list(channel_dict.keys())
-                if len(channel_type) != 1:
-                    raise ValueError(
-                        f"Expected exactly one key in flow value, got keys: {channel_type}"
-                    )
-                channel_type_key = channel_type[0]
-
-                channel_config = flow_config.channels[i]
-                try:
-                    chan_value = channel_config.try_value_from(channel_dict[channel_type_key])  # type: ignore
-                    if is_data_type(chan_value, channel_config.data_type):
-                        values.append(chan_value)
-                except ValueError:
-                    raise IngestionValidationError(
-                        f"Expected value for `{flow_config.channels[i].name}` to be a '{flow_config.channels[i].data_type}'. Instead found {channel_type} in flow {flow_name}."
-                    )
+        if self._is_channel_value(first_value):
+            # Handle ChannelValue list
+            values = self.try_create_ingestion_request_channel_values(
+                flow_name, flow_config, timestamp, cast(List[ChannelValue], channel_values)
+            )
+        elif self._is_ingest_channel_value(first_value):
+            # Handle IngestWithConfigDataChannelValue list
+            values = self.try_create_ingestion_request_ordered_values(
+                flow_name,
+                flow_config,
+                timestamp,
+                cast(List[IngestWithConfigDataChannelValue], channel_values),
+            )
+        else:
+            raise ValueError(
+                f"Unknown channel values format: {type(first_value)}. "
+                "Expected either ChannelValue or IngestWithConfigDataChannelValue"
+            )
 
         if timestamp.tzname() != "UTC":
             raise IngestionValidationError(

--- a/python/lib/sift_py/ingestion/_internal/ingest_test.py
+++ b/python/lib/sift_py/ingestion/_internal/ingest_test.py
@@ -416,9 +416,12 @@ def test_ingestion_service_try_create_ingestion_request_ordered_values(mocker: M
         flow_name="mixed_types",
         timestamp=timestamp,
         channel_values=[
-            {"double": 120.0},  # voltage (double)
-            {"int64": 42},  # count (int)
-            {"string": "active"},  # status (string)
+            # voltage (double)
+            {"double": 120.0},  # type: ignore
+            # count (int)
+            {"int64": 42},  # type: ignore
+            # status (string)
+            {"string": "active"},  # type: ignore
         ],
     )
 
@@ -434,9 +437,10 @@ def test_ingestion_service_try_create_ingestion_request_ordered_values(mocker: M
             flow_name="mixed_types",
             timestamp=timestamp,
             channel_values=[
-                {"string": "not a number"},  # wrong type for voltage (should be double)
-                {"int64": 42},
-                {"string": "active"},
+                # wrong type for voltage (should be double)
+                {"string": "not a number"},  # type: ignore
+                {"int64": 42},  # type: ignore
+                {"string": "active"},  # type: ignore
             ],
         )
 
@@ -445,9 +449,10 @@ def test_ingestion_service_try_create_ingestion_request_ordered_values(mocker: M
             flow_name="mixed_types",
             timestamp=timestamp,
             channel_values=[
-                {"double": 120.0},
-                {"int64": 42},
-                {"double": 1.0},  # wrong type for status (should be string)
+                {"double": 120.0},  # type: ignore
+                {"int64": 42},  # type: ignore
+                # wrong type for status (should be string)
+                {"double": 1.0},  # type: ignore
             ],
         )
 
@@ -457,8 +462,8 @@ def test_ingestion_service_try_create_ingestion_request_ordered_values(mocker: M
             flow_name="mixed_types",
             timestamp=timestamp,
             channel_values=[
-                {"double": 120.0},
-                {"int64": 42},
+                {"double": 120.0},  # type: ignore
+                {"int64": 42},  # type: ignore
                 # missing status value
             ],
         )

--- a/python/lib/sift_py/ingestion/_internal/ingest_test.py
+++ b/python/lib/sift_py/ingestion/_internal/ingest_test.py
@@ -357,3 +357,108 @@ def test_ingestion_service_init_with_rules(mocker: MockFixture):
         )
         for rule in svc.rules:
             assert rule.asset_names == ["my-asset"]
+
+
+def test_ingestion_service_try_create_ingestion_request_ordered_values(mocker: MockFixture):
+    """
+    Tests that try_create_ingestion_request correctly handles ordered channel values
+    with different data types when channel_values_by_fqn is empty (using index-based validation).
+    """
+    voltage_channel = ChannelConfig(
+        name="voltage",
+        data_type=ChannelDataType.DOUBLE,
+    )
+    count_channel = ChannelConfig(
+        name="count",
+        data_type=ChannelDataType.INT_64,
+    )
+    status_channel = ChannelConfig(
+        name="status",
+        data_type=ChannelDataType.STRING,
+    )
+
+    telemetry_config = TelemetryConfig(
+        asset_name="my-asset",
+        ingestion_client_key="my-client-key",
+        flows=[
+            FlowConfig(
+                name="mixed_types",
+                channels=[voltage_channel, count_channel, status_channel],
+            ),
+        ],
+    )
+
+    mock_ingestion_config = IngestionConfigPb(
+        ingestion_config_id="ingestion-config-id",
+        asset_id="my-asset-id",
+        client_key="my-client-key",
+    )
+
+    mock_get_or_create_ingestion_config = mocker.patch.object(
+        _IngestionServiceImpl, "_get_or_create_ingestion_config"
+    )
+    mock_get_or_create_ingestion_config.return_value = mock_ingestion_config
+
+    mock_update_flow_configs = mocker.patch.object(_IngestionServiceImpl, "_update_flow_configs")
+    mock_update_flow_configs.return_value = None
+
+    transport_channel = MockChannel()
+
+    with mocker.patch("sift_py.ingestion._internal.ingest.RuleService"):
+        svc = _IngestionServiceImpl(
+            channel=transport_channel,
+            config=telemetry_config,
+        )
+
+    # Test successful case with ordered values of different types
+    timestamp = datetime.now(timezone.utc)
+    request = svc.try_create_ingestion_request(
+        flow_name="mixed_types",
+        timestamp=timestamp,
+        channel_values=[
+            {"double": 120.0},  # voltage (double)
+            {"int64": 42},  # count (int)
+            {"string": "active"},  # status (string)
+        ],
+    )
+
+    assert request.flow == "mixed_types"
+    assert len(request.channel_values) == 3
+    assert request.channel_values[0].double == 120.0
+    assert request.channel_values[1].int64 == 42
+    assert request.channel_values[2].string == "active"
+
+    # Test wrong data type for each channel type
+    with pytest.raises(IngestionValidationError, match="Expected value"):
+        svc.try_create_ingestion_request(
+            flow_name="mixed_types",
+            timestamp=timestamp,
+            channel_values=[
+                {"string": "not a number"},  # wrong type for voltage (should be double)
+                {"int64": 42},
+                {"string": "active"},
+            ],
+        )
+
+    with pytest.raises(IngestionValidationError, match="Expected value"):
+        svc.try_create_ingestion_request(
+            flow_name="mixed_types",
+            timestamp=timestamp,
+            channel_values=[
+                {"double": 120.0},
+                {"int64": 42},
+                {"double": 1.0},  # wrong type for status (should be string)
+            ],
+        )
+
+    # Test wrong number of values
+    with pytest.raises(IngestionValidationError, match="Expected 3 channel values"):
+        svc.try_create_ingestion_request(
+            flow_name="mixed_types",
+            timestamp=timestamp,
+            channel_values=[
+                {"double": 120.0},
+                {"int64": 42},
+                # missing status value
+            ],
+        )

--- a/python/lib/sift_py/ingestion/_internal/ingest_test.py
+++ b/python/lib/sift_py/ingestion/_internal/ingest_test.py
@@ -28,6 +28,7 @@ from sift_py.ingestion._internal.ingestion_config import (
 from sift_py.ingestion.channel import (
     ChannelConfig,
     ChannelDataType,
+    ChannelValue,
     double_value,
     int32_value,
     string_value,
@@ -231,7 +232,7 @@ def test_ingestion_service_try_create_ingestion_request_validations(mocker: Mock
             flow_name="lerg",  # typo
             timestamp=datetime.now(timezone.utc),
             channel_values=[
-                {"channel_name": "logs", "value": string_value("foobar")},
+                ChannelValue(channel_name="logs", value=string_value("foobar")),
             ],
         )
 
@@ -241,8 +242,8 @@ def test_ingestion_service_try_create_ingestion_request_validations(mocker: Mock
             flow_name="log",
             timestamp=datetime.now(timezone.utc),
             channel_values=[
-                {"channel_name": "logs", "value": string_value("foobar")},
-                {"channel_name": "logs", "value": string_value("foobar")},
+                ChannelValue(channel_name="logs", value=string_value("foobar")),
+                ChannelValue(channel_name="logs", value=string_value("foobar")),
             ],
         )
 
@@ -252,7 +253,7 @@ def test_ingestion_service_try_create_ingestion_request_validations(mocker: Mock
             flow_name="log",
             timestamp=datetime.now(timezone.utc),
             channel_values=[
-                {"channel_name": "logs", "value": int32_value(32)},
+                ChannelValue(channel_name="logs", value=int32_value(32)),
             ],
         )
 
@@ -262,7 +263,7 @@ def test_ingestion_service_try_create_ingestion_request_validations(mocker: Mock
             flow_name="log",
             timestamp=datetime.now(timezone.utc),
             channel_values=[
-                {"channel_name": "voltage", "value": double_value(32)},
+                ChannelValue(channel_name="voltage", value=double_value(32)),
             ],
         )
 

--- a/python/lib/sift_py/ingestion/service.py
+++ b/python/lib/sift_py/ingestion/service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from sift.ingest.v1.ingest_pb2 import (
     IngestWithConfigDataChannelValue,
@@ -83,7 +83,7 @@ class IngestionService(_IngestionServiceImpl):
         self,
         flow_name: str,
         timestamp: datetime,
-        channel_values: List[ChannelValue],
+        channel_values: Union[List[ChannelValue], List[IngestWithConfigDataChannelValue]],
     ) -> IngestWithConfigDataStreamRequest:
         """
         Creates an `IngestWithConfigDataStreamRequest`, i.e. a flow, given a `flow_name` and a


### PR DESCRIPTION
When using [`FlowOrderedChannelValues`](https://github.com/sift-stack/sift/blob/b6fc5fdefda9718850b03da6303944de6db30c90/python/lib/sift_py/ingestion/flow.py#L64) for ingestion ([for example](https://github.com/sift-stack/azimuth/blob/main/customer/mach_industries/scripts/ulog/ulg_buffered_stream.py#L104)) the client side validation the ingestion service implements for `try_create_ingestion_request` cannot handle `channel_values` already being provided as a `List[IngestWithConfigDataChannelValue]`. 

We can still do client side validation here by ensuring the types provided in the `FlowOrderedChannelValues` aligns with the data types expected in the flow config though. So this change will make it so `try_create_ingestion_request` will:
- Try to fetch the fully qualified channel name (the original behavior), but catch the error if this fails and assume we're dealing with a `List[IngestWithConfigDataChannelValue]`
- Validate the datatypes in the given `List[IngestWithConfigDataChannelValue]` match the flow config expected types