### PR TITLE
python(feat): Add support for start and end times to rule evaluation

### DIFF
--- a/python/lib/sift_py/_internal/time.py
+++ b/python/lib/sift_py/_internal/time.py
@@ -29,7 +29,7 @@ def to_timestamp_nanos(arg: Union[TimestampPb, pd.Timestamp, datetime, str, int]
         return cast(pd.Timestamp, pd.Timestamp(arg))
 
 
-def to_timestamp_pb(arg: Union[datetime, str, int]) -> TimestampPb:
+def to_timestamp_pb(arg: Union[datetime, str, int, float]) -> TimestampPb:
     """
     Mainly used for testing at the moment. If using this for non-testing purposes
     should probably make this more robust and support nano-second precision.
@@ -40,7 +40,7 @@ def to_timestamp_pb(arg: Union[datetime, str, int]) -> TimestampPb:
     if isinstance(arg, datetime):
         ts.FromDatetime(arg)
         return ts
-    elif isinstance(arg, int):
+    elif isinstance(arg, (int, float)):
         ts.FromDatetime(datetime.fromtimestamp(arg))
         return ts
     else:

--- a/python/lib/sift_py/rule_evaluation/service.py
+++ b/python/lib/sift_py/rule_evaluation/service.py
@@ -50,8 +50,8 @@ class RuleEvaluationService:
         run_id: str,
         rules: Union[ReportTemplateConfig, List[RuleConfig], List[RuleIdentifier]],
         report_name: str = "",
-        start_time: Optional[Union[datetime, str, int]] = None,
-        end_time: Optional[Union[datetime, str, int]] = None,
+        start_time: Optional[Union[datetime, str, int, float]] = None,
+        end_time: Optional[Union[datetime, str, int, float]] = None,
     ) -> ReportService:
         """Evaluate a set of rules against a run.
 
@@ -60,8 +60,8 @@ class RuleEvaluationService:
             rules: Either a ReportTemplateConfig, a list of RuleConfigs, or a list of
                 RuleIdentifiers (typically from `RuleService.create_external_rules`).
             report_name: Optional report name.
-            start_time: Optional start time to evaluate.
-            end_time: Optional end time to evaluate.
+            start_time: Optional start time to evaluate (datetime, ISO 8601 formatted string, or POSIX timestamp).
+            end_time: Optional end time to evaluate (datetime, ISO 8601 formatted string, or POSIX timestamp).
 
         Returns:
             A ReportService object that can be use to get the status of the executed report.
@@ -81,8 +81,8 @@ class RuleEvaluationService:
     def evaluate_against_assets(
         self,
         asset_names: List[str],
-        start_time: Union[datetime, str, int],
-        end_time: Union[datetime, str, int],
+        start_time: Union[datetime, str, int, float],
+        end_time: Union[datetime, str, int, float],
         rules: Union[ReportTemplateConfig, List[RuleConfig], List[RuleIdentifier]],
         report_name: str = "",
     ) -> ReportService:
@@ -90,8 +90,8 @@ class RuleEvaluationService:
 
         Args:
             asset_names: The list of assets to run against.
-            start_time: The start time to evaluate.
-            end_time: The end time to evaluate.
+            start_time: The start time to evaluate (datetime, ISO 8601 formatted string, or POSIX timestamp).
+            end_time: The end time to evaluate (datetime, ISO 8601 formatted string, or POSIX timestamp).
             rules: Either a ReportTemplateConfig, a list of RuleConfigs, or a list of
                 RuleIdentifiers (typically from `RuleService.create_external_rules`).
             report_name: Optional report name.
@@ -119,8 +119,8 @@ class RuleEvaluationService:
         self,
         run_id: str,
         rules: Union[ReportTemplateConfig, List[RuleConfig], List[RuleIdentifier]],
-        start_time: Optional[Union[datetime, str, int]] = None,
-        end_time: Optional[Union[datetime, str, int]] = None,
+        start_time: Optional[Union[datetime, str, int, float]] = None,
+        end_time: Optional[Union[datetime, str, int, float]] = None,
     ) -> EvaluateRulesPreviewResponse:
         """Preview the evaluation of a set of rules against a run.
 
@@ -128,8 +128,8 @@ class RuleEvaluationService:
             run_id: The Run ID to run against.
             rules: Either a ReportTemplateConfig, a list of RuleConfigs, or a list of
                 RuleIdentifiers (typically from `RuleService.create_external_rules`).
-            start_time: Optional start time to evaluate.
-            end_time: Optional end time to evaluate.
+            start_time: Optional start time to evaluate (datetime, ISO 8601 formatted string, or POSIX timestamp).
+            end_time: Optional end time to evaluate (datetime, ISO 8601 formatted string, or POSIX timestamp).
 
         Returns:
             The EvaluateRulesPreviewResponse object.
@@ -149,8 +149,8 @@ class RuleEvaluationService:
         run_id: str,
         rules: List[RuleConfig],
         report_name: str = "",
-        start_time: Optional[Union[datetime, str, int]] = None,
-        end_time: Optional[Union[datetime, str, int]] = None,
+        start_time: Optional[Union[datetime, str, int, float]] = None,
+        end_time: Optional[Union[datetime, str, int, float]] = None,
     ) -> ReportService:
         """Evaluate a set of external rules against a run.
 
@@ -158,8 +158,8 @@ class RuleEvaluationService:
             run_id: The Run ID to run against.
             rules: A list of RuleConfigs. These must be external rules.
             report_name: Optional report name.
-            start_time: Optional start time to evaluate.
-            end_time: Optional end time to evaluate.
+            start_time: Optional start time to evaluate (datetime, ISO 8601 formatted string, or POSIX timestamp).
+            end_time: Optional end time to evaluate (datetime, ISO 8601 formatted string, or POSIX timestamp).
 
         Returns:
             A Report object that can be use to get the status of the executed report.
@@ -173,8 +173,8 @@ class RuleEvaluationService:
         paths: List[Path],
         named_expressions: Optional[Dict[str, str]] = None,
         report_name: str = "",
-        start_time: Optional[Union[datetime, str, int]] = None,
-        end_time: Optional[Union[datetime, str, int]] = None,
+        start_time: Optional[Union[datetime, str, int, float]] = None,
+        end_time: Optional[Union[datetime, str, int, float]] = None,
     ) -> ReportService:
         """Evaluate a set of external rules from a YAML config against a run.
 
@@ -182,8 +182,8 @@ class RuleEvaluationService:
             run_id: The Run ID to run against.
             paths: The YAML paths to load rules from.
             report_name: Optional report name.
-            start_time: Optional start time to evaluate.
-            end_time: Optional end time to evaluate.
+            start_time: Optional start time to evaluate (datetime, ISO 8601 formatted string, or POSIX timestamp).
+            end_time: Optional end time to evaluate (datetime, ISO 8601 formatted string, or POSIX timestamp).
 
         Returns:
             A Report object that can be use to get the status of the executed report.
@@ -195,16 +195,16 @@ class RuleEvaluationService:
         self,
         run_id: str,
         rules: List[RuleConfig],
-        start_time: Optional[Union[datetime, str, int]] = None,
-        end_time: Optional[Union[datetime, str, int]] = None,
+        start_time: Optional[Union[datetime, str, int, float]] = None,
+        end_time: Optional[Union[datetime, str, int, float]] = None,
     ) -> EvaluateRulesPreviewResponse:
         """Preview the evaluation a set of external rules against a run.
 
         Args:
             run_id: The Run ID to run against.
             rules: A list of RuleConfigs. These must be external rules.
-            start_time: Optional start time to evaluate.
-            end_time: Optional end time to evaluate.
+            start_time: Optional start time to evaluate (datetime, ISO 8601 formatted string, or POSIX timestamp).
+            end_time: Optional end time to evaluate (datetime, ISO 8601 formatted string, or POSIX timestamp).
 
         Returns:
             The EvaluateRulesPreviewResponse object.
@@ -217,8 +217,8 @@ class RuleEvaluationService:
         run_id: str,
         paths: List[Path],
         named_expressions: Optional[Dict[str, str]] = None,
-        start_time: Optional[Union[datetime, str, int]] = None,
-        end_time: Optional[Union[datetime, str, int]] = None,
+        start_time: Optional[Union[datetime, str, int, float]] = None,
+        end_time: Optional[Union[datetime, str, int, float]] = None,
     ) -> EvaluateRulesPreviewResponse:
         """Preview the evaluation a set of external rules from a YAML config against a run.
 
@@ -226,8 +226,8 @@ class RuleEvaluationService:
             run_id: The Run ID to run against.
             paths: The YAML paths to load rules from.
             named_expressions: The named expressions to substitute in the rules.
-            start_time: Optional start time to evaluate.
-            end_time: Optional end time to evaluate.
+            start_time: Optional start time to evaluate (datetime, ISO 8601 formatted string, or POSIX timestamp).
+            end_time: Optional end time to evaluate (datetime, ISO 8601 formatted string, or POSIX timestamp).
 
         Returns:
             The EvaluateRulesPreviewResponse object.
@@ -290,15 +290,15 @@ class RuleEvaluationService:
     def _get_run_kwargs(
         self,
         run_id: str,
-        start_time: Optional[Union[datetime, str, int]] = None,
-        end_time: Optional[Union[datetime, str, int]] = None,
+        start_time: Optional[Union[datetime, str, int, float]] = None,
+        end_time: Optional[Union[datetime, str, int, float]] = None,
     ) -> dict:
         """Returns the Run specific keyword arguments for a EvalutateRules request based on the input type.
 
         Args:
             run_id: The Run ID to run against.
-            start_time: Optional start time to evaluate.
-            end_time: Optional end time to evaluate.
+            start_time: Optional start time to evaluate (datetime, ISO 8601 formatted string, or POSIX timestamp).
+            end_time: Optional end time to evaluate (datetime, ISO 8601 formatted string, or POSIX timestamp).
 
         Returns:
             dict: The keyword arguments.

--- a/python/lib/sift_py/rule_evaluation/service.py
+++ b/python/lib/sift_py/rule_evaluation/service.py
@@ -20,6 +20,7 @@ from sift.rule_evaluation.v1.rule_evaluation_pb2 import (
     EvaluateRulesPreviewResponse,
     EvaluateRulesRequest,
     EvaluateRulesResponse,
+    RunTimeRange,
 )
 from sift.rule_evaluation.v1.rule_evaluation_pb2_grpc import RuleEvaluationServiceStub
 from sift_py._internal.time import to_timestamp_pb
@@ -49,6 +50,8 @@ class RuleEvaluationService:
         run_id: str,
         rules: Union[ReportTemplateConfig, List[RuleConfig], List[RuleIdentifier]],
         report_name: str = "",
+        start_time: Optional[Union[datetime, str, int]] = None,
+        end_time: Optional[Union[datetime, str, int]] = None,
     ) -> ReportService:
         """Evaluate a set of rules against a run.
 
@@ -57,16 +60,19 @@ class RuleEvaluationService:
             rules: Either a ReportTemplateConfig, a list of RuleConfigs, or a list of
                 RuleIdentifiers (typically from `RuleService.create_external_rules`).
             report_name: Optional report name.
+            start_time: Optional start time to evaluate.
+            end_time: Optional end time to evaluate.
 
         Returns:
             A ReportService object that can be use to get the status of the executed report.
         """
-        eval_kwargs = self._get_rules_kwargs(rules)
+        rules_kwargs = self._get_rules_kwargs(rules)
+        run_kwargs = self._get_run_kwargs(run_id, start_time, end_time)
 
         req = EvaluateRulesRequest(
             report_name=report_name,
-            run=ResourceIdentifier(id=run_id),
-            **eval_kwargs,
+            **rules_kwargs,
+            **run_kwargs,
         )
         res = cast(EvaluateRulesResponse, self._rule_evaluation_stub.EvaluateRules(req))
 
@@ -98,12 +104,12 @@ class RuleEvaluationService:
             start_time=to_timestamp_pb(start_time),
             end_time=to_timestamp_pb(end_time),
         )
-        eval_kwargs = self._get_rules_kwargs(rules)
+        rules_kwargs = self._get_rules_kwargs(rules)
 
         req = EvaluateRulesRequest(
             report_name=report_name,
             assets=asset_time_range,
-            **eval_kwargs,
+            **rules_kwargs,
         )
         res = cast(EvaluateRulesResponse, self._rule_evaluation_stub.EvaluateRules(req))
 
@@ -113,6 +119,8 @@ class RuleEvaluationService:
         self,
         run_id: str,
         rules: Union[ReportTemplateConfig, List[RuleConfig], List[RuleIdentifier]],
+        start_time: Optional[Union[datetime, str, int]] = None,
+        end_time: Optional[Union[datetime, str, int]] = None,
     ) -> EvaluateRulesPreviewResponse:
         """Preview the evaluation of a set of rules against a run.
 
@@ -120,15 +128,18 @@ class RuleEvaluationService:
             run_id: The Run ID to run against.
             rules: Either a ReportTemplateConfig, a list of RuleConfigs, or a list of
                 RuleIdentifiers (typically from `RuleService.create_external_rules`).
+            start_time: Optional start time to evaluate.
+            end_time: Optional end time to evaluate.
 
         Returns:
             The EvaluateRulesPreviewResponse object.
         """
         eval_kwargs = self._get_rules_kwargs(rules)
+        run_kwargs = self._get_run_kwargs(run_id, start_time, end_time)
 
         req = EvaluateRulesPreviewRequest(
-            run=ResourceIdentifier(id=run_id),
             **eval_kwargs,
+            **run_kwargs,
         )
 
         return self._rule_evaluation_stub.EvaluateRulesPreview(req)
@@ -138,6 +149,8 @@ class RuleEvaluationService:
         run_id: str,
         rules: List[RuleConfig],
         report_name: str = "",
+        start_time: Optional[Union[datetime, str, int]] = None,
+        end_time: Optional[Union[datetime, str, int]] = None,
     ) -> ReportService:
         """Evaluate a set of external rules against a run.
 
@@ -145,12 +158,14 @@ class RuleEvaluationService:
             run_id: The Run ID to run against.
             rules: A list of RuleConfigs. These must be external rules.
             report_name: Optional report name.
+            start_time: Optional start time to evaluate.
+            end_time: Optional end time to evaluate.
 
         Returns:
             A Report object that can be use to get the status of the executed report.
         """
         rule_ids = self._rule_service.create_external_rules(rules)
-        return self.evaluate_against_run(run_id, rule_ids, report_name)
+        return self.evaluate_against_run(run_id, rule_ids, report_name, start_time, end_time)
 
     def evaluate_external_rules_from_yaml(
         self,
@@ -158,6 +173,8 @@ class RuleEvaluationService:
         paths: List[Path],
         named_expressions: Optional[Dict[str, str]] = None,
         report_name: str = "",
+        start_time: Optional[Union[datetime, str, int]] = None,
+        end_time: Optional[Union[datetime, str, int]] = None,
     ) -> ReportService:
         """Evaluate a set of external rules from a YAML config against a run.
 
@@ -165,35 +182,43 @@ class RuleEvaluationService:
             run_id: The Run ID to run against.
             paths: The YAML paths to load rules from.
             report_name: Optional report name.
+            start_time: Optional start time to evaluate.
+            end_time: Optional end time to evaluate.
 
         Returns:
             A Report object that can be use to get the status of the executed report.
         """
         rule_ids = self._rule_service.create_external_rules_from_yaml(paths, named_expressions)
-        return self.evaluate_against_run(run_id, rule_ids, report_name)
+        return self.evaluate_against_run(run_id, rule_ids, report_name, start_time, end_time)
 
     def preview_external_rules(
         self,
         run_id: str,
         rules: List[RuleConfig],
+        start_time: Optional[Union[datetime, str, int]] = None,
+        end_time: Optional[Union[datetime, str, int]] = None,
     ) -> EvaluateRulesPreviewResponse:
         """Preview the evaluation a set of external rules against a run.
 
         Args:
             run_id: The Run ID to run against.
             rules: A list of RuleConfigs. These must be external rules.
+            start_time: Optional start time to evaluate.
+            end_time: Optional end time to evaluate.
 
         Returns:
             The EvaluateRulesPreviewResponse object.
         """
         rule_ids = self._rule_service.create_external_rules(rules)
-        return self.preview_against_run(run_id, rule_ids)
+        return self.preview_against_run(run_id, rule_ids, start_time, end_time)
 
     def preview_external_rules_from_yaml(
         self,
         run_id: str,
         paths: List[Path],
         named_expressions: Optional[Dict[str, str]] = None,
+        start_time: Optional[Union[datetime, str, int]] = None,
+        end_time: Optional[Union[datetime, str, int]] = None,
     ) -> EvaluateRulesPreviewResponse:
         """Preview the evaluation a set of external rules from a YAML config against a run.
 
@@ -201,12 +226,14 @@ class RuleEvaluationService:
             run_id: The Run ID to run against.
             paths: The YAML paths to load rules from.
             named_expressions: The named expressions to substitute in the rules.
+            start_time: Optional start time to evaluate.
+            end_time: Optional end time to evaluate.
 
         Returns:
             The EvaluateRulesPreviewResponse object.
         """
         rule_ids = self._rule_service.create_external_rules_from_yaml(paths, named_expressions)
-        return self.preview_against_run(run_id, rule_ids)
+        return self.preview_against_run(run_id, rule_ids, start_time, end_time)
 
     def _get_rules_kwargs(
         self, rules: Union[ReportTemplateConfig, List[RuleConfig], List[RuleIdentifier]]
@@ -259,3 +286,32 @@ class RuleEvaluationService:
                 }
 
         raise ValueError("Invalid rules argument")
+
+    def _get_run_kwargs(
+        self,
+        run_id: str,
+        start_time: Optional[Union[datetime, str, int]] = None,
+        end_time: Optional[Union[datetime, str, int]] = None,
+    ) -> dict:
+        """Returns the Run specific keyword arguments for a EvalutateRules request based on the input type.
+
+        Args:
+            run_id: The Run ID to run against.
+            start_time: Optional start time to evaluate.
+            end_time: Optional end time to evaluate.
+
+        Returns:
+            dict: The keyword arguments.
+        """
+        run = ResourceIdentifier(id=run_id)
+
+        if start_time or end_time:
+            return {
+                "run_time_range": RunTimeRange(
+                    run=run,
+                    start_time=to_timestamp_pb(start_time) if start_time else None,
+                    end_time=to_timestamp_pb(end_time) if end_time else None,
+                )
+            }
+        else:
+            return {"run": run}


### PR DESCRIPTION
This change adds support for specifying start and end times with evalutating rules against a run.