### PR TITLE
python(fix): Use name only in ChannelReference creation

### DIFF
--- a/python/lib/sift_py/ingestion/_internal/channel.py
+++ b/python/lib/sift_py/ingestion/_internal/channel.py
@@ -2,11 +2,5 @@ from sift.rules.v1.rules_pb2 import ChannelReference
 
 
 def channel_reference_from_fqn(fqn: str) -> ChannelReference:
-    parts = fqn.split(".")
-
-    if len(parts) == 1:
-        return ChannelReference(name=parts[0])
-
-    component_parts = parts[: len(parts) - 1]
-
-    return ChannelReference(name=parts[-1], component=".".join(component_parts))
+    # Components are depreciated, so use full channel name in name
+    return ChannelReference(name=fqn)


### PR DESCRIPTION
Fixes bug with UpdateRuleRequest

**Verification**
Successfully created rule that failed previously when UpdateRuleRequest received ChannelReferences with the channel name split between the name and depreciated component fields 