### PR TITLE
rust(feat): Sift stream async backup manager

### DIFF
--- a/rust/crates/sift_stream/src/backup/disk/async_manager.rs
+++ b/rust/crates/sift_stream/src/backup/disk/async_manager.rs
@@ -103,7 +103,7 @@ where
             prefix: backup_prefix.to_string(),
             max_size: disk_backup_policy.max_backup_file_size,
             max_file_count: disk_backup_policy.rolling_file_policy.max_file_count,
-            retain_ingested: disk_backup_policy.retain_ingested_backups,
+            retain_ingested: disk_backup_policy.retain_backups,
         };
 
         let backup_files = Arc::new(Mutex::new(vec![]));

--- a/rust/crates/sift_stream/src/backup/disk/async_manager.rs
+++ b/rust/crates/sift_stream/src/backup/disk/async_manager.rs
@@ -1,0 +1,596 @@
+use super::Message;
+use crate::RetryPolicy;
+use crate::backup::DiskBackupPolicy;
+use crate::backup::disk::decode_backup;
+use crate::backup::disk::pbfs::BackupsDecoder;
+use crate::backup::disk::pbfs::{
+    BATCH_SIZE_LEN, CHECKSUM_HEADER_LEN, PbfsChunk, chunk::MESSAGE_LENGTH_PREFIX_LEN,
+};
+use chrono::Utc;
+use prost::Message as PbMessage;
+use sift_error::prelude::*;
+use sift_rs::ingest::v1::IngestWithConfigDataStreamRequest;
+use sift_rs::{SiftChannel, ingest::v1::ingest_service_client::IngestServiceClient};
+use std::{
+    fs::{self, File},
+    io::{Error as IoError, ErrorKind as IoErrorKind, Write},
+    path::PathBuf,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+use tokio::{
+    runtime::Handle,
+    sync::{
+        Mutex, Notify,
+        mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
+    },
+    task::JoinHandle,
+};
+use tokio_stream::StreamExt;
+
+/// The buffer size used by the in-memory message buffer that gets flushed to file when full.
+const CHANNEL_BUFFER_SIZE: usize = 10_000;
+
+#[derive(Clone)]
+struct BackupInfo {
+    directory: PathBuf,
+    prefix: String,
+    max_size: usize,
+    max_file_count: Option<usize>,
+    retain_ingested: bool,
+}
+
+/// Disk-based backup with async ingestion implementation.
+pub struct AsyncBackupsManager<T> {
+    backup_info: BackupInfo,
+    backup_retry_policy: RetryPolicy,
+    backup_task: Option<JoinHandle<Result<()>>>,
+    ingest_task: Option<BackupIngestTask>,
+    backup_files: Arc<Mutex<Vec<PathBuf>>>,
+    backup_tx: UnboundedSender<Message<T>>,
+    backup_full: Arc<AtomicBool>,
+    flush_and_sync_notifier: Arc<Notify>,
+    restart_backup_notifier: Arc<Notify>,
+    grpc_channel: SiftChannel,
+}
+
+impl<T> AsyncBackupsManager<T>
+where
+    T: PbMessage + Default + 'static,
+{
+    /// Create new AsyncBackupsManager.
+    /// Starts backup task for ingesting sent data to files.
+    /// Users shouldn't have to call interact with [AsyncBackupsManager::new] directly, as this is
+    /// normally performed as part of builder
+    ///
+    /// # Arguments
+    ///
+    /// * `new_dir_name` - The name of the directory used for storing backup files
+    /// * `backup_prefix` - The prefix added to all backup files
+    /// * `disk_backup_policy` - The policy for disk backups
+    /// * `backup_retry_policy` - The retry policy used if backup ingestion is required, but with unlimited retries
+    /// * `grpc_channel` - The SiftChannel used for backup ingestion
+    pub fn new(
+        new_dir_name: &str,
+        backup_prefix: &str,
+        disk_backup_policy: DiskBackupPolicy,
+        backup_retry_policy: RetryPolicy,
+        grpc_channel: SiftChannel,
+    ) -> Result<Self> {
+        let (backup_tx, backup_rx) = unbounded_channel::<Message<T>>();
+
+        let Some(backups_root) = disk_backup_policy.backups_dir.or_else(dirs::data_dir) else {
+            return Err(
+                IoError::new(IoErrorKind::NotFound, "user data directory not found").into(),
+            );
+        };
+        let backups_dir = backups_root.join(new_dir_name);
+
+        match fs::create_dir_all(&backups_dir) {
+            Err(err) if err.kind() != IoErrorKind::AlreadyExists => {
+                return Err(Error::new(ErrorKind::BackupsError, err))
+                    .with_context(|| format!("failed to create directory for backups at {}", backups_dir.display()))
+                    .help("if using a custom path for backups directory ensure that it's valid with proper permissions, otherwise contact Sift")
+            }
+            _ => ()
+        }
+
+        let backup_info = BackupInfo {
+            directory: backups_dir,
+            prefix: backup_prefix.to_string(),
+            max_size: disk_backup_policy.max_backup_file_size,
+            max_file_count: disk_backup_policy.rolling_file_policy.max_file_count,
+            retain_ingested: disk_backup_policy.retain_ingested_backups,
+        };
+
+        let backup_files = Arc::new(Mutex::new(vec![]));
+        let flush_and_sync_notifier = Arc::new(Notify::new());
+        let restart_backup_notifier = Arc::new(Notify::new());
+        let backup_full = Arc::new(AtomicBool::new(false));
+
+        let backup_task = Self::init_backup_task(
+            backup_info.clone(),
+            backup_rx,
+            backup_files.clone(),
+            backup_full.clone(),
+            flush_and_sync_notifier.clone(),
+            restart_backup_notifier.clone(),
+        )
+        .context("failed to start backup task")?;
+
+        Ok(Self {
+            backup_info,
+            backup_retry_policy,
+            backup_task: Some(backup_task),
+            ingest_task: None,
+            backup_files,
+            backup_tx,
+            backup_full,
+            flush_and_sync_notifier,
+            restart_backup_notifier,
+            grpc_channel,
+        })
+    }
+
+    // Init the backup task. Runs until Flush or Complete signal given.
+    // Recieves messages with backup_rx.
+    // Adds files to backup_files once finalized.
+    // Backup_full set true if backups are full.
+    // Waits on restart_backup_notifier if full.
+    // Sends notification of flush_and_sync_notifier when flush is complete.
+    fn init_backup_task(
+        backup_info: BackupInfo,
+        mut backup_rx: UnboundedReceiver<Message<T>>,
+        backup_files: Arc<Mutex<Vec<PathBuf>>>,
+        backup_full: Arc<AtomicBool>,
+        flush_and_sync_notifier: Arc<Notify>,
+        restart_backup_notifier: Arc<Notify>,
+    ) -> Result<JoinHandle<Result<()>>> {
+        let handle = Handle::current();
+
+        let join_handle = tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut message_buffer = Vec::with_capacity(CHANNEL_BUFFER_SIZE);
+            //let mut bytes_processed = 0;
+
+            let mut cur_bytes_processed = 0;
+            let (mut cur_backup_file_path, mut cur_backup_file) =
+                Self::create_backup_file(&backup_info)?;
+
+            while let Some(message) = backup_rx.blocking_recv() {
+                match message {
+                    Message::Data(data) => {
+                        cur_bytes_processed += data.encoded_len() + MESSAGE_LENGTH_PREFIX_LEN;
+                        message_buffer.push(data);
+
+                        if cur_bytes_processed >= backup_info.max_size
+                            || message_buffer.len() >= CHANNEL_BUFFER_SIZE
+                        {
+                            Self::flush_message_buffer(&mut cur_backup_file, &mut message_buffer)?;
+                            cur_bytes_processed += CHECKSUM_HEADER_LEN + BATCH_SIZE_LEN;
+
+                            if cur_bytes_processed >= backup_info.max_size {
+                                #[cfg(feature = "tracing")]
+                                tracing::debug!(
+                                    cur_backup_file = format!("{}", cur_backup_file_path.display()),
+                                    cur_bytes_processed,
+                                    max_backup_size = backup_info.max_size,
+                                    "current backup file has reached max size"
+                                );
+
+                                // Close out the current file
+                                drop(cur_backup_file);
+
+                                let backup_files_len;
+                                {
+                                    let mut backup_files_guard = backup_files.blocking_lock();
+                                    backup_files_guard.push(cur_backup_file_path);
+                                    backup_files_len = backup_files_guard.len();
+                                }
+                                if let Some(max_file_count) = backup_info.max_file_count
+                                    && backup_files_len >= max_file_count
+                                {
+                                    // We've reached our max file/size limit. Send signal and wait for restart notification
+                                    backup_full.store(true, Ordering::Relaxed);
+                                    handle.block_on(restart_backup_notifier.notified());
+                                }
+
+                                cur_bytes_processed = 0;
+                                (cur_backup_file_path, cur_backup_file) =
+                                    Self::create_backup_file(&backup_info)?;
+                            }
+                        }
+                    }
+                    Message::Flush => {
+                        #[cfg(feature = "tracing")]
+                        tracing::debug!("backup task received flush and sync signal");
+
+                        if !message_buffer.is_empty() {
+                            Self::flush_message_buffer(&mut cur_backup_file, &mut message_buffer)?;
+                        }
+                        drop(cur_backup_file);
+                        {
+                            let mut backup_files_guard = backup_files.blocking_lock();
+                            backup_files_guard.push(cur_backup_file_path);
+                        }
+                        flush_and_sync_notifier.notify_one();
+                        (cur_backup_file_path, cur_backup_file) =
+                            Self::create_backup_file(&backup_info)?;
+                    }
+                    Message::Complete => {
+                        #[cfg(feature = "tracing")]
+                        tracing::debug!("backup task complete - shutting down");
+
+                        // Close out current file and add to file list
+                        drop(cur_backup_file);
+                        {
+                            let mut backup_files_guard = backup_files.blocking_lock();
+                            backup_files_guard.push(cur_backup_file_path);
+                        }
+
+                        return Ok(());
+                    }
+                }
+            }
+            Ok(())
+        });
+        Ok(join_handle)
+    }
+
+    // Write to file from message_buffer. Called from backup task
+    fn flush_message_buffer(backup_file: &mut File, message_buffer: &mut Vec<T>) -> Result<()> {
+        let chunk = PbfsChunk::new(message_buffer)?;
+        backup_file.write_all(&chunk)?;
+        backup_file.sync_all()?;
+        message_buffer.clear();
+        Ok(())
+    }
+
+    // Create a backup file. Called from backup task
+    fn create_backup_file(backup_info: &BackupInfo) -> Result<(PathBuf, File)> {
+        let backup_file_path = backup_info.directory.join(format!(
+            "{}-{}",
+            backup_info.prefix,
+            Utc::now().timestamp_millis()
+        ));
+        let backup_file = File::create(&backup_file_path)
+            .map_err(|e| Error::new(ErrorKind::BackupsError, e))
+            .context("failed to generate backup file")
+            .help("please contact Sift")?;
+
+        Ok((backup_file_path, backup_file))
+    }
+
+    /// Restart the backup task. Clears the current list of unprocessed backup files, and deleting them
+    /// if allowed by the retain policy. Unpauses the backup task if the backups were full.
+    pub async fn restart(&mut self) -> Result<()> {
+        #[cfg(feature = "tracing")]
+        tracing::info!("Restarting async backup. Clearing existing backup files");
+
+        // Always clear backup files on restart since it indicates a successful checkpoint
+        let mut backup_files_guard = self.backup_files.lock().await;
+        if !self.backup_info.retain_ingested {
+            for file_path in backup_files_guard.iter() {
+                if let Err(err) = fs::remove_file(file_path) {
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!(
+                        backup_file = file_path.display().to_string(),
+                        "Unable to delete backup file: {:?}",
+                        err
+                    );
+                }
+            }
+        }
+        backup_files_guard.clear();
+
+        if self.backup_task.is_some() {
+            if self.backup_full.swap(false, Ordering::Relaxed) {
+                // Was previously full. Need to restart backup
+                self.restart_backup_notifier.notify_one();
+            }
+        } else {
+            #[cfg(feature = "tracing")]
+            tracing::warn!("No backup task found. Restarting. Some backup data may have been lost");
+
+            let (backup_tx, backup_rx) = unbounded_channel::<Message<T>>();
+
+            let backup_task = Self::init_backup_task(
+                self.backup_info.clone(),
+                backup_rx,
+                self.backup_files.clone(),
+                self.backup_full.clone(),
+                self.flush_and_sync_notifier.clone(),
+                self.restart_backup_notifier.clone(),
+            )
+            .context("failed to start backup task")?;
+
+            self.backup_tx = backup_tx;
+            self.backup_task = Some(backup_task);
+        }
+
+        Ok(())
+    }
+
+    /// Start backup ingestion
+    /// Send flush command and wait
+    /// Takes the current list of backup files and adds them to a queue for ingestion
+    /// The ingestion task is started if not already running
+    pub async fn start_backup_ingestion(&mut self) -> usize {
+        match self.backup_tx.send(Message::Flush) {
+            Ok(_) => {
+                // Wait for notification that we've flushed the backup file
+                self.flush_and_sync_notifier.notified().await;
+                #[cfg(feature = "tracing")]
+                tracing::debug!("Got flush notification from backup task");
+            }
+            Err(err) => {
+                // Skip the flush notification since we don't want to get stuck
+                #[cfg(feature = "tracing")]
+                tracing::warn!("Error sending flush command to backup task. {:?}", err);
+            }
+        }
+
+        let unprocessed_files: Vec<PathBuf> = {
+            let mut backup_files_guard = self.backup_files.lock().await;
+            backup_files_guard.drain(..).collect()
+        };
+
+        let file_count = unprocessed_files.len();
+
+        if file_count == 0 {
+            return file_count;
+        }
+
+        if let Some(ingest_task) = self.ingest_task.as_mut() {
+            if let Err(err) = ingest_task.add(unprocessed_files.clone()) {
+                #[cfg(feature = "tracing")]
+                tracing::warn!(
+                    "Error trying to add files to ingest queue. Restarting ingest task. {:?}",
+                    err
+                );
+            } else {
+                return file_count;
+            }
+        }
+
+        // No ingest task, or we saw errors when trying to add to the queue, so we should try restarting it
+
+        let mut ingest_task = BackupIngestTask::new(
+            self.grpc_channel.clone(),
+            self.backup_retry_policy.clone(),
+            self.backup_info.retain_ingested,
+        );
+        if let Err(err) = ingest_task.add(unprocessed_files) {
+            #[cfg(feature = "tracing")]
+            tracing::warn!(
+                "Saw error when trying to add files to ingest queue: {:?}",
+                err
+            );
+        }
+        self.ingest_task = Some(ingest_task);
+
+        file_count
+    }
+
+    /// Send files for backup or sends message to flush/complete
+    pub async fn send(&mut self, msg: T) -> Result<()> {
+        if self.backup_full.load(Ordering::Relaxed) {
+            return Err(Error::new_msg(
+                ErrorKind::BackupLimitReached,
+                "backup limit reached",
+            ));
+        }
+
+        match self.backup_tx.send(Message::Data(msg)) {
+            Ok(_) => Ok(()),
+
+            // data_rx must be dropped, indicating backup task has shutdown
+            Err(_) => {
+                let Some(backup_task) = self.backup_task.take() else {
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!("no backup task found during send");
+                    return Ok(());
+                };
+
+                tokio::select! {
+                    res = backup_task => {
+                        match res {
+                            Ok(Ok(_)) => Err(Error::new_msg(
+                                ErrorKind::BackupLimitReached,
+                                "backup limit reached",
+                            )),
+                            Ok(Err(err)) => Err(Error::new(ErrorKind::BackupsError, err))
+                                .context("backup task encountered an error")
+                                .help("please notify Sift"),
+                            Err(err) => Err(Error::new(ErrorKind::BackupsError, err))
+                                .context("error waiting for backup task to finish")
+                                .help("please notify Sift"),
+                        }
+                    },
+                    // Should never reach this, but included to avoid potential block on send
+                    _ = tokio::time::sleep(Duration::from_secs(5)) => {
+                        Err(Error::new_msg(ErrorKind::BackupsError, "timed out waiting for backup_task to return"))
+                            .help("please notify Sift")
+                    }
+                }
+            }
+        }
+    }
+
+    /// Shutdown the manager. Flushes the open backup file and adds to the backup file list
+    pub async fn finish(&mut self) -> Result<()> {
+        // Signal to close out last file
+        let _ = self.backup_tx.send(Message::Complete);
+
+        // Abort the ingest task, if it exists
+        // Any files marked for ingestion but not ingested will remain on disk
+        if let Some(ingest_task) = self.ingest_task.take() {
+            ingest_task.task_handle.abort();
+        }
+
+        // If we aren't retaining backup files, wait for task to complete and clean up
+        if !self.backup_info.retain_ingested
+            && let Some(backup_task) = self.backup_task.take()
+        {
+            let _ = backup_task.await;
+            for file_path in self.backup_files.lock().await.iter() {
+                if let Err(err) = fs::remove_file(file_path) {
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!(
+                        backup_file = file_path.display().to_string(),
+                        "Unable to delete backup file: {:?}",
+                        err
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Contains handle to the ingest task and an unbound queue for transmitting data
+/// Task will ingest each file provided in the ingestion queue, retrying indefinitely if needed
+/// Successfully ingested files are cleared using the provided retention policy
+struct BackupIngestTask {
+    ingest_tx: UnboundedSender<PathBuf>,
+    task_handle: JoinHandle<Result<()>>,
+}
+
+impl BackupIngestTask {
+    fn new(grpc_channel: SiftChannel, retry_policy: RetryPolicy, retain_ingested: bool) -> Self {
+        let (ingest_tx, mut ingest_rx) = unbounded_channel::<PathBuf>();
+
+        let task_handle = tokio::spawn(async move {
+            let mut files_ingested = 0;
+
+            // Will sleep, waiting for more files until BackupIngestTask is dropped
+            while let Some(backup_file_path) = ingest_rx.recv().await {
+                let mut retries = 0;
+                let mut current_wait = retry_policy.initial_backoff;
+
+                loop {
+                    if ingest_rx.is_closed() {
+                        break;
+                    }
+
+                    if let Err(err) =
+                        Self::ingest_file(grpc_channel.clone(), backup_file_path.clone()).await
+                    {
+                        retries += 1;
+
+                        #[cfg(feature = "tracing")]
+                        tracing::warn!(
+                            backup_file = backup_file_path.display().to_string(),
+                            err = format!("{err:?}"),
+                            current_retry = retries,
+                            "Retrying backup file ingestion after backoff: {} secs",
+                            current_wait.as_secs_f32()
+                        );
+                        tokio::time::sleep(current_wait).await;
+                        current_wait = (current_wait * u32::from(retry_policy.backoff_multiplier))
+                            .min(retry_policy.max_backoff);
+
+                        continue;
+                    }
+                    files_ingested += 1;
+
+                    #[cfg(feature = "tracing")]
+                    tracing::info!(
+                        backup_file = backup_file_path.display().to_string(),
+                        files_ingested,
+                        "Backup file ingested",
+                    );
+                    break;
+                }
+
+                if !retain_ingested && let Err(err) = std::fs::remove_file(backup_file_path.clone())
+                {
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!(
+                        backup_file = backup_file_path.display().to_string(),
+                        "Unable to delete ingested backup file: {:?}",
+                        err
+                    );
+                }
+            }
+
+            Ok(())
+        });
+
+        Self {
+            ingest_tx,
+            task_handle,
+        }
+    }
+
+    /// Attempt to ingest a provided file into sift
+    async fn ingest_file(grpc_channel: SiftChannel, backup_file_path: PathBuf) -> Result<()> {
+        let mut client = IngestServiceClient::new(grpc_channel);
+
+        let decoder_res: Result<BackupsDecoder<IngestWithConfigDataStreamRequest, _>> =
+            decode_backup(&backup_file_path);
+
+        match decoder_res {
+            Ok(backups_decoder) => {
+                let iter_stream =
+                    tokio_stream::iter(backups_decoder.into_iter()).filter_map(|res| res.ok());
+
+                let raw_response = client.ingest_with_config_data_stream(iter_stream).await;
+                let response = raw_response
+                    .map(|res| res.into_inner())
+                    .map_err(|e| Error::new(ErrorKind::StreamError, e));
+
+                match response {
+                    Ok(_) => {
+                        #[cfg(feature = "tracing")]
+                        tracing::info!(
+                            backup_file = backup_file_path.display().to_string(),
+                            "Ingested backup file"
+                        );
+                        Ok(())
+                    }
+                    Err(err) => {
+                        #[cfg(feature = "tracing")]
+                        tracing::info!(
+                            backup_file = backup_file_path.display().to_string(),
+                            "Encountered error from sift ingesting backup file: {:?}",
+                            err
+                        );
+                        Err(err)
+                    }
+                }
+            }
+            Err(err) => {
+                #[cfg(feature = "tracing")]
+                tracing::warn!(
+                    backup_file = backup_file_path.display().to_string(),
+                    "saw an error while trying to open backup file for ingestion. Ignoring file: {:?}",
+                    err
+                );
+                // We want to return Ok here, since we aren't going to try re-ingesting this file
+                Ok(())
+            }
+        }
+    }
+
+    /// Add files into the ingestion queue
+    fn add(&mut self, files: Vec<PathBuf>) -> Result<()> {
+        if self.task_handle.is_finished() {
+            return Err(Error::new_msg(
+                ErrorKind::BackupsError,
+                "BackupIngestTask ended prematurely",
+            ));
+        }
+
+        for file in files {
+            self.ingest_tx
+                .send(file)
+                .map_err(|e| Error::new(ErrorKind::BackupsError, e))?;
+        }
+
+        Ok(())
+    }
+}

--- a/rust/crates/sift_stream/src/backup/disk/mod.rs
+++ b/rust/crates/sift_stream/src/backup/disk/mod.rs
@@ -17,6 +17,12 @@ use tokio::{
     task::JoinHandle,
 };
 
+mod async_manager;
+pub use async_manager::AsyncBackupsManager;
+
+mod policy;
+pub use policy::{DiskBackupPolicy, RollingFilePolicy};
+
 /// Concerned with writing/reading protobuf from disk.
 mod pbfs;
 use pbfs::{

--- a/rust/crates/sift_stream/src/backup/disk/policy.rs
+++ b/rust/crates/sift_stream/src/backup/disk/policy.rs
@@ -20,7 +20,7 @@ pub const DEFAULT_BACKUP_FILE_COUNT: Option<usize> = None;
 ///
 /// - `rolling_file_policy` is the rolling backup file policy to use
 ///
-/// - `retain_ingested_backups` will retain backup files indefinitely, instead of deleting them once a checkpoint
+/// - `retain_backups` will retain backup files indefinitely, instead of deleting them once a checkpoint
 ///   has been cleared or the data has otherwise been confirmed to be ingested in Sift.
 ///
 /// **Important Note**: The `max_backup_file_size` does not represent that actual amount of
@@ -31,7 +31,7 @@ pub struct DiskBackupPolicy {
     pub backups_dir: Option<PathBuf>,
     pub max_backup_file_size: usize,
     pub rolling_file_policy: RollingFilePolicy,
-    pub retain_ingested_backups: bool,
+    pub retain_backups: bool,
 }
 
 impl Default for DiskBackupPolicy {
@@ -40,7 +40,7 @@ impl Default for DiskBackupPolicy {
             backups_dir: Default::default(),
             max_backup_file_size: DEFAULT_MAX_BACKUP_SIZE,
             rolling_file_policy: Default::default(),
-            retain_ingested_backups: false,
+            retain_backups: false,
         }
     }
 }

--- a/rust/crates/sift_stream/src/backup/disk/policy.rs
+++ b/rust/crates/sift_stream/src/backup/disk/policy.rs
@@ -1,0 +1,64 @@
+use std::path::PathBuf;
+
+/// Default maximum backup file size - 500 MiB.
+pub const DEFAULT_MAX_BACKUP_SIZE: usize = 500 * 2_usize.pow(20);
+
+/// Default rolling file count - None (unlimited files)
+pub const DEFAULT_BACKUP_FILE_COUNT: Option<usize> = None;
+
+/// A policy that is used to configure the disk backup behavior of a Sift stream. Most users wanting disk
+/// backups should opt to use the default policy provided by [DiskBackupPolicy::default], however, they are able
+/// to completely configure their own.
+/// - `backups_dir` is the directory where the backups will get created. If `backups_dir` is
+///   `None`, then the user's [data
+///   directory](https://docs.rs/dirs/latest/dirs/fn.data_dir.html) is used. If `backups_dir` is provided but
+///   doesn't exist, then there will be an attempt to create that directory.
+///
+/// - `max_backup_file_size` is the maximum size that an individual backup file is allowed to be, befor the
+///   file is rolled if using rolling backups, or a checkpoint forced if the max file count is exceeded.
+///   Defaults to 500 MiB
+///
+/// - `rolling_file_policy` is the rolling backup file policy to use
+///
+/// - `retain_ingested_backups` will retain backup files indefinitely, instead of deleting them once a checkpoint
+///   has been cleared or the data has otherwise been confirmed to be ingested in Sift.
+///
+/// **Important Note**: The `max_backup_file_size` does not represent that actual amount of
+/// space on disk which is affected by operating system-level compression and block allocation;
+/// instead the byte-length is the actual measure.
+#[derive(Debug, Clone)]
+pub struct DiskBackupPolicy {
+    pub backups_dir: Option<PathBuf>,
+    pub max_backup_file_size: usize,
+    pub rolling_file_policy: RollingFilePolicy,
+    pub retain_ingested_backups: bool,
+}
+
+impl Default for DiskBackupPolicy {
+    fn default() -> Self {
+        Self {
+            backups_dir: Default::default(),
+            max_backup_file_size: DEFAULT_MAX_BACKUP_SIZE,
+            rolling_file_policy: Default::default(),
+            retain_ingested_backups: false,
+        }
+    }
+}
+
+/// A policy that is used to configure the rolling file policy of a Sift stream. Most users wanting disk
+/// backups should opt to use the default policy provided by [RollingFilePolicy::default], however, they are able
+/// to completely configure their own.
+/// - `max_file_count` is the maximum number of files allowed to exist for a backup. Once this count is reached
+///   a checkpoint is forced, and the files are either cleared or re-ingested. None signifies unlimited files
+#[derive(Debug, Clone)]
+pub struct RollingFilePolicy {
+    pub max_file_count: Option<usize>,
+}
+
+impl Default for RollingFilePolicy {
+    fn default() -> Self {
+        Self {
+            max_file_count: DEFAULT_BACKUP_FILE_COUNT,
+        }
+    }
+}

--- a/rust/crates/sift_stream/src/backup/mod.rs
+++ b/rust/crates/sift_stream/src/backup/mod.rs
@@ -2,7 +2,7 @@ use prost::Message as PbMessage;
 use sift_error::prelude::*;
 
 pub mod disk;
-pub use disk::DiskBackupsManager;
+pub use disk::{AsyncBackupsManager, DiskBackupPolicy, DiskBackupsManager};
 
 pub mod memory;
 pub use memory::InMemoryBackupsManager;

--- a/rust/crates/sift_stream/src/backup/test.rs
+++ b/rust/crates/sift_stream/src/backup/test.rs
@@ -1,12 +1,109 @@
-use super::{BackupsManager, DiskBackupsManager, InMemoryBackupsManager};
+use super::{
+    AsyncBackupsManager, BackupsManager, DiskBackupPolicy, DiskBackupsManager,
+    InMemoryBackupsManager,
+};
+use crate::SiftChannel;
 use crate::TimeValue;
+use hyper_util::rt::TokioIo;
+use sift_connect::grpc::interceptor::AuthInterceptor;
 use sift_error::ErrorKind;
 use sift_rs::ingest::v1::{
     IngestWithConfigDataChannelValue, IngestWithConfigDataStreamRequest,
     ingest_with_config_data_channel_value::Type,
 };
+use sift_rs::ingest::v1::{
+    IngestWithConfigDataStreamResponse,
+    ingest_service_server::{IngestService, IngestServiceServer},
+};
 use std::fs;
+use std::sync::{Arc, Mutex};
 use tempdir::TempDir;
+use tonic::transport::{Endpoint, Server, Uri};
+use tonic::{Request, Response, Status};
+use tower::{ServiceBuilder, service_fn};
+
+#[derive(Debug, Clone)]
+struct MockIngestService {
+    captured_data: Arc<Mutex<Vec<IngestWithConfigDataStreamRequest>>>,
+}
+
+impl MockIngestService {
+    fn new() -> Self {
+        Self {
+            captured_data: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn get_captured_data(&self) -> Vec<IngestWithConfigDataStreamRequest> {
+        self.captured_data.lock().unwrap().clone()
+    }
+}
+
+#[tonic::async_trait]
+impl IngestService for MockIngestService {
+    async fn ingest_with_config_data_stream(
+        &self,
+        request: Request<tonic::Streaming<IngestWithConfigDataStreamRequest>>,
+    ) -> Result<Response<IngestWithConfigDataStreamResponse>, Status> {
+        let mut stream = request.into_inner();
+
+        while let Some(data) = stream.message().await? {
+            self.captured_data.lock().unwrap().push(data);
+        }
+
+        Ok(Response::new(IngestWithConfigDataStreamResponse {}))
+    }
+
+    async fn ingest_arbitrary_protobuf_data_stream(
+        &self,
+        _request: Request<
+            tonic::Streaming<sift_rs::ingest::v1::IngestArbitraryProtobufDataStreamRequest>,
+        >,
+    ) -> Result<Response<sift_rs::ingest::v1::IngestArbitraryProtobufDataStreamResponse>, Status>
+    {
+        Err(Status::unimplemented("Not implemented for test"))
+    }
+}
+
+async fn create_mock_grpc_channel_with_service() -> (SiftChannel, Arc<MockIngestService>) {
+    let mock_service = Arc::new(MockIngestService::new());
+    let service_clone = mock_service.clone();
+
+    let (client, server) = tokio::io::duplex(1024);
+
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(IngestServiceServer::new(service_clone.as_ref().clone()))
+            .serve_with_incoming(tokio_stream::once(Ok::<_, std::io::Error>(server)))
+            .await
+            .unwrap();
+    });
+
+    let mut client = Some(client);
+    let channel = Endpoint::try_from("http://[::]:50051")
+        .unwrap()
+        .connect_with_connector(service_fn(move |_: Uri| {
+            let client = client.take();
+
+            async move {
+                if let Some(client) = client {
+                    Ok(TokioIo::new(client))
+                } else {
+                    Err(std::io::Error::other("Client already taken"))
+                }
+            }
+        }))
+        .await
+        .unwrap();
+
+    let sift_channel = ServiceBuilder::new()
+        .layer(tonic::service::interceptor(AuthInterceptor {
+            apikey: "test-api-key".to_string(),
+        }))
+        .service(channel);
+
+    (sift_channel, mock_service)
+}
 
 #[tokio::test]
 async fn test_disk_backups_manager_retrieve_data_with_graceful_termination() {
@@ -109,4 +206,147 @@ async fn test_in_memory_backups_manager_retrieve_data() {
             .is_err_and(|e| e.kind() == ErrorKind::BackupLimitReached),
     );
     assert!(backups_manager.finish().await.is_ok());
+}
+
+#[tokio::test]
+async fn test_async_backups_manager_retrieve_data_with_graceful_termination() {
+    let backups_dir = uuid::Uuid::new_v4().to_string();
+    let backup_prefix = "test_async_backups_manager_retrieve_data_with_graceful_termination";
+
+    let tmp_dir = TempDir::new(&backups_dir).expect("failed to creat tempdir");
+    let tmp_dir_path = tmp_dir.path();
+
+    let test_data = (0..100).map(|i| IngestWithConfigDataStreamRequest {
+        ingestion_config_id: format!("{i}"),
+        flow: String::from("some_flow"),
+        timestamp: Some(*TimeValue::now()),
+        channel_values: vec![IngestWithConfigDataChannelValue {
+            r#type: Some(Type::Int32(i)),
+        }],
+        ..Default::default()
+    });
+
+    let disk_backup_policy = DiskBackupPolicy {
+        backups_dir: Some(tmp_dir_path.to_path_buf()),
+        ..Default::default()
+    };
+    let backup_retry_policy = crate::RetryPolicy::default();
+    let (grpc_channel, mock_service) = create_mock_grpc_channel_with_service().await;
+
+    let mut backups_manager = AsyncBackupsManager::<IngestWithConfigDataStreamRequest>::new(
+        &backups_dir,
+        backup_prefix,
+        disk_backup_policy,
+        backup_retry_policy,
+        grpc_channel,
+    )
+    .expect("failed to start backups manager");
+
+    let mut expected = Vec::new();
+
+    for data in test_data {
+        expected.push(data.clone());
+
+        backups_manager
+            .send(data)
+            .await
+            .expect("failed to send data to backup task");
+    }
+
+    let captured_data = mock_service.get_captured_data();
+    // No data should be sent prior to commanding start_backup_ingestion
+    assert!(captured_data.is_empty());
+
+    let file_count = backups_manager.start_backup_ingestion().await;
+
+    // We should have a single file for ingestion
+    assert_eq!(file_count, 1);
+
+    // Wait a bit for the ingestion to complete
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Verify that the mock service received the data via gRPC
+    let captured_data = mock_service.get_captured_data();
+    assert_eq!(
+        captured_data.len(),
+        expected.len(),
+        "gRPC should have received all sent data"
+    );
+
+    // Make sure the data sent via gRPC matches what we sent to the backup manager
+    for (lhs, rhs) in expected.into_iter().zip(captured_data) {
+        assert_eq!(lhs.ingestion_config_id, rhs.ingestion_config_id);
+        assert_eq!(lhs.flow, rhs.flow);
+        assert_eq!(lhs.channel_values, rhs.channel_values);
+    }
+
+    // Graceful termination
+    backups_manager
+        .finish()
+        .await
+        .expect("failed to finish backup manager");
+}
+
+#[tokio::test]
+async fn test_async_backups_manager_discard_data_with_graceful_termination() {
+    let backups_dir = uuid::Uuid::new_v4().to_string();
+    let backup_prefix = "test_async_backups_manager_discard_data_with_graceful_termination";
+
+    let tmp_dir = TempDir::new(&backups_dir).expect("failed to creat tempdir");
+    let tmp_dir_path = tmp_dir.path();
+
+    let test_data = (0..100).map(|i| IngestWithConfigDataStreamRequest {
+        ingestion_config_id: format!("{i}"),
+        flow: String::from("some_flow"),
+        timestamp: Some(*TimeValue::now()),
+        channel_values: vec![IngestWithConfigDataChannelValue {
+            r#type: Some(Type::Int32(i)),
+        }],
+        ..Default::default()
+    });
+
+    let disk_backup_policy = DiskBackupPolicy {
+        backups_dir: Some(tmp_dir_path.to_path_buf()),
+        ..Default::default()
+    };
+    let backup_retry_policy = crate::RetryPolicy::default();
+    let (grpc_channel, mock_service) = create_mock_grpc_channel_with_service().await;
+
+    let mut backups_manager = AsyncBackupsManager::<IngestWithConfigDataStreamRequest>::new(
+        &backups_dir,
+        backup_prefix,
+        disk_backup_policy,
+        backup_retry_policy,
+        grpc_channel,
+    )
+    .expect("failed to start backups manager");
+
+    let mut expected = Vec::new();
+
+    for data in test_data {
+        expected.push(data.clone());
+
+        backups_manager
+            .send(data)
+            .await
+            .expect("failed to send data to backup task");
+    }
+
+    backups_manager
+        .restart()
+        .await
+        .expect("Had error restarting");
+
+    // Wait a moment for any possible ingestion to complete
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Verify that the mock service recieved no data, since we didn't need to ingest
+    let captured_data = mock_service.get_captured_data();
+    assert!(captured_data.is_empty());
+
+    // Graceful termination
+    backups_manager
+        .finish()
+        .await
+        .expect("failed to finish backup manager");
 }

--- a/rust/crates/sift_stream/src/stream/builder.rs
+++ b/rust/crates/sift_stream/src/stream/builder.rs
@@ -108,7 +108,7 @@ pub struct IngestionConfigForm {
 /// is used in [SiftStreamBuilder::attach_run]. Note that if there is an existing run with the
 /// given `client_key`, any other fields that are updated in this [RunForm] will be updated in
 /// Sift, with the exception of `Option` fields that are `None`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct RunForm {
     pub name: String,
     pub client_key: String,

--- a/rust/crates/sift_stream/src/stream/mode/ingestion_config.rs
+++ b/rust/crates/sift_stream/src/stream/mode/ingestion_config.rs
@@ -2,7 +2,9 @@ use super::super::{
     RetryPolicy, SiftStream, SiftStreamMode, channel::ChannelValue, time::TimeValue,
 };
 use crate::{
-    backup::{BackupsManager, DiskBackupsManager, InMemoryBackupsManager},
+    backup::{
+        BackupsManager, DiskBackupsManager, InMemoryBackupsManager, disk::AsyncBackupsManager,
+    },
     stream::run::{RunSelector, load_run_by_form, load_run_by_id},
 };
 use futures_core::Stream;
@@ -76,6 +78,7 @@ pub struct IngestionConfigMode {
 pub enum IngestionConfigModeBackupsManager {
     Disk(DiskBackupsManager<IngestWithConfigDataStreamRequest>),
     InMemory(InMemoryBackupsManager<IngestWithConfigDataStreamRequest>),
+    AsyncStream(AsyncBackupsManager<IngestWithConfigDataStreamRequest>),
 }
 
 /// Used for fine-grain control of [DataStream].
@@ -414,6 +417,9 @@ impl SiftStream<IngestionConfigMode> {
                 IngestionConfigModeBackupsManager::InMemory(manager) => {
                     return manager.send(req.clone()).await;
                 }
+                IngestionConfigModeBackupsManager::AsyncStream(manager) => {
+                    return manager.send(req.clone()).await;
+                }
             }
         }
         Ok(())
@@ -425,6 +431,7 @@ impl SiftStream<IngestionConfigMode> {
         match backups_manager {
             IngestionConfigModeBackupsManager::Disk(manager) => manager.finish().await,
             IngestionConfigModeBackupsManager::InMemory(manager) => manager.finish().await,
+            IngestionConfigModeBackupsManager::AsyncStream(mut manager) => manager.finish().await,
         }
     }
 
@@ -610,6 +617,12 @@ impl SiftStream<IngestionConfigMode> {
                 self.mode.backups_manager = Some(new_manager);
                 let _ = manager.finish().await;
             }
+            IngestionConfigModeBackupsManager::AsyncStream(mut manager) => {
+                // Restart backup manager. Don't replace, since we don't want to drop a running stream backups task
+                manager.restart().await?;
+                self.mode.backups_manager =
+                    Some(IngestionConfigModeBackupsManager::AsyncStream(manager));
+            }
         }
 
         #[cfg(feature = "tracing")]
@@ -632,11 +645,11 @@ impl SiftStream<IngestionConfigMode> {
             "processing backups"
         );
 
-        let mut data_points = 0;
         let mut start = Instant::now();
 
         match backup_manager {
             IngestionConfigModeBackupsManager::Disk(manager) => {
+                let mut data_points = 0;
                 for data in manager.get_backup_data().await? {
                     let data = match data {
                         Ok(d) => d,
@@ -683,8 +696,24 @@ impl SiftStream<IngestionConfigMode> {
                         start = Instant::now();
                     }
                 }
+
+                if data_points == 0 {
+                    #[cfg(feature = "tracing")]
+                    tracing::info!(
+                        sift_stream_id = self.mode.sift_stream_id.to_string(),
+                        "no backups to reingest"
+                    );
+                } else {
+                    #[cfg(feature = "tracing")]
+                    tracing::info!(
+                        sift_stream_id = self.mode.sift_stream_id.to_string(),
+                        data_items_recovered = data_points,
+                        "successfully reingested data since last checkpoint"
+                    );
+                }
             }
             IngestionConfigModeBackupsManager::InMemory(manager) => {
+                let mut data_points = 0;
                 for data in manager.get_backup_data().await? {
                     // The in-memory backup manager should return all `Result::Ok`;
                     let Ok(data) = data else {
@@ -713,23 +742,42 @@ impl SiftStream<IngestionConfigMode> {
                         start = Instant::now();
                     }
                 }
+
+                if data_points == 0 {
+                    #[cfg(feature = "tracing")]
+                    tracing::info!(
+                        sift_stream_id = self.mode.sift_stream_id.to_string(),
+                        "no backups to reingest"
+                    );
+                } else {
+                    #[cfg(feature = "tracing")]
+                    tracing::info!(
+                        sift_stream_id = self.mode.sift_stream_id.to_string(),
+                        data_items_recovered = data_points,
+                        "successfully reingested data since last checkpoint"
+                    );
+                }
+            }
+            IngestionConfigModeBackupsManager::AsyncStream(manager) => {
+                let file_count = manager.start_backup_ingestion().await;
+
+                if file_count == 0 {
+                    #[cfg(feature = "tracing")]
+                    tracing::info!(
+                        sift_stream_id = self.mode.sift_stream_id.to_string(),
+                        "no backups to reingest"
+                    );
+                } else {
+                    #[cfg(feature = "tracing")]
+                    tracing::info!(
+                        sift_stream_id = self.mode.sift_stream_id.to_string(),
+                        backup_files_to_ingest = file_count,
+                        "queued backup files since last checkpoint for ingest"
+                    );
+                }
             }
         }
 
-        if data_points == 0 {
-            #[cfg(feature = "tracing")]
-            tracing::info!(
-                sift_stream_id = self.mode.sift_stream_id.to_string(),
-                "no backups to reingest"
-            );
-        } else {
-            #[cfg(feature = "tracing")]
-            tracing::info!(
-                sift_stream_id = self.mode.sift_stream_id.to_string(),
-                data_points_recovered = data_points,
-                "successfully reingested data since last checkpoint"
-            );
-        }
         Ok(())
     }
 


### PR DESCRIPTION
Add AsyncBackupsManager to sift stream, which incorporates rolling backup files and async backup file ingestion.

Can be used with the new `RecoveryStrategy::RetryWithBackups` which is configured with the standard `RetryPolicy` and a new `DiskBackupPolicy`.

The number of rolling files (defaults to unlimited) can be defined, as well as individual backup file size, and whether backups should be retained or deleted once either re-ingested or cleared by a checkpoint.

**Verification**
Integration tests added to verify basic functionality of manager and the async ingestion

Ongoing soak test and stress testing