### PR TITLE
python(bugfix): add fallback when retrieving flows

### DIFF
--- a/python/lib/sift_py/ingestion/_internal/ingestion_config.py
+++ b/python/lib/sift_py/ingestion/_internal/ingestion_config.py
@@ -1,5 +1,6 @@
 from typing import List, Optional, cast
 
+import grpc
 from sift.ingestion_configs.v2.ingestion_configs_pb2 import (
     CreateIngestionConfigFlowsRequest,
     CreateIngestionConfigFlowsResponse,
@@ -78,7 +79,9 @@ def get_ingestion_config_flow_names(
 
 
 def get_ingestion_config_flows(
-    channel: SiftChannel, ingestion_config_id: str
+    channel: SiftChannel,
+    ingestion_config_id: str,
+    page_size: int = 1_000,
 ) -> List[FlowConfigPb]:
     svc = IngestionConfigServiceStub(channel)
 
@@ -86,10 +89,15 @@ def get_ingestion_config_flows(
 
     req = ListIngestionConfigFlowsRequest(
         ingestion_config_id=ingestion_config_id,
-        page_size=1_000,
+        page_size=page_size,
         filter="",
     )
-    res = cast(ListIngestionConfigFlowsResponse, svc.ListIngestionConfigFlows(req))
+    try:
+        res = cast(ListIngestionConfigFlowsResponse, svc.ListIngestionConfigFlows(req))
+    except grpc.RpcError as e:
+        if e.code() != grpc.StatusCode.RESOURCE_EXHAUSTED or page_size == 1:
+            raise
+        return get_ingestion_config_flows(channel, ingestion_config_id, page_size=1)
 
     for flow in res.flows:
         flows.append(flow)
@@ -99,7 +107,7 @@ def get_ingestion_config_flows(
     while len(page_token) > 0:
         req = ListIngestionConfigFlowsRequest(
             ingestion_config_id=ingestion_config_id,
-            page_size=1_000,
+            page_size=page_size,
             filter="",
             page_token=page_token,
         )


### PR DESCRIPTION
Fall back to using 1 page when getting flows from an ingestion config.

### Verification:
I created a large ingestion config then ran the following to retrieve and print out the number of flows in that config:
```
if __name__ == "__main__":
    load_dotenv()
    channel_config: SiftChannelConfig = {
        "apikey": os.getenv("SIFT_API_KEY"),
        "uri": os.getenv("BASE_URI"),
    }
    with use_sift_channel(channel_config) as channel:
        print(len(get_ingestion_config_flows(channel, "8613786e-b42f-4afc-9a6e-ec4c4cdbc5d3")))
```

Before, we get this resource exhaustion error:
```
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.RESOURCE_EXHAUSTED
	details = "CLIENT: Received message larger than max (14898020 vs. 4194304)"
	debug_error_string = "UNKNOWN:Error received from peer ipv6:%5B::1%5D:50051 {created_time:"2025-05-14T12:41:56.529649-07:00", grpc_status:8, grpc_message:"CLIENT: Received message larger than max (14898020 vs. 4194304)"}"
>
```

After, the entire ingestion config is returned:
```
179
```