### PR TITLE
python(bug): Fix IngestService bugs

### DIFF
--- a/python/lib/sift_py/ingestion/_internal/ingest.py
+++ b/python/lib/sift_py/ingestion/_internal/ingest.py
@@ -417,7 +417,9 @@ class _IngestionServiceImpl:
                 # Found a channel for this flow that doesn't exist in Sift based on channel
                 # fully-qualified name and data-type. Create a new flow.
                 if not config_channel_identifier(config_channel) in sift_channel_identifiers:
-                    raise IngestionValidationError("Encountered duplicate flow with mismatched channels")
+                    raise IngestionValidationError(
+                        "Encountered duplicate flow with mismatched channels"
+                    )
 
         if len(flows_to_create) > 0:
             create_flow_configs(channel, ingestion_config_id, flows_to_create)

--- a/python/lib/sift_py/ingestion/_internal/ingest.py
+++ b/python/lib/sift_py/ingestion/_internal/ingest.py
@@ -374,7 +374,7 @@ class _IngestionServiceImpl:
     ):
         """
         Compares local flows from a telemetry config with the flows registered in Sift. If a local flow
-        contains channels that isn't in Sift then this will create a new flow containing those channels.
+        contains channels that isn't in Sift then this will fail.
         """
         config_flows = telemetry_config.flows
 
@@ -417,8 +417,7 @@ class _IngestionServiceImpl:
                 # Found a channel for this flow that doesn't exist in Sift based on channel
                 # fully-qualified name and data-type. Create a new flow.
                 if not config_channel_identifier(config_channel) in sift_channel_identifiers:
-                    flows_to_create.append(config_flow)
-                    break
+                    raise IngestionValidationError("Encountered duplicate flow with mismatched channels")
 
         if len(flows_to_create) > 0:
             create_flow_configs(channel, ingestion_config_id, flows_to_create)

--- a/python/lib/sift_py/ingestion/_internal/ingest_test.py
+++ b/python/lib/sift_py/ingestion/_internal/ingest_test.py
@@ -215,6 +215,9 @@ def test_ingestion_service_try_create_ingestion_request_validations(mocker: Mock
     )
     mock_get_or_create_ingestion_config.return_value = mock_ingestion_config
 
+    mock_ingestion_config_flows = mocker.patch("sift_py.ingestion._internal.ingest.get_ingestion_config_flows")
+    mock_ingestion_config_flows.return_value = [f.as_pb(FlowConfigPb) for f in telemetry_config.flows]
+
     mock_update_flow_configs = mocker.patch.object(_IngestionServiceImpl, "_update_flow_configs")
     mock_update_flow_configs.return_value = None
 
@@ -349,6 +352,9 @@ def test_ingestion_service_init_with_rules(mocker: MockFixture):
         rules=[rule_on_voltage, rule_on_pressure],
     )
 
+    mock_ingestion_config_flows = mocker.patch("sift_py.ingestion._internal.ingest.get_ingestion_config_flows")
+    mock_ingestion_config_flows.return_value = [f.as_pb(FlowConfigPb) for f in telemetry_config.flows]
+
     mock_channel = MockChannel()
 
     with mocker.patch("sift_py.ingestion._internal.ingest.RuleService"):
@@ -388,6 +394,9 @@ def test_ingestion_service_try_create_ingestion_request_ordered_values(mocker: M
             ),
         ],
     )
+
+    mock_ingestion_config_flows = mocker.patch("sift_py.ingestion._internal.ingest.get_ingestion_config_flows")
+    mock_ingestion_config_flows.return_value = [f.as_pb(FlowConfigPb) for f in telemetry_config.flows]
 
     mock_ingestion_config = IngestionConfigPb(
         ingestion_config_id="ingestion-config-id",

--- a/python/lib/sift_py/ingestion/_internal/ingest_test.py
+++ b/python/lib/sift_py/ingestion/_internal/ingest_test.py
@@ -215,8 +215,12 @@ def test_ingestion_service_try_create_ingestion_request_validations(mocker: Mock
     )
     mock_get_or_create_ingestion_config.return_value = mock_ingestion_config
 
-    mock_ingestion_config_flows = mocker.patch("sift_py.ingestion._internal.ingest.get_ingestion_config_flows")
-    mock_ingestion_config_flows.return_value = [f.as_pb(FlowConfigPb) for f in telemetry_config.flows]
+    mock_ingestion_config_flows = mocker.patch(
+        "sift_py.ingestion._internal.ingest.get_ingestion_config_flows"
+    )
+    mock_ingestion_config_flows.return_value = [
+        f.as_pb(FlowConfigPb) for f in telemetry_config.flows
+    ]
 
     mock_update_flow_configs = mocker.patch.object(_IngestionServiceImpl, "_update_flow_configs")
     mock_update_flow_configs.return_value = None
@@ -352,8 +356,12 @@ def test_ingestion_service_init_with_rules(mocker: MockFixture):
         rules=[rule_on_voltage, rule_on_pressure],
     )
 
-    mock_ingestion_config_flows = mocker.patch("sift_py.ingestion._internal.ingest.get_ingestion_config_flows")
-    mock_ingestion_config_flows.return_value = [f.as_pb(FlowConfigPb) for f in telemetry_config.flows]
+    mock_ingestion_config_flows = mocker.patch(
+        "sift_py.ingestion._internal.ingest.get_ingestion_config_flows"
+    )
+    mock_ingestion_config_flows.return_value = [
+        f.as_pb(FlowConfigPb) for f in telemetry_config.flows
+    ]
 
     mock_channel = MockChannel()
 
@@ -395,8 +403,12 @@ def test_ingestion_service_try_create_ingestion_request_ordered_values(mocker: M
         ],
     )
 
-    mock_ingestion_config_flows = mocker.patch("sift_py.ingestion._internal.ingest.get_ingestion_config_flows")
-    mock_ingestion_config_flows.return_value = [f.as_pb(FlowConfigPb) for f in telemetry_config.flows]
+    mock_ingestion_config_flows = mocker.patch(
+        "sift_py.ingestion._internal.ingest.get_ingestion_config_flows"
+    )
+    mock_ingestion_config_flows.return_value = [
+        f.as_pb(FlowConfigPb) for f in telemetry_config.flows
+    ]
 
     mock_ingestion_config = IngestionConfigPb(
         ingestion_config_id="ingestion-config-id",

--- a/python/lib/sift_py/ingestion/_service_test.py
+++ b/python/lib/sift_py/ingestion/_service_test.py
@@ -297,7 +297,9 @@ def test_ingestion_service_modify_existing_channel_configs(mocker: MockFixture):
         telemetry_config.ingestion_client_key,
         None,
     )
-    assert ingestion_service.flow_configs_by_name[flow_a.name].channels[0] == channel_a
+    assert ingestion_service.flow_configs_by_name[flow_a.name].channels[0].name == channel_a.name
+    assert ingestion_service.flow_configs_by_name[flow_a.name].channels[0].component == channel_a.component
+    assert ingestion_service.flow_configs_by_name[flow_a.name].channels[0].data_type == channel_a.data_type
 
     # Modify an existing channel but don't modify flow
     channel_a.data_type = ChannelDataType.STRING
@@ -308,18 +310,15 @@ def test_ingestion_service_modify_existing_channel_configs(mocker: MockFixture):
     mock_get_ingestion_config_by_client_key.reset_mock()
     mock_get_ingestion_config_by_client_key.return_value = mock_ingestion_config
 
-    # Re-initialize ingestion service
-    ingestion_service = IngestionService(
-        channel=mock_channel,
-        config=telemetry_config,
-    )
-
     # Assert that we are trying to create a new flow with the same name as `flow_a`
-    # but with a new channel.
-    mock_create_flow_configs.assert_called_once_with(
-        mock_channel, mock_ingestion_config.ingestion_config_id, [flow_a]
-    )
-    assert ingestion_service.flow_configs_by_name[flow_a.name].channels[0] == channel_a
+    # but with a new channel, an error is raised.
+
+    # Re-initialize ingestion service
+    with pytest.raises(IngestionValidationError):
+        ingestion_service = IngestionService(
+            channel=mock_channel,
+            config=telemetry_config,
+        )
 
     # Okay now what happens if someone were to change the channel config back to the original..
 
@@ -336,7 +335,9 @@ def test_ingestion_service_modify_existing_channel_configs(mocker: MockFixture):
 
     # We shouldn't be creating a new flow, should re-use an existing flow.
     mock_create_flow_configs.assert_not_called()
-    assert ingestion_service.flow_configs_by_name[flow_a.name].channels[0] == channel_a
+    assert ingestion_service.flow_configs_by_name[flow_a.name].channels[0].name == channel_a.name
+    assert ingestion_service.flow_configs_by_name[flow_a.name].channels[0].component == channel_a.component
+    assert ingestion_service.flow_configs_by_name[flow_a.name].channels[0].data_type == channel_a.data_type
 
 
 def test_ingestion_service_register_new_flow(mocker: MockFixture):

--- a/python/lib/sift_py/ingestion/_service_test.py
+++ b/python/lib/sift_py/ingestion/_service_test.py
@@ -298,8 +298,14 @@ def test_ingestion_service_modify_existing_channel_configs(mocker: MockFixture):
         None,
     )
     assert ingestion_service.flow_configs_by_name[flow_a.name].channels[0].name == channel_a.name
-    assert ingestion_service.flow_configs_by_name[flow_a.name].channels[0].component == channel_a.component
-    assert ingestion_service.flow_configs_by_name[flow_a.name].channels[0].data_type == channel_a.data_type
+    assert (
+        ingestion_service.flow_configs_by_name[flow_a.name].channels[0].component
+        == channel_a.component
+    )
+    assert (
+        ingestion_service.flow_configs_by_name[flow_a.name].channels[0].data_type
+        == channel_a.data_type
+    )
 
     # Modify an existing channel but don't modify flow
     channel_a.data_type = ChannelDataType.STRING
@@ -336,8 +342,14 @@ def test_ingestion_service_modify_existing_channel_configs(mocker: MockFixture):
     # We shouldn't be creating a new flow, should re-use an existing flow.
     mock_create_flow_configs.assert_not_called()
     assert ingestion_service.flow_configs_by_name[flow_a.name].channels[0].name == channel_a.name
-    assert ingestion_service.flow_configs_by_name[flow_a.name].channels[0].component == channel_a.component
-    assert ingestion_service.flow_configs_by_name[flow_a.name].channels[0].data_type == channel_a.data_type
+    assert (
+        ingestion_service.flow_configs_by_name[flow_a.name].channels[0].component
+        == channel_a.component
+    )
+    assert (
+        ingestion_service.flow_configs_by_name[flow_a.name].channels[0].data_type
+        == channel_a.data_type
+    )
 
 
 def test_ingestion_service_register_new_flow(mocker: MockFixture):


### PR DESCRIPTION
### Issue 1:
Originally, this only initialized with flows from the `TelemetryConfig` while ignoring any flows that may have been added at runtime with `create_flows` or `try_create_flows`.

I added some additional flows previously to running this:
```
ingestion_service = IngestionService(
            channel,
            telemetry_config,
            end_stream_on_error=True, 
        )
print(ingestion_service.flow_configs_by_name)
```

Before this change it only listed the flows in the TelemetryConfig:
```
{'readings': <sift_py.ingestion.flow.FlowConfig object at 0x10439eba0>, 'voltage': <sift_py.ingestion.flow.FlowConfig object at 0x10479c410>, 'gpio_channel': <sift_py.ingestion.flow.FlowConfig object at 0x10479c550>, 'logs': <sift_py.ingestion.flow.FlowConfig object at 0x1047a02b0>}
```

After this change it list all flows that have been added:
```
{'readings': <sift_py.ingestion.flow.FlowConfig object at 0x103ee6d70>, 'voltage': <sift_py.ingestion.flow.FlowConfig object at 0x103f68950>, 'gpio_channel': <sift_py.ingestion.flow.FlowConfig object at 0x103f74f30>, 'logs': <sift_py.ingestion.flow.FlowConfig object at 0x103f75040>, 'new_flow': <sift_py.ingestion.flow.FlowConfig object at 0x103f9c550>, 'brand_new_flow': <sift_py.ingestion.flow.FlowConfig object at 0x103f9c650>, 'new_flow2': <sift_py.ingestion.flow.FlowConfig object at 0x103f79a90>}
```

### Issue 2:
When updating an existing `TelemetryConfig` such that the flows change, the `IngestService` should raise an error if the config is different from what's in Sift.

I ran the ingestion example, then ran it again after modifying the data type for one of the channels
Before:
```
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.ALREADY_EXISTS
	details = "already exists (1cd7f239-9acd-4e61-8a4d-c0e90a8737da)"
	debug_error_string = "UNKNOWN:Error received from peer  {grpc_message:"already exists (1cd7f239-9acd-4e61-8a4d-c0e90a8737da)", grpc_status:6, created_time:"2025-05-12T21:19:05.009812-07:00"}"
>
```

After:
```
sift_py.ingestion._internal.error.IngestionValidationError: Encountered duplicate flow with mismatched channels
``` 
### Other:
Also, update the docstring to not indicate that is it possible to overwrite flows.

