### PR TITLE
fix(sift-stream-bindings): Wheels are downloaded to root dir

### DIFF
--- a/.github/workflows/sift_stream_bindings_release.yaml
+++ b/.github/workflows/sift_stream_bindings_release.yaml
@@ -130,4 +130,3 @@ jobs:
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*
-          working-directory: rust/crates/sift_stream_bindings


### PR DESCRIPTION
Artifacts for upload are downloaded to root dir of worker: https://github.com/sift-stack/sift/actions/runs/15768225922/job/44494926642#step:2:112