### PR TITLE
build: Fix directories used to extra sift-stream-bindings release wheels

### DIFF
--- a/.github/workflows/sift_stream_bindings_release.yaml
+++ b/.github/workflows/sift_stream_bindings_release.yaml
@@ -119,22 +119,22 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          path: $GITHUB_WORKSPACE/artifacts
+          path: ${{ github.workspace }}/artifacts
       - name: Extract artifacts
         run: |
-          mkdir -p $GITHUB_WORKSPACE/dist
+          mkdir -p ${{ github.workspace }}/dist
           # Extract each artifact directory's contents
-          for artifact_dir in $GITHUB_WORKSPACE/artifacts/*/; do
+          for artifact_dir in ${{ github.workspace }}/artifacts/*/; do
             if [ -d "$artifact_dir" ]; then
               echo "Extracting from $artifact_dir"
-              cp -r "$artifact_dir"* $GITHUB_WORKSPACE/dist/
+              cp -r "$artifact_dir"* ${{ github.workspace }}/dist/
             fi
           done
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: $GITHUB_WORKSPACE/artifacts/wheels-*/*
+          subject-path: ${{ github.workspace }}/artifacts/wheels-*/*
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: $GITHUB_WORKSPACE/dist
+          packages-dir: ${{ github.workspace }}/dist

--- a/rust/crates/sift_stream_bindings/Cargo.toml
+++ b/rust/crates/sift_stream_bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sift-stream-bindings"
-version = { workspace = true }
+version = "0.1.0"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
Successfully tested these changes here: https://github.com/sift-stack/sift/actions/runs/15862570069/job/44723185415
Uploaded to Test PyPI: https://test.pypi.org/project/sift-stream-bindings/0.1.0/

This also makes it so the version of this package to be separate from the workspace version that is used in the rest of the rust packages. Caught that when checking TestPyPI. 

Also sanity checked that the diff between the working test version and what's on this branch is just the test pypi url:
```
git diff build/test-sift-stream-bindings-gha..build/bindings-upload-fix 
diff --git a/.github/workflows/sift_stream_bindings_release.yaml b/.github/workflows/sift_stream_bindings_release.yaml
index 5197701..7f40545 100644
--- a/.github/workflows/sift_stream_bindings_release.yaml
+++ b/.github/workflows/sift_stream_bindings_release.yaml
@@ -138,4 +138,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: ${{ github.workspace }}/dist
-          repository-url: https://test.pypi.org/legacy/
```