### PR TITLE
python(bug): Retry on internal errors

### DIFF
--- a/python/lib/sift_py/grpc/_retry.py
+++ b/python/lib/sift_py/grpc/_retry.py
@@ -32,6 +32,7 @@ class RetryPolicy:
                     "maxBackoff": "5s",
                     "backoffMultiplier": 4,
                     "retryableStatusCodes": [
+                        StatusCode.INTERNAL.name,
                         StatusCode.UNKNOWN.name,
                         StatusCode.UNAVAILABLE.name,
                         StatusCode.ABORTED.name,


### PR DESCRIPTION
Created a simple gRPC server that returns internal errors for the first 3 calls, then a successful response on the 4 call.
Here is the client code used to test:
```
with use_sift_channel(channel_config) as channel:
    svc = IngestionConfigServiceStub(channel)
    req = ListIngestionConfigsRequest(
        filter=f'client_key=="test-key"',
    )
    res = svc.ListIngestionConfigs(req)
    print(res)
```
### Before:
The error raises the RPC error on the first try.
**Server:**
```
2025/06/02 09:58:20 Starting mock Sift gRPC server on localhost:50051
2025/06/02 09:58:30 Received ListIngestionConfigs request
```
**Client:**
```
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.INTERNAL
	details = "test internal error"
	debug_error_string = "UNKNOWN:Error received from peer  {created_time:"2025-06-02T09:58:30.857761-07:00", grpc_status:13, grpc_message:"test internal error"}"
>
```

### After:
With this change, the client retries
**Server:**
```
2025/06/02 10:02:25 Starting mock Sift gRPC server on localhost:50051
2025/06/02 10:02:27 Received ListIngestionConfigs request
2025/06/02 10:02:27 Received ListIngestionConfigs request
2025/06/02 10:02:27 Received ListIngestionConfigs request
2025/06/02 10:02:28 Received ListIngestionConfigs request
```

**Client:**
```
ingestion_configs {
  ingestion_config_id: "test-ingestion-config-id"
}
```

Re-ran the test with a server that only returns internal error and made sure the client eventually raised the exception.
**Server:**
```
2025/06/02 10:03:27 Starting mock Sift gRPC server on localhost:50051
2025/06/02 10:03:28 Received ListIngestionConfigs request
2025/06/02 10:03:28 Received ListIngestionConfigs request
2025/06/02 10:03:28 Received ListIngestionConfigs request
2025/06/02 10:03:29 Received ListIngestionConfigs request
2025/06/02 10:03:33 Received ListIngestionConfigs request
```

**Client:**
```
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.INTERNAL
	details = "test internal error"
	debug_error_string = "UNKNOWN:Error received from peer  {created_time:"2025-06-02T10:03:33.319801-07:00", grpc_status:13, grpc_message:"test internal error"}"
>
```