### PR TITLE
python(feat): Add public method for creating new run

### DIFF
--- a/python/lib/sift_py/ingestion/_internal/ingest.py
+++ b/python/lib/sift_py/ingestion/_internal/ingest.py
@@ -136,39 +136,19 @@ class _IngestionServiceImpl:
         organization_id: Optional[str] = None,
         tags: Optional[List[str]] = None,
         metadata: Optional[Dict[str, Union[str, float, bool]]] = None,
+        force_new: bool = False,
     ):
         """
         Retrieve an existing run or create one to use during this period of ingestion.
-        """
-        run_id = get_run_id_by_name(channel, run_name)
 
-        if run_id is not None:
-            self.run_id = run_id
-            return
-
-        self.run_id = create_run(
-            channel=channel,
-            run_name=run_name,
-            description=description or "",
-            organization_id=organization_id or "",
-            tags=tags or [],
-            metadata=metadata,
-        )
-
-    def attach_new_run(
-        self,
-        channel: SiftChannel,
-        run_name: str,
-        description: Optional[str] = None,
-        organization_id: Optional[str] = None,
-        tags: Optional[List[str]] = None,
-        metadata: Optional[Dict[str, Union[str, float, bool]]] = None,
-    ):
+        Include `force_new=True` to force the creation of a new run, which will allow creation of a new run using an existing name.
         """
-        Create a new run to use during this period of ingestion.
-        Will generate a new `run_id` even if a run with the same name already exists, allowing multiple runs with the same name.
-        Prefer `attach_run` unless intent is to create a new run regardless of existing run names.
-        """
+        if not force_new:
+            run_id = get_run_id_by_name(channel, run_name)
+
+            if run_id is not None:
+                self.run_id = run_id
+                return
 
         self.run_id = create_run(
             channel=channel,

--- a/python/lib/sift_py/ingestion/_internal/ingest.py
+++ b/python/lib/sift_py/ingestion/_internal/ingest.py
@@ -155,6 +155,30 @@ class _IngestionServiceImpl:
             metadata=metadata,
         )
 
+    def attach_new_run(
+        self,
+        channel: SiftChannel,
+        run_name: str,
+        description: Optional[str] = None,
+        organization_id: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Union[str, float, bool]]] = None,
+    ):
+        """
+        Create a new run to use during this period of ingestion.
+        Will generate a new `run_id` even if a run with the same name already exists, allowing multiple runs with the same name.
+        Prefer `attach_run` unless intent is to create a new run regardless of existing run names.
+        """
+
+        self.run_id = create_run(
+            channel=channel,
+            run_name=run_name,
+            description=description or "",
+            organization_id=organization_id or "",
+            tags=tags or [],
+            metadata=metadata,
+        )
+
     def detach_run(self):
         """
         Detach run from this period of ingestion. Subsequent data ingested won't be associated with

--- a/python/lib/sift_py/ingestion/service.py
+++ b/python/lib/sift_py/ingestion/service.py
@@ -67,27 +67,16 @@ class IngestionService(_IngestionServiceImpl):
         organization_id: Optional[str] = None,
         tags: Optional[List[str]] = None,
         metadata: Optional[Dict[str, Union[str, float, bool]]] = None,
+        force_new: bool = False,
     ):
         """
         Retrieve an existing run or create one to use during this period of ingestion.
-        """
-        super().attach_run(channel, run_name, description, organization_id, tags, metadata)
 
-    def attach_new_run(
-        self,
-        channel: SiftChannel,
-        run_name: str,
-        description: Optional[str] = None,
-        organization_id: Optional[str] = None,
-        tags: Optional[List[str]] = None,
-        metadata: Optional[Dict[str, Union[str, float, bool]]] = None,
-    ):
+        Include `force_new=True` to force the creation of a new run, which will allow creation of a new run using an existing name.
         """
-        Create a new run to use during this period of ingestion.
-        Will generate a new `run_id` even if a run with the same name already exists, allowing multiple runs with the same name.
-        Prefer `attach_run` unless intent is to create a new run regardless of existing run names.
-        """
-        super().attach_new_run(channel, run_name, description, organization_id, tags, metadata)
+        super().attach_run(
+            channel, run_name, description, organization_id, tags, metadata, force_new
+        )
 
     def detach_run(self):
         """

--- a/python/lib/sift_py/ingestion/service.py
+++ b/python/lib/sift_py/ingestion/service.py
@@ -73,6 +73,22 @@ class IngestionService(_IngestionServiceImpl):
         """
         super().attach_run(channel, run_name, description, organization_id, tags, metadata)
 
+    def attach_new_run(
+        self,
+        channel: SiftChannel,
+        run_name: str,
+        description: Optional[str] = None,
+        organization_id: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Union[str, float, bool]]] = None,
+    ):
+        """
+        Create a new run to use during this period of ingestion.
+        Will generate a new `run_id` even if a run with the same name already exists, allowing multiple runs with the same name.
+        Prefer `attach_run` unless intent is to create a new run regardless of existing run names.
+        """
+        super().attach_new_run(channel, run_name, description, organization_id, tags, metadata)
+
     def detach_run(self):
         """
         Detach run from this period of ingestion. Subsequent data ingested won't be associated with


### PR DESCRIPTION
Added an optional flag to attach_run() named `force_new`, which when true, forces creation of a new run even if an existing run of the same name exists. Defaults to False to match the existing behavior of the function.

Equivalent to running sift_py.ingestion._internal.run.create_run(), but consistent with the existing public interface.

**Verification:**
Ran the following simplified code snippet to verify a new run is attached despite a duplicate run name.

```
def test_attach_run(grpc_channel, config, run_name, force_new=False):
    logging.info(f"Attach run {run_name}")
    ingestion_service = IngestionService(grpc_channel, config)
    ingestion_service.attach_run(grpc_channel, run_name, force_new=force_new)
    write_data(ingestion_service)
    logging.info(f"Now using run_id {ingestion_service.run_id}")

with use_sift_channel(credentials) as grpc_channel:
        test_attach_run(grpc_channel, "TestRun")
        test_attach_run(grpc_channel, "TestRun")
        test_attach_run(grpc_channel, "TestRun", force_new=True)
        test_attach_run(grpc_channel, "TestRun")

```

Output:
```
Existing runs:
3f3aba34-737e-4e3d-996b-24bef14d7cb4: TestRun
e00eb986-4c25-4080-a17a-3693bd3efcef: TestRun

2025-06-23 16:44:54,746 - INFO - Attach run TestRun with force_new=False
2025-06-23 16:44:55,113 - INFO - Now using run_id "3f3aba34-737e-4e3d-996b-24bef14d7cb4"
2025-06-23 16:44:55,113 - INFO - Attach run TestRun with force_new=False
2025-06-23 16:44:55,501 - INFO - Now using run_id "3f3aba34-737e-4e3d-996b-24bef14d7cb4"
2025-06-23 16:44:55,502 - INFO - Attach run TestRun with force_new=True
2025-06-23 16:44:55,840 - INFO - Now using run_id "8af50950-497f-43d7-96a2-50ee73b266ff"
2025-06-23 16:44:55,840 - INFO - Attach run TestRun with force_new=False
2025-06-23 16:44:56,181 - INFO - Now using run_id "8af50950-497f-43d7-96a2-50ee73b266ff"

Current runs:
8af50950-497f-43d7-96a2-50ee73b266ff: TestRun
3f3aba34-737e-4e3d-996b-24bef14d7cb4: TestRun
e00eb986-4c25-4080-a17a-3693bd3efcef: TestRun
```
