### PR TITLE
python(fix) Include rule_id when updating rule

### DIFF
--- a/python/lib/sift_py/rule/_service_test.py
+++ b/python/lib/sift_py/rule/_service_test.py
@@ -184,7 +184,12 @@ def test_rule_service_attach_asset():
         asset_names=["abc"],
     )
     asset = Asset(name="asset", asset_id="asset-id", organization_id="org-id")
-    with mock.patch("sift_py.rule.service.RuleServiceStub", return_value=mock.MagicMock()):
+    with mock.patch(
+        "sift_py.rule.service.RuleServiceStub", return_value=mock.MagicMock()
+    ) as mock_stub:
+        # Need to return a rule_id string when calling get_rule
+        mock_instance = mock_stub.return_value
+        mock_instance.GetRule.return_value.rule.rule_id = ""
         rule_service = RuleService(MockChannel())
         with mock.patch.object(RuleService, "_get_assets", return_value=[asset]):
             returned_config = rule_service.attach_asset(rule_config, ["asset"])
@@ -203,7 +208,12 @@ def test_rule_service_detach_asset():
     )
     asset_abc = Asset(name="abc", asset_id="abc-id", organization_id="org-id")
     asset_def = Asset(name="def", asset_id="def-id", organization_id="org-id")
-    with mock.patch("sift_py.rule.service.RuleServiceStub", return_value=mock.MagicMock()):
+    with mock.patch(
+        "sift_py.rule.service.RuleServiceStub", return_value=mock.MagicMock()
+    ) as mock_stub:
+        # Need to return a rule_id string when calling get_rule
+        mock_instance = mock_stub.return_value
+        mock_instance.GetRule.return_value.rule.rule_id = ""
         rule_service = RuleService(MockChannel())
         with mock.patch.object(RuleService, "_get_assets", return_value=[asset_abc, asset_def]):
             returned_config = rule_service.detach_asset(rule_config, ["abc"])

--- a/python/lib/sift_py/rule/config.py
+++ b/python/lib/sift_py/rule/config.py
@@ -38,6 +38,7 @@ class RuleConfig(AsJson):
     asset_names: List[str]
     contextual_channels: List[str]
     is_external: bool
+    _rule_id: Optional[str]  # Allow passing of rule_id when existing config retrieved from API
 
     def __init__(
         self,
@@ -65,6 +66,7 @@ class RuleConfig(AsJson):
         self.description = description
         self.expression = self.__class__.interpolate_sub_expressions(expression, sub_expressions)
         self.is_external = is_external
+        self._rule_id = None
 
     def as_json(self) -> Any:
         """


### PR DESCRIPTION
Fixes potential error when making updates to a rule by ensuring `rule_id` is always passed to `UpdateRuleRequest`

**Verification**
```
with use_sift_channel(sift_channel_config) as channel:
    rule_service = RuleService(channel)

    rule_service.create_or_update_rules(rules)
    for rule in rules:
        rule_service.attach_asset(rule, ["asset-2"])
```

Would previously cause an `_InactiveRpcError` due to `UpdateRuleRequest` being sent without an `rule_id`. Successfully runs with fix, and rule is updated as expected in Sift.