### PR TITLE
rust(enhancement): additional network unavailability resilience

### DIFF
--- a/rust/crates/sift_stream/src/stream/mode/ingestion_config.rs
+++ b/rust/crates/sift_stream/src/stream/mode/ingestion_config.rs
@@ -43,7 +43,7 @@ use uuid::Uuid;
 /// streams data to Sift.
 const DATA_BUFFER_CAPACITY: usize = 10_000;
 
-/// If Sift doesn't send back a cheeckpoint acknowledgement after this amount of time we will
+/// If Sift doesn't send back a checkpoint acknowledgement after this amount of time we will
 /// forcefully end the current stream.
 const FORCE_CHECKPOINT_THRESHOLD_SEC: u64 = 10;
 


### PR DESCRIPTION
## Changes

Depending on the timing of a network disruption, a gRPC stream could still freeze waiting for a response from Sift, whether it be from Sift itself or the load balancer. The changes in this PR https://github.com/sift-stack/sift/pull/258, although it minimized disruptions, didn't provide total resilience it seems.

This PR simplifies and improves the forceful checkpointing logic and adds the retry functionality in places where it was previously missing. For the forceful checkpointing mechanism it looks like we have to drop that actual ingestion client since `tonic` will freeze until it gets a response from Sift the moment it requests it. The way we achieve this is:

- When the checkpoint timer goes off we send a gentle signal to tonic saying that it should initiate a request for the checkpoint acknowledgement. This is blocking.
- Along with this gentle signal is a 10 second timer. Once this 10 second timer goes off we will send a notification forcing the ingestion client to be dropped.
- Once it is dropped we will then apply the retry policy.

## Verification

To verify these changes a H2/gRPC NGINX reverse-proxy was stood up locally which would hold the connection with the Rust client event if the gRPC service gets shut down mid-stream. Once a checkpoint acknowledgement is requested but no response is given within the 10 second timeout, we forcefully reconnect. In theory this would force `SiftStream` to reconnect to the next available pod.

Here is the recovery process:
<img width="1769" height="533" alt="image" src="https://github.com/user-attachments/assets/5fd187ac-a25f-49a0-a2df-2cccb74076aa" />
