### PR TITLE
rust(build): restore explicit versions for crates in workspace

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,9 +25,9 @@ chrono = { version = "0.4.39", default-features = false, features = ["clock"] }
 pbjson-types = "^0.7"
 tonic = { version = "^0.12" }
 
-sift_connect = { path = "crates/sift_connect" }
-sift_rs = { path = "crates/sift_rs" }
-sift_error = {  path = "crates/sift_error" }
-sift_stream = { path = "crates/sift_stream" }
+sift_connect = { version = "0.4.0", path = "crates/sift_connect" }
+sift_rs = { version = "0.4.0", path = "crates/sift_rs" }
+sift_error = { version = "0.4.0", path = "crates/sift_error" }
+sift_stream = { version = "0.4.0", path = "crates/sift_stream" }
 
 sift_stream_bindings = { version = "0.1.0", path = "crates/sift_stream_bindings" }


### PR DESCRIPTION
## Changes

Restore explicit versions for each crate in workspace. `crates.io` is strict about this.