### PR TITLE
protos: update store_message_as_bytes description

### DIFF
--- a/protos/sift/protobuf_descriptors/v2/channel_parsing_options.proto
+++ b/protos/sift/protobuf_descriptors/v2/channel_parsing_options.proto
@@ -121,8 +121,7 @@ extend google.protobuf.FieldOptions {
 
   // Adding the store_message_as_bytes FieldOption to a message field indicates that the message should be stored as serialized
   // protobuf. When enabled, instead of creating channels for each field in the message, a single bytes channel will be created
-  // for the entire message. This tag will cause a validation error if the field is not a message type, or is a repeated/map of
-  // a message.
+  // for the entire message. This tag will cause a validation error if the field is not a message type.
   optional bool store_message_as_bytes = 50010;
 }
 


### PR DESCRIPTION
update description of the `store_message_as_bytes` FieldOption to reflect the fact that it can be used on lists and maps now