### PR TITLE
fix: Manually extract sift-stream-bindings artifacts for upload

### DIFF
--- a/.github/workflows/sift_stream_bindings_release.yaml
+++ b/.github/workflows/sift_stream_bindings_release.yaml
@@ -119,7 +119,13 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          path: ${{ github.workspace }}/dist
+          path: $GITHUB_WORKSPACE/artifacts
+      - name: Extract artifacts
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/dist
+          for zipfile in $GITHUB_WORKSPACE/artifacts/*.zip; do
+            unzip -o "$zipfile" -d $GITHUB_WORKSPACE/dist/
+          done
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
@@ -127,4 +133,4 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: ${{ github.workspace }}/dist
+          packages-dir: $GITHUB_WORKSPACE/dist


### PR DESCRIPTION
Unlike our other python releases that download a single named artifact where we've manually bundled all the wheels, this workflow currently uploads artifacts that contain the wheels for each os/arch, and since we're downloading all of the artifacts instead of a single named artifact, the wheels are not present in the dist/ directory but rather in subdirectories. We can manually extract the zips and put everything in the dist/ directory where the publishing artifacts expects them.