### PR TITLE
python(bug): Catch PermissionError when removing temp files.

### DIFF
--- a/python/lib/sift_py/data_import/tempfile.py
+++ b/python/lib/sift_py/data_import/tempfile.py
@@ -35,5 +35,5 @@ class NamedTemporaryFile:
         try:
             os.remove(self.name)
             os.rmdir(self.temp_dir)
-        except FileNotFoundError:
+        except (FileNotFoundError, PermissionError):
             pass


### PR DESCRIPTION
PermissionError can happen when another program (like a virus scanner) is reading the file and we try to close it. Since removing the file is not critical, we should not throw an error. The file will be removed by the operating system's temp file retention policies.