### PR TITLE
fix: Copy artifacts from subdirs into dist

### DIFF
--- a/.github/workflows/sift_stream_bindings_release.yaml
+++ b/.github/workflows/sift_stream_bindings_release.yaml
@@ -130,8 +130,6 @@ jobs:
               cp -r "$artifact_dir"* $GITHUB_WORKSPACE/dist/
             fi
           done
-          # Remove the artifact directories
-          rm -rf $GITHUB_WORKSPACE/artifacts/*
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:

--- a/.github/workflows/sift_stream_bindings_release.yaml
+++ b/.github/workflows/sift_stream_bindings_release.yaml
@@ -123,13 +123,19 @@ jobs:
       - name: Extract artifacts
         run: |
           mkdir -p $GITHUB_WORKSPACE/dist
-          for zipfile in $GITHUB_WORKSPACE/artifacts/*.zip; do
-            unzip -o "$zipfile" -d $GITHUB_WORKSPACE/dist/
+          # Extract each artifact directory's contents
+          for artifact_dir in $GITHUB_WORKSPACE/artifacts/*/; do
+            if [ -d "$artifact_dir" ]; then
+              echo "Extracting from $artifact_dir"
+              cp -r "$artifact_dir"* $GITHUB_WORKSPACE/dist/
+            fi
           done
+          # Remove the artifact directories
+          rm -rf $GITHUB_WORKSPACE/artifacts/*
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: ${{ github.workspace }}/dist/wheels-*/*
+          subject-path: $GITHUB_WORKSPACE/dist/wheels-*/*
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
The artifact zips are already extracted into subdirs, so we just need to copy them into a dir the publish action can upload from: https://github.com/sift-stack/sift/actions/runs/15788760455/job/44511080583#step:3:17