### PR TITLE
rust(fix): Add ErrorSignal to avoid checkpoint misses

### DIFF
--- a/rust/crates/sift_stream/src/stream/mode/ingestion_config.rs
+++ b/rust/crates/sift_stream/src/stream/mode/ingestion_config.rs
@@ -79,6 +79,7 @@ pub enum IngestionConfigModeBackupsManager {
 enum StreamMessage {
     Request(IngestWithConfigDataStreamRequest),
     CheckpointSignal,
+    ErrorSignal
 }
 
 impl SiftStreamMode for IngestionConfigMode {}
@@ -311,39 +312,63 @@ impl SiftStream<IngestionConfigMode> {
         match data_tx.send(StreamMessage::Request(req.clone())).await {
             Ok(_) => Ok(()),
 
-            Err(SendError(_)) => match self.mode.streaming_task.take() {
-                None => {
-                    self.restart_stream_and_backups_manager(false).await?;
-                    Box::pin(self.send_impl(req)).await
-                }
-
-                Some(streaming_task) => match streaming_task.await {
-                    Ok(Ok(_)) => {
+            Err(SendError(_)) => {
+                #[cfg(feature = "tracing")]
+                tracing::debug!(
+                    sift_stream_id = self.mode.sift_stream_id.to_string(),
+                    "Returned Err(SendError) during data_tx.send()"
+                );
+                match self.mode.streaming_task.take() {
+                    None => {
+                        #[cfg(feature = "tracing")]
+                        tracing::debug!(
+                            sift_stream_id = self.mode.sift_stream_id.to_string(),
+                            "No streaming task was taken. Awaiting restart_stream_and_backups_manager()"
+                        );
                         self.restart_stream_and_backups_manager(false).await?;
                         Box::pin(self.send_impl(req)).await
                     }
-                    Ok(Err(err)) => {
-                        #[cfg(feature = "tracing")]
-                        tracing::warn!(
-                            sift_stream_id = self.mode.sift_stream_id.to_string(),
-                            error = format!("{err:?}"),
-                            "encountered an error while streaming to Sift"
-                        );
 
-                        self.retry(req, err).await
-                    }
-                    Err(err) => {
+                    Some(streaming_task) => {
                         #[cfg(feature = "tracing")]
-                        tracing::warn!(
+                        tracing::debug!(
                             sift_stream_id = self.mode.sift_stream_id.to_string(),
-                            error = format!("{err:?}"),
-                            "something went wrong while waiting for response from Sift"
+                            "Awaiting streaming_task"
                         );
+                        match streaming_task.await {
+                            Ok(Ok(_)) => {
+                                #[cfg(feature = "tracing")]
+                                tracing::debug!(
+                                    sift_stream_id = self.mode.sift_stream_id.to_string(),
+                                    "Streaming_task returned Ok(). Awaiting restart_stream_and_backups_manager()"
+                                );
+                                self.restart_stream_and_backups_manager(false).await?;
+                                Box::pin(self.send_impl(req)).await
+                            }
+                            Ok(Err(err)) => {
+                                #[cfg(feature = "tracing")]
+                                tracing::warn!(
+                                    sift_stream_id = self.mode.sift_stream_id.to_string(),
+                                    error = format!("{err:?}"),
+                                    "encountered an error while streaming to Sift"
+                                );
 
-                        self.retry(req, Error::new(ErrorKind::StreamError, err))
-                            .await
-                    }
-                },
+                                self.retry(req, err).await
+                            }
+                            Err(err) => {
+                                #[cfg(feature = "tracing")]
+                                tracing::warn!(
+                                    sift_stream_id = self.mode.sift_stream_id.to_string(),
+                                    error = format!("{err:?}"),
+                                    "something went wrong while waiting for response from Sift"
+                                );
+
+                                self.retry(req, Error::new(ErrorKind::StreamError, err))
+                                    .await
+                            }
+                        }
+                    },
+                }
             },
         }
     }
@@ -366,6 +391,7 @@ impl SiftStream<IngestionConfigMode> {
                 .and_modify(|flows| flows.push(flow_config.clone()))
                 .or_insert_with(|| vec![flow_config.clone()]);
 
+            #[cfg(feature = "tracing")]
             tracing::info!(
                 sift_stream_id = self.mode.sift_stream_id.to_string(),
                 flow = flow_config.name,
@@ -784,6 +810,7 @@ impl SiftStream<IngestionConfigMode> {
             let force_checkpoint = Arc::new(Notify::new());
             let force_checkpoint_c = force_checkpoint.clone();
 
+            let data_tx_c = data_tx.clone();
             let checkpoint_task = tokio::spawn(async move {
                 let mut checkpoint_timer = {
                     let mut timer = tokio::time::interval(checkpoint_interval);
@@ -839,7 +866,16 @@ impl SiftStream<IngestionConfigMode> {
                             );
                             Ok(res)
                         }
-                        Err(err) => Err(err),
+                        Err(err) => {
+                            #[cfg(feature = "tracing")]
+                            tracing::info!(
+                                sift_stream_id = sift_stream_id.to_string(),
+                                "received error from Sift: {:?}",
+                                err
+                            );
+                            let _ = data_tx_c.send(StreamMessage::ErrorSignal).await;
+                            Err(err)
+                        }
                     }
                 }
                 _ = force_checkpoint.notified() => {
@@ -978,6 +1014,16 @@ impl Stream for DataStream {
                     );
 
                     // Checkpoint was requested.. conclude stream
+                    Poll::Ready(None)
+                }
+                StreamMessage::ErrorSignal => {
+                    #[cfg(feature = "tracing")]
+                    tracing::debug!(
+                        sift_stream_id = self.sift_stream_id.to_string(),
+                        "error signal received",
+                    );
+
+                    // Had error response.. conclude stream
                     Poll::Ready(None)
                 }
             },


### PR DESCRIPTION
Adds `ErrorSignal` to `StreamMessage` to catch errors from `client.ingest_with_config_data_stream(data_stream)`. Fix allows restart of checkpoint instead of dropping it entirely.

**Verification**
Dev branch with fix running with soak test