### PR TITLE
FD-89: Add optional metadata to create_run/attach_run and create asse…

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -76,5 +76,5 @@ cmake --build . -j 4
 
 5. Run the example with required environment variables:
 ```
-$ SIFT_URL=<grpc_api_url>:443 SIFT_API_KEY=<api_key> SIFT_ORGANIZATION_ID=<organization_id> ./Example
+$ BASE_URI=<grpc_api_url>:443 SIFT_API_KEY=<api_key> SIFT_ORGANIZATION_ID=<organization_id> ./Example
 ```

--- a/cpp/ingestion/ingest.cc
+++ b/cpp/ingestion/ingest.cc
@@ -142,12 +142,12 @@ void GetTimestamp(std::chrono::time_point<std::chrono::system_clock> time, googl
 
 int main()
 {
-    const char *apiUrl = std::getenv("SIFT_URL");
+    const char *apiUrl = std::getenv("BASE_URI");
     const char *apiKey = std::getenv("SIFT_API_KEY");
     const char *organizationId = std::getenv("SIFT_ORGANIZATION_ID");
     if (!apiUrl)
     {
-        std::cerr << "Run with SIFT_URL environment variable" << std::endl;
+        std::cerr << "Run with BASE_URI environment variable" << std::endl;
         exit(1);
     }
     if (!apiKey)

--- a/cpp/ping/ping.cc
+++ b/cpp/ping/ping.cc
@@ -69,11 +69,11 @@ void ExitOnError(const std::string &msg, const Status &status)
 
 int main()
 {
-    const char *apiUrl = std::getenv("SIFT_URL");
+    const char *apiUrl = std::getenv("BASE_URI");
     const char *apiKey = std::getenv("SIFT_API_KEY");
     if (!apiUrl)
     {
-        std::cerr << "Run with SIFT_URL environment variable" << std::endl;
+        std::cerr << "Run with BASE_URI environment variable" << std::endl;
         exit(1);
     }
     if (!apiKey)

--- a/python/examples/assets/.env-example
+++ b/python/examples/assets/.env-example
@@ -1,0 +1,2 @@
+BASE_URI=
+SIFT_API_KEY=

--- a/python/examples/assets/README.md
+++ b/python/examples/assets/README.md
@@ -1,0 +1,5 @@
+# Update an asset
+
+main.py has a runable example that modifies the test asset NostromoLV426.
+Run an ingestion example to setup an example asset to modify.
+Navigate to your sift instance to see updated metadata on that asset.

--- a/python/examples/assets/main.py
+++ b/python/examples/assets/main.py
@@ -1,0 +1,60 @@
+import os
+from datetime import datetime
+
+from dotenv import load_dotenv
+from sift_py.asset.service import AssetService
+from sift_py.grpc.transport import SiftChannelConfig, use_sift_channel
+
+
+def update_asset_metadata():
+    """
+    Updates the NostromoLV426 asset with test metadata.
+    """
+    load_dotenv()
+
+    apikey = os.getenv("SIFT_API_KEY")
+    if apikey is None:
+        raise Exception("Missing 'SIFT_API_KEY' environment variable.")
+
+    base_uri = os.getenv("BASE_URI")
+    if base_uri is None:
+        raise Exception("Missing 'BASE_URI' environment variable.")
+
+    # Use the asset name from an ingestion example (here from ingestion_with_python_config).
+    # Run that example to populate a run w/ data assigned to the example asset.
+    asset_name = "NostromoLV426"
+
+    # Create a gRPC transport channel configured specifically for the Sift API
+    sift_channel_config = SiftChannelConfig(uri=base_uri, apikey=apikey)
+
+    with use_sift_channel(sift_channel_config) as channel:
+        # Create asset service
+        asset_service = AssetService(channel)
+
+        # Get the asset by name
+        assets = asset_service.list_assets(names=[asset_name])
+        if not assets:
+            raise Exception(f"Asset '{asset_name}' not found")
+
+        asset = assets[0]
+        print(f"Found asset {asset.name} with ID {asset.asset_id}")
+
+        # Update a specific metadata field.
+        asset.metadata["test_boolean"] = True
+
+        # You can update existing metadata with a dict.
+        timestamp = datetime.now()
+        test_metadata = {
+            "test_string": f"updated at {timestamp.isoformat()}",
+            "test_number": timestamp.timestamp(),
+        }
+        # Note: If you assign the metadata to a dict vs updating it, all existing metadata not in the new dict is lost.
+        asset.metadata.update(test_metadata)
+
+        updated_asset = asset_service.update_asset(asset=asset, update_metadata=True)
+
+        print(f"Successfully updated asset {updated_asset.name} with test metadata")
+
+
+if __name__ == "__main__":
+    update_asset_metadata()

--- a/python/examples/assets/requirements.txt
+++ b/python/examples/assets/requirements.txt
@@ -1,0 +1,3 @@
+python-dotenv
+pandas
+sift-stack-py

--- a/python/examples/ingestion_with_dynamic_flows/.env-example
+++ b/python/examples/ingestion_with_dynamic_flows/.env-example
@@ -2,7 +2,7 @@
 # Be sure to exclude "https://" from the BASE_URI
 #
 # BASE URIs and further details can be found here:
-#   https://docs.siftstack.com/docs/api/authentication
+#   https://docs.siftstack.com/docs/api/how-to-guides/grpc/authenticate-with-the-grpc-api
 BASE_URI=""
 
 SIFT_API_KEY=""

--- a/python/examples/ingestion_with_no_buffering/.env-example
+++ b/python/examples/ingestion_with_no_buffering/.env-example
@@ -2,7 +2,7 @@
 # Be sure to exclude "https://" from the BASE_URI
 #
 # BASE URIs and further details can be found here:
-#   https://docs.siftstack.com/docs/api/authentication
+#   https://docs.siftstack.com/docs/api/how-to-guides/grpc/authenticate-with-the-grpc-api
 BASE_URI=""
 
 SIFT_API_KEY=""

--- a/python/examples/ingestion_with_python_config/.env-example
+++ b/python/examples/ingestion_with_python_config/.env-example
@@ -2,7 +2,7 @@
 # Be sure to exclude "https://" from the BASE_URI
 #
 # BASE URIs and further details can be found here:
-#   https://docs.siftstack.com/docs/api/authentication
+#   https://docs.siftstack.com/docs/api/how-to-guides/grpc/authenticate-with-the-grpc-api
 BASE_URI=""
 
 SIFT_API_KEY=""

--- a/python/examples/ingestion_with_python_config/main.py
+++ b/python/examples/ingestion_with_python_config/main.py
@@ -42,7 +42,8 @@ if __name__ == "__main__":
         # Create an optional run as part of this ingestion
         current_ts = datetime.now(timezone.utc)
         run_name = f"[{telemetry_config.asset_name}].{current_ts.timestamp()}"
-        ingestion_service.attach_run(channel, run_name, "Run simulation")
+        metadata = {"test_key": "test_value"}
+        ingestion_service.attach_run(channel, run_name, "Run simulation", metadata=metadata)
 
         # Create our simulator
         simulator = Simulator(ingestion_service)

--- a/python/examples/ingestion_with_python_config/simulator.py
+++ b/python/examples/ingestion_with_python_config/simulator.py
@@ -39,7 +39,7 @@ class Simulator:
         sample_bit_field_values = ["00001001", "00100011", "00001101", "11000001"]
         self.sample_bit_field_values = [bytes([int(byte, 2)]) for byte in sample_bit_field_values]
 
-        sample_logs = Path().joinpath("sample_data").joinpath("sample_logs.txt")
+        sample_logs = Path().joinpath(Path(__file__).parent, "sample_data", "sample_logs.txt")
 
         with open(sample_logs, "r") as file:
             self.sample_logs = file.readlines()

--- a/python/examples/ingestion_with_yaml_config/.env-example
+++ b/python/examples/ingestion_with_yaml_config/.env-example
@@ -2,7 +2,7 @@
 # Be sure to exclude "https://" from the BASE_URI
 #
 # BASE URIs and further details can be found here:
-#   https://docs.siftstack.com/docs/api/authentication
+#   https://docs.siftstack.com/docs/api/how-to-guides/grpc/authenticate-with-the-grpc-api
 BASE_URI=""
 
 SIFT_API_KEY=""

--- a/python/examples/report_templates/report_template_with_python_config/.env-example
+++ b/python/examples/report_templates/report_template_with_python_config/.env-example
@@ -2,7 +2,7 @@
 # Be sure to exclude "https://" from the BASE_URI
 #
 # BASE URIs and further details can be found here:
-#   https://docs.siftstack.com/docs/api/authentication
+#   https://docs.siftstack.com/docs/api/how-to-guides/grpc/authenticate-with-the-grpc-api
 BASE_URI=""
 
 SIFT_API_KEY=""

--- a/python/examples/report_templates/report_template_with_yaml_config/.env-example
+++ b/python/examples/report_templates/report_template_with_yaml_config/.env-example
@@ -2,7 +2,7 @@
 # Be sure to exclude "https://" from the BASE_URI
 #
 # BASE URIs and further details can be found here:
-#   https://docs.siftstack.com/docs/api/authentication
+#   https://docs.siftstack.com/docs/api/how-to-guides/grpc/authenticate-with-the-grpc-api
 BASE_URI=""
 
 SIFT_API_KEY=""

--- a/python/lib/sift_py/_internal/metadata.py
+++ b/python/lib/sift_py/_internal/metadata.py
@@ -1,0 +1,70 @@
+from typing import Dict, List, Union
+
+from sift.metadata.v1.metadata_pb2 import MetadataKey, MetadataKeyType, MetadataValue
+
+
+def metadata_dict_to_pb(_metadata: Dict[str, Union[str, float, bool]]) -> List[MetadataValue]:
+    """
+    Wraps metadata dictionary into a list of MetadataValue objects.
+
+    Args:
+        _metadata: Dictionary of metadata key-value pairs.
+
+    Returns:
+        List of MetadataValue objects.
+    """
+    metadata = []
+
+    for key, value in _metadata.items():
+        type = MetadataKeyType.METADATA_KEY_TYPE_UNSPECIFIED
+        string_value = None
+        boolean_value = None
+        number_value = None
+
+        if isinstance(value, str):
+            string_value = value
+            type = MetadataKeyType.METADATA_KEY_TYPE_STRING
+        elif isinstance(value, bool):
+            # Need to check bool before int since python thinks "True" is an int
+            boolean_value = value
+            type = MetadataKeyType.METADATA_KEY_TYPE_BOOLEAN
+        elif isinstance(value, (int, float)):
+            number_value = value
+            type = MetadataKeyType.METADATA_KEY_TYPE_NUMBER
+        else:
+            raise ValueError(f"Unsupported metadata value type for key '{key}': {value}")
+
+        wrapped_key = MetadataKey(name=key, type=type)
+        wrapped_value = MetadataValue(
+            key=wrapped_key,
+            string_value=string_value,  # type: ignore
+            boolean_value=boolean_value,  # type: ignore
+            number_value=number_value,  # type: ignore
+        )
+        metadata.append(wrapped_value)
+
+    return metadata
+
+
+def metadata_pb_to_dict(metadata: List[MetadataValue]) -> Dict[str, Union[str, float, bool]]:
+    """
+    Unwraps a list of MetadataValue objects into a dictionary.
+
+    Args:
+        metadata: List of MetadataValue objects.
+
+    Returns:
+        Dictionary of metadata key-value pairs.
+    """
+    unwrapped_metadata: Dict[str, Union[str, float, bool]] = {}
+    for md in metadata:
+        if md.key.name in unwrapped_metadata:
+            raise ValueError(f"Key already exists: {md.key.name}")
+        if md.key.type == MetadataKeyType.METADATA_KEY_TYPE_STRING:
+            unwrapped_metadata[md.key.name] = md.string_value
+        elif md.key.type == MetadataKeyType.METADATA_KEY_TYPE_BOOLEAN:
+            unwrapped_metadata[md.key.name] = md.boolean_value
+        elif md.key.type == MetadataKeyType.METADATA_KEY_TYPE_NUMBER:
+            unwrapped_metadata[md.key.name] = md.number_value
+
+    return unwrapped_metadata

--- a/python/lib/sift_py/_internal/metadata_test.py
+++ b/python/lib/sift_py/_internal/metadata_test.py
@@ -1,0 +1,134 @@
+from unittest import TestCase
+
+from sift.metadata.v1.metadata_pb2 import MetadataKey, MetadataKeyType, MetadataValue
+
+from sift_py._internal.metadata import metadata_dict_to_pb, metadata_pb_to_dict
+
+
+class TestMetadata(TestCase):
+    """Tests for metadata wrapping and unwrapping functions."""
+
+    def test_metadata_dict_to_pb_mixed_types(self):
+        # Arrange
+        metadata = {
+            "string_key": "test",
+            "number_key": 42,
+            "float_key": 3.14,
+            "bool_key": True,
+            "zero_value": 0,
+            "empty_string": "",
+        }
+
+        # Act
+        result = metadata_dict_to_pb(metadata)
+
+        # Assert
+        self.assertEqual(len(result), 6)
+
+        # Verify each type is wrapped correctly
+        metadata_dict = {md.key.name: md for md in result}
+
+        # String values
+        self.assertEqual(metadata_dict["string_key"].key.type, 1)
+        self.assertEqual(metadata_dict["string_key"].string_value, "test")
+        self.assertEqual(metadata_dict["empty_string"].string_value, "")
+
+        # Number values
+        self.assertEqual(metadata_dict["number_key"].key.type, 2)
+        self.assertEqual(metadata_dict["number_key"].number_value, 42.0)
+        self.assertEqual(metadata_dict["float_key"].number_value, 3.14)
+        self.assertEqual(metadata_dict["zero_value"].number_value, 0.0)
+
+        # Boolean value
+        self.assertEqual(metadata_dict["bool_key"].key.type, 3)
+        self.assertTrue(metadata_dict["bool_key"].boolean_value)
+
+    def test_metadata_dict_to_pb_invalid_type(self):
+        # Arrange
+        invalid_metadata = {
+            "list_key": [1, 2, 3],
+            "dict_key": {"nested": "value"},
+            "none_key": None,
+        }
+
+        # Act & Assert
+        for key, value in invalid_metadata.items():
+            with self.assertRaises(ValueError) as context:
+                metadata_dict_to_pb({key: value})
+            self.assertIn("Unsupported metadata value type", str(context.exception))
+
+    def test_metadata_pb_to_dict_mixed_types(self):
+        # Arrange
+        wrapped_metadata = metadata_dict_to_pb(
+            {
+                "string_key": "test",
+                "number_key": 42,
+                "float_key": 3.14,
+                "bool_key": True,
+                "zero_value": 0,
+                "empty_string": "",
+            }
+        )
+
+        # Act
+        result = metadata_pb_to_dict(wrapped_metadata)
+
+        # Assert
+        self.assertEqual(len(result), 6)
+        self.assertEqual(result["string_key"], "test")
+        self.assertEqual(result["number_key"], 42.0)
+        self.assertEqual(result["float_key"], 3.14)
+        self.assertTrue(result["bool_key"])
+        self.assertEqual(result["zero_value"], 0.0)
+        self.assertEqual(result["empty_string"], "")
+
+    def test_metadata_pb_to_dict_empty(self):
+        # Arrange
+        wrapped_metadata = []
+
+        # Act
+        result = metadata_pb_to_dict(wrapped_metadata)
+
+        # Assert
+        self.assertEqual(result, {})
+
+    def test_metadata_pb_to_dict_duplicate_key(self):
+        # Arrange
+        # Create metadata with duplicate keys
+        wrapped_metadata = [
+            MetadataValue(
+                key=MetadataKey(
+                    name="duplicate_key", type=MetadataKeyType.METADATA_KEY_TYPE_STRING
+                ),
+                string_value="first_value",
+            ),
+            MetadataValue(
+                key=MetadataKey(
+                    name="duplicate_key", type=MetadataKeyType.METADATA_KEY_TYPE_STRING
+                ),
+                string_value="second_value",
+            ),
+        ]
+
+        # Act & Assert
+        with self.assertRaises(ValueError) as context:
+            metadata_pb_to_dict(wrapped_metadata)
+        self.assertIn("Key already exists: duplicate_key", str(context.exception))
+
+    def test_metadata_roundtrip(self):
+        # Arrange
+        original_metadata = {
+            "string_key": "test",
+            "number_key": 42,
+            "float_key": 3.14,
+            "bool_key": True,
+            "zero_value": 0,
+            "empty_string": "",
+        }
+
+        # Act
+        wrapped = metadata_dict_to_pb(original_metadata)
+        unwrapped = metadata_pb_to_dict(wrapped)
+
+        # Assert
+        self.assertEqual(unwrapped, original_metadata)

--- a/python/lib/sift_py/asset/_config_test.py
+++ b/python/lib/sift_py/asset/_config_test.py
@@ -1,0 +1,211 @@
+from datetime import datetime, timezone
+from unittest import TestCase
+
+from sift.assets.v1.assets_pb2 import Asset
+
+from sift_py._internal.metadata import metadata_dict_to_pb
+from sift_py.asset.config import AssetConfig
+
+
+class TestAssetConfig(TestCase):
+    def test_from_asset_basic(self):
+        # Arrange
+        timestamp = datetime.now(timezone.utc)
+        asset = Asset(
+            asset_id="test-asset-id",
+            name="Test Asset",
+            organization_id="test-org",
+            created_date=timestamp,
+            created_by_user_id="creator-123",
+            modified_date=timestamp,
+            modified_by_user_id="modifier-456",
+        )
+
+        # Act
+        config = AssetConfig.from_asset(asset)
+
+        # Assert
+        self.assertEqual(config.asset_id, "test-asset-id")
+        self.assertEqual(config.name, "Test Asset")
+        self.assertEqual(config.organization_id, "test-org")
+        self.assertEqual(config.created_by_user_id, "creator-123")
+        self.assertEqual(config.modified_by_user_id, "modifier-456")
+        self.assertEqual(config.created_date, timestamp)
+        self.assertEqual(config.modified_date, timestamp)
+        self.assertEqual(config.tags, [])
+        self.assertEqual(config.metadata, {})
+
+    def test_from_asset_with_optional_fields(self):
+        # Arrange
+        timestamp = datetime.now(timezone.utc)
+        metadata = {"string_key": "string_value", "number_key": 42, "bool_key": True}
+        asset = Asset(
+            asset_id="test-asset-id",
+            name="Test Asset",
+            organization_id="test-org",
+            created_date=timestamp,
+            created_by_user_id="creator-123",
+            modified_date=timestamp,
+            modified_by_user_id="modifier-456",
+            tags=["tag1", "tag2"],
+            metadata=metadata_dict_to_pb(metadata),
+        )
+
+        # Act
+        config = AssetConfig.from_asset(asset)
+
+        # Assert
+        self.assertEqual(config.asset_id, "test-asset-id")
+        self.assertEqual(config.name, "Test Asset")
+        self.assertEqual(config.organization_id, "test-org")
+        self.assertEqual(config.created_by_user_id, "creator-123")
+        self.assertEqual(config.modified_by_user_id, "modifier-456")
+        self.assertEqual(config.created_date, timestamp)
+        self.assertEqual(config.modified_date, timestamp)
+        self.assertEqual(config.tags, ["tag1", "tag2"])
+        self.assertEqual(config.metadata, metadata)
+
+    def test_from_asset_with_empty_fields(self):
+        # Arrange
+        timestamp = datetime.now(timezone.utc)
+        asset = Asset(
+            asset_id="test-asset-id",
+            name="Test Asset",
+            organization_id="test-org",
+            created_date=timestamp,
+            created_by_user_id="creator-123",
+            modified_date=timestamp,
+            modified_by_user_id="modifier-456",
+            tags=[],  # Empty tags
+            metadata=[],  # Empty metadata
+        )
+
+        # Act
+        config = AssetConfig.from_asset(asset)
+
+        # Assert
+        self.assertEqual(config.asset_id, "test-asset-id")
+        self.assertEqual(config.name, "Test Asset")
+        self.assertEqual(config.organization_id, "test-org")
+        self.assertEqual(config.created_by_user_id, "creator-123")
+        self.assertEqual(config.modified_by_user_id, "modifier-456")
+        self.assertEqual(config.created_date, timestamp)
+        self.assertEqual(config.modified_date, timestamp)
+        self.assertEqual(config.tags, [])  # Empty list should be preserved
+        self.assertEqual(config.metadata, {})  # Empty metadata should be converted to empty dict
+
+    def test_to_asset_basic(self):
+        # Arrange
+        timestamp = datetime.now(timezone.utc)
+        config = AssetConfig(
+            asset_id="test-asset-id",
+            name="Test Asset",
+            organization_id="test-org",
+            created_date=timestamp,
+            created_by_user_id="creator-123",
+            modified_date=timestamp,
+            modified_by_user_id="modifier-456",
+        )
+
+        # Act
+        asset = config.to_asset()
+
+        # Assert
+        self.assertEqual(asset.asset_id, "test-asset-id")
+        self.assertEqual(asset.name, "Test Asset")
+        self.assertEqual(asset.organization_id, "test-org")
+        self.assertEqual(asset.created_by_user_id, "creator-123")
+        self.assertEqual(asset.modified_by_user_id, "modifier-456")
+        self.assertEqual(asset.created_date.seconds, int(timestamp.timestamp()))
+        self.assertEqual(asset.modified_date.seconds, int(timestamp.timestamp()))
+        self.assertEqual(list(asset.tags), [])  # Empty list for no tags
+        self.assertEqual(list(asset.metadata), [])  # Empty list for no metadata
+
+    def test_to_asset_with_optional_fields(self):
+        # Arrange
+        timestamp = datetime.now(timezone.utc)
+        metadata = {"string_key": "string_value", "number_key": 42, "bool_key": True}
+        config = AssetConfig(
+            asset_id="test-asset-id",
+            name="Test Asset",
+            organization_id="test-org",
+            created_date=timestamp,
+            created_by_user_id="creator-123",
+            modified_date=timestamp,
+            modified_by_user_id="modifier-456",
+            tags=["tag1", "tag2"],
+            metadata=metadata,
+        )
+
+        # Act
+        asset = config.to_asset()
+
+        # Assert
+        self.assertEqual(asset.asset_id, "test-asset-id")
+        self.assertEqual(asset.name, "Test Asset")
+        self.assertEqual(asset.organization_id, "test-org")
+        self.assertEqual(asset.created_by_user_id, "creator-123")
+        self.assertEqual(asset.modified_by_user_id, "modifier-456")
+        self.assertEqual(asset.created_date.seconds, int(timestamp.timestamp()))
+        self.assertEqual(asset.modified_date.seconds, int(timestamp.timestamp()))
+        self.assertEqual(list(asset.tags), ["tag1", "tag2"])
+
+        # Verify metadata conversion
+        metadata_dict = {md.key.name: md for md in asset.metadata}
+        self.assertEqual(metadata_dict["string_key"].string_value, "string_value")
+        self.assertEqual(metadata_dict["number_key"].number_value, 42.0)
+        self.assertTrue(metadata_dict["bool_key"].boolean_value)
+
+    def test_roundtrip_conversion(self):
+        # Arrange
+        timestamp = datetime.now(timezone.utc)
+        metadata = {"string_key": "string_value", "number_key": 42, "bool_key": True}
+        original_asset = Asset(
+            asset_id="test-asset-id",
+            name="Test Asset",
+            organization_id="test-org",
+            created_date=timestamp,
+            created_by_user_id="creator-123",
+            modified_date=timestamp,
+            modified_by_user_id="modifier-456",
+            tags=["tag1", "tag2"],
+            metadata=metadata_dict_to_pb(metadata),
+        )
+
+        # Act
+        config = AssetConfig.from_asset(original_asset)
+        roundtrip_asset = config.to_asset()
+
+        # Assert
+        self.assertEqual(roundtrip_asset.asset_id, original_asset.asset_id)
+        self.assertEqual(roundtrip_asset.name, original_asset.name)
+        self.assertEqual(roundtrip_asset.organization_id, original_asset.organization_id)
+        self.assertEqual(roundtrip_asset.created_by_user_id, original_asset.created_by_user_id)
+        self.assertEqual(roundtrip_asset.modified_by_user_id, original_asset.modified_by_user_id)
+        self.assertEqual(roundtrip_asset.created_date.seconds, original_asset.created_date.seconds)
+        self.assertEqual(
+            roundtrip_asset.modified_date.seconds, original_asset.modified_date.seconds
+        )
+        self.assertEqual(list(roundtrip_asset.tags), list(original_asset.tags))
+
+        # Compare metadata
+        original_metadata = {md.key.name: md for md in original_asset.metadata}
+        roundtrip_metadata = {md.key.name: md for md in roundtrip_asset.metadata}
+        self.assertEqual(len(original_metadata), len(roundtrip_metadata))
+        for key in original_metadata:
+            self.assertEqual(
+                original_metadata[key].WhichOneof("value"),
+                roundtrip_metadata[key].WhichOneof("value"),
+            )
+            if original_metadata[key].HasField("string_value"):
+                self.assertEqual(
+                    original_metadata[key].string_value, roundtrip_metadata[key].string_value
+                )
+            elif original_metadata[key].HasField("number_value"):
+                self.assertEqual(
+                    original_metadata[key].number_value, roundtrip_metadata[key].number_value
+                )
+            elif original_metadata[key].HasField("boolean_value"):
+                self.assertEqual(
+                    original_metadata[key].boolean_value, roundtrip_metadata[key].boolean_value
+                )

--- a/python/lib/sift_py/asset/_internal/shared.py
+++ b/python/lib/sift_py/asset/_internal/shared.py
@@ -1,0 +1,57 @@
+from typing import List, Optional, cast
+
+from sift.assets.v1.assets_pb2 import Asset, ListAssetsRequest, ListAssetsResponse
+from sift.assets.v1.assets_pb2_grpc import AssetServiceStub
+from sift_py._internal.cel import cel_in
+
+
+def list_assets_impl(
+    _asset_service_stub: AssetServiceStub,
+    names: Optional[List[str]] = None,
+    ids: Optional[List[str]] = None,
+) -> List[Asset]:
+    """
+    Lists assets in an organization.
+
+    Args:
+        _asset_service_stub: The asset service stub to use.
+        names: Optional list of names to filter by.
+        ids: Optional list of IDs to filter by.
+
+    Returns:
+        A list of assets matching the criteria.
+    """
+
+    def get_assets_with_filter(
+        _asset_service_stub: AssetServiceStub, cel_filter: str
+    ) -> List[Asset]:
+        assets: List[Asset] = []
+        next_page_token = ""
+        while True:
+            req = ListAssetsRequest(
+                filter=cel_filter,
+                page_size=1_000,
+                page_token=next_page_token,
+            )
+            res = cast(ListAssetsResponse, _asset_service_stub.ListAssets(req))
+            assets.extend(res.assets)
+
+            if not res.next_page_token:
+                break
+            next_page_token = res.next_page_token
+
+        return assets
+
+    if names is None:
+        names = []
+    if ids is None:
+        ids = []
+
+    if names:
+        names_cel = cel_in("name", names)
+        return get_assets_with_filter(_asset_service_stub, names_cel)
+    elif ids:
+        ids_cel = cel_in("asset_id", ids)
+        return get_assets_with_filter(_asset_service_stub, ids_cel)
+    else:
+        return []

--- a/python/lib/sift_py/asset/_service_test.py
+++ b/python/lib/sift_py/asset/_service_test.py
@@ -1,0 +1,285 @@
+from datetime import datetime, timezone
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from sift.assets.v1.assets_pb2 import (
+    Asset,
+    GetAssetResponse,
+    ListAssetsResponse,
+    UpdateAssetResponse,
+)
+
+from sift_py._internal.metadata import metadata_dict_to_pb
+from sift_py.asset.config import AssetConfig
+from sift_py.asset.service import AssetService
+from sift_py.grpc.transport import SiftChannel
+
+
+class TestAssetService(TestCase):
+    """
+    Tests for the AssetService class.
+
+    Note: Most of these tests are useful purely for exercising code paths but importantly do not simulate the backend service so the returns are just the expected values.
+    """
+
+    def setUp(self):
+        self.channel = MagicMock(spec=SiftChannel)
+        self.service = AssetService(self.channel)
+        self.asset_service_stub = self.service._asset_service_stub
+
+    def test_get_asset_success(self):
+        # Arrange
+        asset_id = "test-asset-id"
+        timestamp = datetime.now(timezone.utc)
+        expected_asset = Asset(
+            asset_id=asset_id,
+            name="Test Asset",
+            organization_id="test-org",
+            created_by_user_id="test-user-id",
+            modified_by_user_id="test-user-id",
+            created_date=timestamp,
+            modified_date=timestamp,
+            tags=["tag1", "tag2"],
+        )
+        self.asset_service_stub.GetAsset.return_value = GetAssetResponse(asset=expected_asset)
+
+        # Act
+        result = self.service.get_asset(asset_id)
+
+        # Assert
+        self.assertIsInstance(result, AssetConfig)
+        self.assertEqual(result, AssetConfig.from_asset(expected_asset))
+        self.asset_service_stub.GetAsset.assert_called_once()
+
+    def test_get_asset_not_found(self):
+        # Arrange
+        asset_id = "non-existent-asset"
+        self.asset_service_stub.GetAsset.side_effect = Exception("Not found")
+
+        # Act
+        result = self.service.get_asset(asset_id)
+
+        # Assert
+        self.assertIsNone(result)
+        self.asset_service_stub.GetAsset.assert_called_once()
+
+    def test_delete_asset(self):
+        # Arrange
+        asset_id = "test-asset-id"
+
+        # Act
+        self.service.delete_asset(asset_id)
+
+        # Assert
+        self.asset_service_stub.DeleteAsset.assert_called_once()
+
+    def test_list_assets_by_names(self):
+        # Arrange
+        names = ["Asset 1", "Asset 2"]
+        timestamp = datetime.now(timezone.utc)
+        expected_assets = [
+            Asset(
+                asset_id=f"asset-{i}",
+                name=name,
+                organization_id="test-org",
+                created_date=timestamp,
+                modified_date=timestamp,
+                tags=[f"tag{i}"],
+            )
+            for i, name in enumerate(names)
+        ]
+        self.asset_service_stub.ListAssets.return_value = ListAssetsResponse(assets=expected_assets)
+
+        # Act
+        result = self.service.list_assets(names=names)
+
+        # Assert
+        self.assertEqual(len(result), 2)
+        for i, config in enumerate(result):
+            self.assertIsInstance(config, AssetConfig)
+            self.assertEqual(config, AssetConfig.from_asset(expected_assets[i]))
+        self.asset_service_stub.ListAssets.assert_called_once()
+
+    def test_list_assets_by_ids(self):
+        # Arrange
+        ids = ["asset-1", "asset-2"]
+        timestamp = datetime.now(timezone.utc)
+        expected_assets = [
+            Asset(
+                asset_id=id,
+                name=f"Asset {i}",
+                created_date=timestamp,
+                modified_date=timestamp,
+                organization_id="test-org",
+                tags=[f"tag{i}"],
+            )
+            for i, id in enumerate(ids)
+        ]
+        self.asset_service_stub.ListAssets.return_value = ListAssetsResponse(assets=expected_assets)
+
+        # Act
+        result = self.service.list_assets(ids=ids)
+
+        # Assert
+        self.assertEqual(len(result), 2)
+        for i, config in enumerate(result):
+            self.assertIsInstance(config, AssetConfig)
+            self.assertEqual(config, AssetConfig.from_asset(expected_assets[i]))
+        self.asset_service_stub.ListAssets.assert_called_once()
+
+    def test_list_assets_empty(self):
+        # Act
+        result = self.service.list_assets()
+
+        # Assert
+        self.assertEqual(result, [])
+        self.asset_service_stub.ListAssets.assert_not_called()
+
+    def test_update_asset_full(self):
+        # Arrange
+        timestamp = datetime.now(timezone.utc)
+        asset = AssetConfig(
+            asset_id="test-asset",
+            name="Test Asset",
+            organization_id="test-org",
+            created_date=timestamp,
+            created_by_user_id="creator-123",
+            modified_date=timestamp,
+            modified_by_user_id="modifier-456",
+            tags=["tag1", "tag2"],
+            metadata={"key1": "value1", "key2": 42, "key3": True},
+        )
+
+        expected_asset = Asset(
+            asset_id=asset.asset_id,
+            name=asset.name,
+            organization_id=asset.organization_id,
+            created_date=timestamp,
+            created_by_user_id=asset.created_by_user_id,
+            modified_date=timestamp,
+            modified_by_user_id=asset.modified_by_user_id,
+            tags=asset.tags,
+            metadata=metadata_dict_to_pb(asset.metadata),
+        )
+        self.asset_service_stub.UpdateAsset.return_value = UpdateAssetResponse(asset=expected_asset)
+
+        # Act
+        result = self.service.update_asset(asset)
+
+        # Assert
+        self.assertIsInstance(result, AssetConfig)
+        self.assertEqual(result, AssetConfig.from_asset(expected_asset))
+        self.asset_service_stub.UpdateAsset.assert_called_once()
+
+    def test_update_asset_with_tags(self):
+        # Arrange
+        timestamp = datetime.now(timezone.utc)
+        asset = AssetConfig(
+            asset_id="test-asset",
+            name="Test Asset",
+            organization_id="test-org",
+            created_date=timestamp,
+            created_by_user_id="creator-123",
+            modified_date=timestamp,
+            modified_by_user_id="modifier-456",
+            tags=["tag1", "tag2"],
+            metadata={"key1": "value1"},
+        )
+
+        expected_asset = Asset(
+            asset_id=asset.asset_id,
+            name=asset.name,
+            organization_id=asset.organization_id,
+            created_date=timestamp,
+            created_by_user_id=asset.created_by_user_id,
+            modified_date=timestamp,
+            modified_by_user_id=asset.modified_by_user_id,
+            tags=asset.tags,
+            metadata=metadata_dict_to_pb(asset.metadata),
+        )
+        self.asset_service_stub.UpdateAsset.return_value = UpdateAssetResponse(asset=expected_asset)
+
+        # Act
+        result = self.service.update_asset(asset, update_tags=True, update_metadata=False)
+
+        # Assert
+        self.assertIsInstance(result, AssetConfig)
+        self.assertEqual(result, AssetConfig.from_asset(expected_asset))
+        self.asset_service_stub.UpdateAsset.assert_called_once()
+
+    def test_update_asset_tags_only(self):
+        # Arrange
+        timestamp = datetime.now(timezone.utc)
+        asset = AssetConfig(
+            asset_id="test-asset",
+            name="Test Asset",
+            organization_id="test-org",
+            created_date=timestamp,
+            created_by_user_id="creator-123",
+            modified_date=timestamp,
+            modified_by_user_id="modifier-456",
+            tags=[],
+            metadata={},
+        )
+
+        expected_asset = Asset(
+            asset_id=asset.asset_id,
+            name=asset.name,
+            organization_id=asset.organization_id,
+            created_date=timestamp,
+            created_by_user_id=asset.created_by_user_id,
+            modified_date=timestamp,
+            modified_by_user_id=asset.modified_by_user_id,
+            tags=[],
+            metadata=[],
+        )
+        self.asset_service_stub.UpdateAsset.return_value = UpdateAssetResponse(asset=expected_asset)
+
+        # Act
+        result = self.service.update_asset(asset)
+
+        # Assert
+        self.assertIsInstance(result, AssetConfig)
+        self.assertEqual(result, AssetConfig.from_asset(expected_asset))
+        self.asset_service_stub.UpdateAsset.assert_called_once()
+
+    def test_update_asset_metadata_only(self):
+        # Arrange
+        timestamp = datetime.now(timezone.utc)
+        asset = AssetConfig(
+            asset_id="test-asset",
+            name="Test Asset",
+            organization_id="test-org",
+            created_date=timestamp,
+            created_by_user_id="creator-123",
+            modified_date=timestamp,
+            modified_by_user_id="modifier-456",
+            metadata={
+                "string_value": "test",
+                "number_value": 42,
+                "float_value": 3.14,
+                "bool_value": True,
+                "zero_value": 0,
+                "empty_string": "",
+            },
+        )
+
+        expected_asset = Asset(
+            asset_id=asset.asset_id,
+            name=asset.name,
+            organization_id=asset.organization_id,
+            created_date=timestamp,
+            created_by_user_id=asset.created_by_user_id,
+            modified_date=timestamp,
+            modified_by_user_id=asset.modified_by_user_id,
+            metadata=metadata_dict_to_pb(asset.metadata),
+        )
+        self.asset_service_stub.UpdateAsset.return_value = UpdateAssetResponse(asset=expected_asset)
+
+        # Act
+        result = self.service.update_asset(asset, update_tags=False, update_metadata=True)
+
+        # Assert
+        self.assertIsInstance(result, AssetConfig)
+        self.assertEqual(result, AssetConfig.from_asset(expected_asset))
+        self.asset_service_stub.UpdateAsset.assert_called_once()

--- a/python/lib/sift_py/asset/config.py
+++ b/python/lib/sift_py/asset/config.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Union
+
+from pydantic.dataclasses import dataclass
+from sift.assets.v1.assets_pb2 import Asset
+
+from sift_py._internal.metadata import metadata_dict_to_pb, metadata_pb_to_dict
+from sift_py._internal.time import to_timestamp_pb
+
+
+@dataclass
+class AssetConfig:
+    """
+    Thin wrapper class for an Asset that can be created from an Asset protobuf object.
+    This provides a more Python-friendly interface than the generated protobuf object.
+    """
+
+    asset_id: str
+    name: str
+    organization_id: str
+    created_date: datetime
+    created_by_user_id: str
+    modified_date: datetime
+    modified_by_user_id: str
+    tags: Optional[List[str]] = None
+    metadata: Optional[Dict[str, Union[str, float, bool]]] = None
+
+    @classmethod
+    def from_asset(cls, asset: Asset) -> AssetConfig:
+        """
+        Creates an AssetConfig from an Asset protobuf object.
+
+        Args:
+            asset: The Asset protobuf object to convert.
+
+        Returns:
+            An AssetConfig instance with the data from the Asset.
+        """
+        return cls(
+            asset_id=asset.asset_id,
+            name=asset.name,
+            organization_id=asset.organization_id,
+            created_date=datetime.fromtimestamp(
+                asset.created_date.ToMicroseconds() / 1000000, tz=timezone.utc
+            ),
+            created_by_user_id=asset.created_by_user_id,
+            modified_date=datetime.fromtimestamp(
+                asset.modified_date.ToMicroseconds() / 1000000, tz=timezone.utc
+            ),
+            modified_by_user_id=asset.modified_by_user_id,
+            tags=list(asset.tags),
+            metadata=metadata_pb_to_dict(list(asset.metadata)),
+        )
+
+    def to_asset(self) -> Asset:
+        """
+        Converts this AssetConfig to an Asset protobuf object.
+
+        Returns:
+            An Asset protobuf object with the data from this config.
+        """
+        return Asset(
+            asset_id=self.asset_id,
+            name=self.name,
+            organization_id=self.organization_id,
+            created_date=to_timestamp_pb(self.created_date),
+            created_by_user_id=self.created_by_user_id,
+            modified_date=to_timestamp_pb(self.modified_date),
+            modified_by_user_id=self.modified_by_user_id,
+            tags=self.tags if self.tags else [],
+            metadata=metadata_dict_to_pb(self.metadata) if self.metadata else [],
+        )

--- a/python/lib/sift_py/asset/service.py
+++ b/python/lib/sift_py/asset/service.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import List, Optional, cast
+
+from google.protobuf.field_mask_pb2 import FieldMask
+from sift.assets.v1.assets_pb2 import (
+    DeleteAssetRequest,
+    GetAssetRequest,
+    GetAssetResponse,
+    UpdateAssetRequest,
+    UpdateAssetResponse,
+)
+from sift.assets.v1.assets_pb2_grpc import AssetServiceStub
+
+from sift_py.asset._internal.shared import list_assets_impl
+from sift_py.asset.config import AssetConfig
+from sift_py.grpc.transport import SiftChannel
+
+
+class AssetService:
+    """
+    A service for managing assets. Allows for creating, updating, and retrieving assets in the Sift API.
+    """
+
+    _asset_service_stub: AssetServiceStub
+
+    def __init__(self, channel: SiftChannel):
+        self._asset_service_stub = AssetServiceStub(channel)
+
+    def get_asset(self, asset_id: str) -> Optional[AssetConfig]:
+        """
+        Retrieves an asset by its ID.
+
+        Args:
+            asset_id: The ID of the asset to retrieve.
+
+        Returns:
+            The Asset if found, None otherwise.
+        """
+        req = GetAssetRequest(asset_id=asset_id)
+        try:
+            res = cast(GetAssetResponse, self._asset_service_stub.GetAsset(req))
+            return AssetConfig.from_asset(res.asset) if res.asset else None
+        except:
+            return None
+
+    def delete_asset(self, asset_id: str) -> None:
+        """
+        Deletes an asset by its ID.
+        """
+        req = DeleteAssetRequest(asset_id=asset_id)
+        self._asset_service_stub.DeleteAsset(req)
+
+    def list_assets(
+        self,
+        names: Optional[List[str]] = None,
+        ids: Optional[List[str]] = None,
+    ) -> List[AssetConfig]:
+        """
+        Lists assets in an organization.
+
+        Args:
+            names: Optional list of names to filter by.
+            ids: Optional list of IDs to filter by.
+
+        Returns:
+            A list of assets matching the criteria.
+        """
+        return [
+            AssetConfig.from_asset(asset)
+            for asset in list_assets_impl(self._asset_service_stub, names, ids)
+        ]
+
+    def update_asset(
+        self, asset: AssetConfig, update_tags: bool = True, update_metadata: bool = True
+    ) -> AssetConfig:
+        """
+        Updates an existing asset.
+
+        Args:
+            asset: The asset to update.
+            update_tags: Whether to update the tags.
+            update_metadata: Whether to update the metadata.
+
+        Returns:
+            The updated AssetConfig.
+        """
+        update_mask = []
+        if update_tags:
+            update_mask.append("tags")
+        if update_metadata:
+            update_mask.append("metadata")
+        req = UpdateAssetRequest(
+            asset=asset.to_asset(),
+            update_mask=FieldMask(paths=update_mask),
+        )
+        res = cast(UpdateAssetResponse, self._asset_service_stub.UpdateAsset(req))
+
+        return AssetConfig.from_asset(res.asset)

--- a/python/lib/sift_py/ingestion/_internal/ingest.py
+++ b/python/lib/sift_py/ingestion/_internal/ingest.py
@@ -135,6 +135,7 @@ class _IngestionServiceImpl:
         description: Optional[str] = None,
         organization_id: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Union[str, float, bool]]] = None,
     ):
         """
         Retrieve an existing run or create one to use during this period of ingestion.
@@ -151,6 +152,7 @@ class _IngestionServiceImpl:
             description=description or "",
             organization_id=organization_id or "",
             tags=tags or [],
+            metadata=metadata,
         )
 
     def detach_run(self):

--- a/python/lib/sift_py/ingestion/_internal/run.py
+++ b/python/lib/sift_py/ingestion/_internal/run.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, cast
+from typing import Dict, List, Optional, Union, cast
 
 from sift.runs.v2.runs_pb2 import (
     CreateRunRequest,
@@ -8,6 +8,7 @@ from sift.runs.v2.runs_pb2 import (
 )
 from sift.runs.v2.runs_pb2_grpc import RunServiceStub
 
+from sift_py._internal.metadata import metadata_dict_to_pb
 from sift_py.grpc.transport import SiftChannel
 
 
@@ -34,13 +35,18 @@ def create_run(
     description: str,
     organization_id: str,
     tags: List[str],
+    metadata: Optional[Dict[str, Union[str, float, bool]]] = None,
 ) -> str:
     svc = RunServiceStub(channel)
+
+    _metadata = metadata_dict_to_pb(metadata) if metadata else None
+
     req = CreateRunRequest(
         name=run_name,
         description=description,
         organization_id=organization_id,
         tags=tags,
+        metadata=_metadata,
     )
     res = cast(CreateRunResponse, svc.CreateRun(req))
     return res.run.run_id

--- a/python/lib/sift_py/ingestion/service.py
+++ b/python/lib/sift_py/ingestion/service.py
@@ -66,11 +66,12 @@ class IngestionService(_IngestionServiceImpl):
         description: Optional[str] = None,
         organization_id: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Union[str, float, bool]]] = None,
     ):
         """
         Retrieve an existing run or create one to use during this period of ingestion.
         """
-        super().attach_run(channel, run_name, description, organization_id, tags)
+        super().attach_run(channel, run_name, description, organization_id, tags, metadata)
 
     def detach_run(self):
         """


### PR DESCRIPTION
## Testing

###  Functional
Ran python/examples/ingestion_with_python_config/simulator.py and you can see metadata attached to run: 
<img width="1175" alt="Screenshot 2025-06-12 at 4 42 22 PM" src="https://github.com/user-attachments/assets/421aa2ea-527c-4d6e-aa9e-b794a185be4d" />

Also, results from new example:
``` 
(venv) ╭─ian@Mac ~/code/sift/python  ‹dev/FD-89*› 
╰─➤  python ./examples/assets/main.py                   
Found asset NostromoLV426 with ID 0bb2dc89-2b00-4000-9d4a-f4343b252f9f
Successfully updated asset NostromoLV426 with test metadata
```
<img width="1513" alt="Screenshot 2025-06-13 at 1 34 04 PM" src="https://github.com/user-attachments/assets/4e735523-3d7f-4ffb-a04c-54ce624ad8ef" />

### Regression
Unit tests updated