### PR TITLE
fix: Attestation should look into artifacts dir

### DIFF
--- a/.github/workflows/sift_stream_bindings_release.yaml
+++ b/.github/workflows/sift_stream_bindings_release.yaml
@@ -133,7 +133,7 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: $GITHUB_WORKSPACE/dist/wheels-*/*
+          subject-path: $GITHUB_WORKSPACE/artifacts/wheels-*/*
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
Previously this worked when artifacts were downloaded to dist: https://github.com/sift-stack/sift/actions/runs/15786779218/job/44505916179#step:3:19
But we're using the `artifacts` subdir now.