### PR TITLE
python(feat): Allow creating multiple new flows at the same time

### DIFF
--- a/python/lib/sift_py/ingestion/_internal/ingest.py
+++ b/python/lib/sift_py/ingestion/_internal/ingest.py
@@ -337,26 +337,33 @@ class _IngestionServiceImpl:
             end_stream_on_validation_error=self.end_stream_on_error,
         )
 
-    def try_create_flow(self, flow_config: FlowConfig):
+    def try_create_flow(self, *flow_configs: FlowConfig):
         """
         Tries to create a new flow at runtime. Will raise an `IngestionValidationError` if there already exists
         a flow with the name of the `flow_config` argument.
         """
-
-        if flow_config.name in self.flow_configs_by_name:
-            raise IngestionValidationError(
-                f"There is already a flow with name '{flow_config.name}'."
-            )
+        for flow_config in flow_configs:
+            if flow_config.name in self.flow_configs_by_name:
+                raise IngestionValidationError(
+                    f"There is already a flow with name '{flow_config.name}'."
+                )
 
         create_flow_configs(
             self.transport_channel,
             self.ingestion_config.ingestion_config_id,
-            [flow_config],
+            flow_configs,
         )
 
-        self.flow_configs_by_name[flow_config.name] = flow_config
+        for flow_config in flow_configs:
+            self.flow_configs_by_name[flow_config.name] = flow_config
 
-    def create_flow(self, flow_config: FlowConfig):
+    def try_create_flows(self, *flow_configs: FlowConfig):
+        """
+        See `try_create_flows`.
+        """
+        return self.try_create_flow(*flow_configs)
+
+    def create_flow(self, *flow_configs: FlowConfig):
         """
         Like `try_create_flow` but will not do any client side validation and
         raise `IngestionValidationError`.
@@ -364,9 +371,16 @@ class _IngestionServiceImpl:
         create_flow_configs(
             self.transport_channel,
             self.ingestion_config.ingestion_config_id,
-            [flow_config],
+            flow_configs,
         )
-        self.flow_configs_by_name[flow_config.name] = flow_config
+        for flow_config in flow_configs:
+            self.flow_configs_by_name[flow_config.name] = flow_config
+
+    def create_flows(self, *flow_configs: FlowConfig):
+        """
+        See `create_flow`.
+        """
+        return self.create_flow(*flow_configs)
 
     @staticmethod
     def _update_flow_configs(

--- a/python/lib/sift_py/ingestion/_internal/ingestion_config.py
+++ b/python/lib/sift_py/ingestion/_internal/ingestion_config.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, cast
+from typing import List, Optional, Sequence, cast
 
 import grpc
 from sift.ingestion_configs.v2.ingestion_configs_pb2 import (
@@ -124,7 +124,7 @@ def get_ingestion_config_flows(
 def create_flow_configs(
     channel: SiftChannel,
     ingestion_config_id: str,
-    flow_configs: List[FlowConfig],
+    flow_configs: Sequence[FlowConfig],
 ):
     """
     Adds flow configs to an existing ingestion config.

--- a/python/lib/sift_py/ingestion/_service_test.py
+++ b/python/lib/sift_py/ingestion/_service_test.py
@@ -407,7 +407,7 @@ def test_ingestion_service_register_new_flow(mocker: MockFixture):
     ingestion_service.try_create_flow(new_flow_config)
 
     mock_create_flow_configs.assert_called_once_with(
-        mock_channel, mock_ingestion_config.ingestion_config_id, [new_flow_config]
+        mock_channel, mock_ingestion_config.ingestion_config_id, (new_flow_config,)
     )
     assert ingestion_service.flow_configs_by_name["my_new_flow"] == new_flow_config
 

--- a/python/lib/sift_py/ingestion/service.py
+++ b/python/lib/sift_py/ingestion/service.py
@@ -216,17 +216,28 @@ class IngestionService(_IngestionServiceImpl):
         """
         return BufferedIngestionService(self, buffer_size, flush_interval_sec, on_error)
 
-    def create_flow(self, flow_config: FlowConfig):
+    def create_flow(self, *flow_config: FlowConfig):
         """
-        Like `try_create_new_flow` but will automatically overwrite any existing flow config with `flow_config` if they
-        share the same name. If you'd an exception to be raise in the case of a name collision then see `try_create_new_flow`.
+        Like `try_create_new_flow` but will not raise an `IngestionValidationError` if there already exists
+        a flow with the name of the `flow_config` argument.
         """
-        super().create_flow(flow_config)
+        super().create_flow(*flow_config)
 
-    def try_create_flow(self, flow_config: FlowConfig):
+    def create_flows(self, *flow_config: FlowConfig):
+        """
+        See `create_flow`.
+        """
+        super().create_flow(*flow_config)
+
+    def try_create_flow(self, *flow_config: FlowConfig):
         """
         Tries to create a new flow at runtime. Will raise an `IngestionValidationError` if there already exists
-        a flow with the name of the `flow_config` argument. If you'd like to overwrite any flow configs with that
-        have the same name as the provided `flow_config`, then see `create_new_flow`.
+        a flow with the name of the `flow_config` argument.
         """
-        super().try_create_flow(flow_config)
+        super().try_create_flow(*flow_config)
+
+    def try_create_flows(self, *flow_config: FlowConfig):
+        """
+        See `try_create_flows`.
+        """
+        super().try_create_flow(*flow_config)


### PR DESCRIPTION
* Added the ability to create multiple new flows in the same call of `try_crew_flow` since the underlying API call already supports that.
* Add plural versions of the existing functions to match the naming of other functions in this class.


Verification:
Ran this modified example:
```
with use_sift_channel(sift_channel_config) as channel:
    tlm_config = TelemetryConfig.try_from_yaml("telemetry.yml")
    cmd_config = TelemetryConfig.try_from_yaml("command.yml")

    empty_config = TelemetryConfig(
        asset_name="NostromoLV426", ingestion_client_key=tlm_config.ingestion_client_key
    )
    ingestion_service = IngestionService(channel, empty_config)

    ingestion_service.try_create_flow(*(tlm_config.flows + cmd_config.flows))

    print(ingestion_service.flow_configs_by_name)
```
Output:
```
{ 
  'readings': <sift_py.ingestion.flow.FlowConfig object at 0x104059010>, 
  'voltage': <sift_py.ingestion.flow.FlowConfig object at 0x1040c4b90>, 
  'gpio_channel': <sift_py.ingestion.flow.FlowConfig object at 0x1040c4910>, 
  'logs': <sift_py.ingestion.flow.FlowConfig object at 0x1040b4510>, 
  'cmds': <sift_py.ingestion.flow.FlowConfig object at 0x1040b43e0>
}
```
flows from both telem configs appear as expected.