### PR TITLE
build(sift-stream-bindings): Use trusted publishing process to publish

### DIFF
--- a/.github/workflows/sift_stream_bindings_release.yaml
+++ b/.github/workflows/sift_stream_bindings_release.yaml
@@ -118,15 +118,13 @@ jobs:
       attestations: write
     steps:
       - uses: actions/download-artifact@v4
+        with:
+          path: $GITHUB_WORKSPACE/dist
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: 'wheels-*/*'
       - name: Publish to PyPI
-        if: ${{ startsWith(github.ref, 'refs/tags/sift-stream-bindings/') }}
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          command: upload
-          args: --non-interactive --skip-existing wheels-*/*
+          packages-dir: $GITHUB_WORKSPACE/dist

--- a/.github/workflows/sift_stream_bindings_release.yaml
+++ b/.github/workflows/sift_stream_bindings_release.yaml
@@ -119,12 +119,12 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          path: $GITHUB_WORKSPACE/dist
+          path: ${{ github.workspace }}/dist
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: 'wheels-*/*'
+          subject-path: ${{ github.workspace }}/dist/wheels-*/*
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: $GITHUB_WORKSPACE/dist
+          packages-dir: ${{ github.workspace }}/dist


### PR DESCRIPTION
This is the same action we use to publish the rest of our python packages, using pypi's [trusted publishing](https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#trusted-publishing) implementation so we don't need to set up separate pypi API tokens for our projects. 
It looks like this action was recently updated to work with and be [tested against maturin projects](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.12.3) as well.