### PR TITLE
python(feat): lazy flow creation

### DIFF
--- a/python/lib/sift_py/error.py
+++ b/python/lib/sift_py/error.py
@@ -1,5 +1,7 @@
 import warnings
 
+import google.protobuf.message
+
 
 class SiftError(Exception):
     """
@@ -28,3 +30,20 @@ def _component_deprecation_warning():
         "See docs for more details: https://docs.siftstack.com/docs/glossary#component",
         SiftAPIDeprecationWarning,
     )
+
+
+# The default max message size for the Sift gRPC server.
+GRPC_MAX_MESSAGE_SIZE = 4_194_304
+
+
+class ProtobufMaxSizeExceededError(Exception):
+    """
+    The library limits the size of certain protobufs to prevent gRPC messages from being too big.
+    """
+
+
+def raise_if_too_large(pb: google.protobuf.message.Message):
+    size = len(pb.SerializeToString())
+    name = getattr(pb, "name", pb.__class__.__name__)
+    if size > GRPC_MAX_MESSAGE_SIZE:
+        raise ProtobufMaxSizeExceededError(f"{name} too large: {size}")

--- a/python/lib/sift_py/ingestion/service.py
+++ b/python/lib/sift_py/ingestion/service.py
@@ -32,11 +32,11 @@ class IngestionService(_IngestionServiceImpl):
         won't be interrupted. The errors produced are surfaced on the user errors page. Setting this field to `True`
         will ensure that any errors that occur during ingestion is returned immediately, terminating the stream. This
         is useful for debugging purposes.
-    - `lazy_flow_ingestion`:
+    - `lazy_flow_creation`:
         By default, the entire telemetry config is processed when the service is initialized, and if needed, the config and all flow info
         is sent to Sift. In the event a sufficiently large telemetry config is provided which is too large to send in one single
         gRPC message, the ingestion service will instead use a lazy flow ingestion method, which sets this boolean to True. This method
-        registers individual flows the first time they are ingested. Initializing with `force_lazy_flow_ingestion` will force this behavior
+        registers individual flows the first time they are ingested. Initializing with `force_lazy_flow_creation` will force this behavior
         for any telemetry flow size. If a sufficently large telemetry config is being sent, and lazy flow ingestion behavior is not desired,
         the list of flows must be broken up beforehand and sent through the service's create flow methods.
     """
@@ -56,14 +56,14 @@ class IngestionService(_IngestionServiceImpl):
         config: TelemetryConfig,
         run_id: Optional[str] = None,
         end_stream_on_error: bool = False,
-        force_lazy_flow_ingestion: bool = False,
+        force_lazy_flow_creation: bool = False,
     ):
         super().__init__(
             channel=channel,
             config=config,
             run_id=run_id,
             end_stream_on_error=end_stream_on_error,
-            force_lazy_flow_ingestion=force_lazy_flow_ingestion,
+            force_lazy_flow_creation=force_lazy_flow_creation,
         )
 
     def ingest(self, *requests: IngestWithConfigDataStreamRequest):

--- a/python/lib/sift_py/ingestion/service.py
+++ b/python/lib/sift_py/ingestion/service.py
@@ -32,6 +32,13 @@ class IngestionService(_IngestionServiceImpl):
         won't be interrupted. The errors produced are surfaced on the user errors page. Setting this field to `True`
         will ensure that any errors that occur during ingestion is returned immediately, terminating the stream. This
         is useful for debugging purposes.
+    - `lazy_flow_ingestion`:
+        By default, the entire telemetry config is processed when the service is initialized, and if needed, the config and all flow info
+        is sent to Sift. In the event a sufficiently large telemetry config is provided which is too large to send in one single
+        gRPC message, the ingestion service will instead use a lazy flow ingestion method, which sets this boolean to True. This method
+        registers individual flows the first time they are ingested. Initializing with `force_lazy_flow_ingestion` will force this behavior
+        for any telemetry flow size. If a sufficently large telemetry config is being sent, and lazy flow ingestion behavior is not desired,
+        the list of flows must be broken up beforehand and sent through the service's create flow methods.
     """
 
     transport_channel: SiftChannel
@@ -41,6 +48,7 @@ class IngestionService(_IngestionServiceImpl):
     run_id: Optional[str]
     organization_id: Optional[str]
     end_stream_on_error: bool
+    lazy_flow_creation: bool
 
     def __init__(
         self,
@@ -48,9 +56,14 @@ class IngestionService(_IngestionServiceImpl):
         config: TelemetryConfig,
         run_id: Optional[str] = None,
         end_stream_on_error: bool = False,
+        force_lazy_flow_ingestion: bool = False,
     ):
         super().__init__(
-            channel=channel, config=config, run_id=run_id, end_stream_on_error=end_stream_on_error
+            channel=channel,
+            config=config,
+            run_id=run_id,
+            end_stream_on_error=end_stream_on_error,
+            force_lazy_flow_ingestion=force_lazy_flow_ingestion,
         )
 
     def ingest(self, *requests: IngestWithConfigDataStreamRequest):


### PR DESCRIPTION
Implements lazy flow creation for the IngestionService.

Lazy flow creation registers the telemetry config at IngestionService initialization without any flow configs. Flow configs are registered only upon initial ingestion of that flow. This amortizes flow config registration over time, allowing very large telemetry configs which previously would have reached the maximum gRPC message size, and reducing the time needed for initilization of the IngestionService for larger configs.

By default, smaller telemetry configs will continue to be initialized up front. A `force_lazy_flow_ingestion` flag can be set to true at IngestionService initialization to force this behavior for smaller configs.

### Benchmark

**4 asset sizes**
- Small: 2 flows, 5 channels each
- Medium: 20 flows, 50 channels each
- Large: 200 flows, 1000 channels each
- Very large: 1000 flows, 2500 channels each

**Tests**
- 1 data point: Init IngestionService and ingest up to 50 flows worth of channels once
- 100 data points: Init IngestionService and ingest up to 50 flows worth of channels 10 times
- Performed on new assets, than repeated to provide existing asset stats
- Benchmarked both initialization time and ingestion time
- Tested with the following:
  - Baseline library 0.8.3
  - Lazy flow default behavior (`force_lazy_flow_ingestion` = False)
  - All lazy flow (`force_lazy_flow_ingestion` = True)

<img width="1140" height="299" alt="image" src="https://github.com/user-attachments/assets/8b156fff-585f-4ef5-aad7-994240511a5c" />

**Conclusions**
- No noticeable impact on smaller flows with default behavior (as expected)
- The slow large asset initialization issues are mitigated with lazy flow ingestion
  - 60s init reduces to <1s. First flow ingestion time increases, due to amortization of flow creation, but overall time is still faster. Also true for ingestion of existing assets
- Lack of significant ingest time increase with 10 data point test vs 1 point test indicates that ingestion remains fast after initial flows are sent.
- Lazy flow enables use of very large assets without need to split up flows beforehand. With the existing library, very large assets throw a gRPC error due to exceeding the gRPC message size
