### PR TITLE
protos: Add 'field_kind' to the IncompatibleProtobufField message

### DIFF
--- a/protos/sift/protobuf_descriptors/v2/protobuf_descriptors.proto
+++ b/protos/sift/protobuf_descriptors/v2/protobuf_descriptors.proto
@@ -95,6 +95,7 @@ message IncompatibleProtobufField {
   string field_number = 5;
   string reason = 6;
   string details = 7;
+  string field_kind = 8;
 } 
 
 message CheckProtobufDescriptorCompatibilityResponse {


### PR DESCRIPTION
Adds the string field "field_kind" to the `IncompatibleProtobufField` message definition.

This new field helps indicate the "kind" (or type) of the incompatible field; when an incompatible type change is found, this new field also includes what the field type previously was to help drive corrective actions.