### PR TITLE
rust(feat): Run and Asset Tags and Metadata

### DIFF
--- a/rust/crates/sift_error/src/lib.rs
+++ b/rust/crates/sift_error/src/lib.rs
@@ -108,6 +108,8 @@ pub enum ErrorKind {
     RetrieveRunError,
     /// Indicates that the program was unable to retrieve the asset being requested.
     RetrieveAssetError,
+    /// Indicates that the program was unable to update the asset being requested.
+    UpdateAssetError,
     /// Indicates a failure to update a run.
     UpdateRunError,
     /// Indicates that the program was unable to retrieve the ingestion config being requested.
@@ -193,6 +195,7 @@ impl fmt::Display for ErrorKind {
             Self::GrpcConnectError => write!(f, "GrpcConnectError"),
             Self::RetriesExhausted => write!(f, "RetriesExhausted"),
             Self::RetrieveAssetError => write!(f, "RetrieveAssetError"),
+            Self::UpdateAssetError => write!(f, "UpdateAssetError"),
             Self::RetrieveRunError => write!(f, "RetrieveRunError"),
             Self::RetrieveIngestionConfigError => write!(f, "RetrieveIngestionConfigError"),
             Self::EmptyResponseError => write!(f, "EmptyResponseError"),

--- a/rust/crates/sift_rs/src/wrappers/assets.rs
+++ b/rust/crates/sift_rs/src/wrappers/assets.rs
@@ -1,10 +1,13 @@
 use std::ops::{Deref, DerefMut};
 
 use async_trait::async_trait;
+use pbjson_types::FieldMask;
 use sift_connect::SiftChannel;
 use sift_error::prelude::*;
 
-use crate::assets::v1::{Asset, GetAssetRequest, asset_service_client::AssetServiceClient};
+use crate::assets::v1::{
+    Asset, GetAssetRequest, UpdateAssetRequest, asset_service_client::AssetServiceClient,
+};
 
 /// Return an implementation of [AssetServiceWrapper] which also exposes methods from the
 /// raw [AssetServiceClient].
@@ -17,6 +20,9 @@ pub fn new_asset_service(grpc_channel: SiftChannel) -> impl AssetServiceWrapper 
 pub trait AssetServiceWrapper: Deref<Target = AssetServiceClient<SiftChannel>> + DerefMut {
     /// Retrieves an asset by ID
     async fn try_get_asset_by_id(&mut self, asset_id: &str) -> Result<Asset>;
+
+    /// Update an asset
+    async fn try_update_asset(&mut self, asset: Asset, update_mask: Vec<String>) -> Result<Asset>;
 }
 
 /// A convenience wrapper around [AssetServiceClient].
@@ -35,6 +41,21 @@ impl AssetServiceWrapper for AssetServiceImpl {
 
         resp.into_inner().asset.ok_or_else(|| {
             Error::new_empty_response("unexpected empty response from AssetService/GetAsset")
+        })
+    }
+
+    async fn try_update_asset(&mut self, asset: Asset, update_mask: Vec<String>) -> Result<Asset> {
+        let req = UpdateAssetRequest {
+            asset: Some(asset),
+            update_mask: Some(FieldMask { paths: update_mask }),
+        };
+        let resp = self
+            .update_asset(req)
+            .await
+            .map_err(|e| Error::new(ErrorKind::UpdateAssetError, e))?;
+
+        resp.into_inner().asset.ok_or_else(|| {
+            Error::new_empty_response("unexpected empty response from AssetService/UpdateAsset")
         })
     }
 }

--- a/rust/crates/sift_rs/src/wrappers/metadata.rs
+++ b/rust/crates/sift_rs/src/wrappers/metadata.rs
@@ -1,8 +1,7 @@
 use crate::metadata::v1::{MetadataKey, MetadataKeyType};
 
-pub use crate::metadata::v1::metadata_value::Value as MetadataEnumValue;
 pub use crate::metadata::v1::MetadataValue;
-
+pub use crate::metadata::v1::metadata_value::Value as MetadataEnumValue;
 
 impl From<f64> for MetadataEnumValue {
     fn from(value: f64) -> Self {
@@ -57,9 +56,9 @@ impl<T: Into<MetadataEnumValue>> From<(&str, T)> for MetadataValue {
     }
 }
 
-/// A macro for easily creating an array of metadata to be provided to Sift. 
+/// A macro for easily creating an array of metadata to be provided to Sift.
 /// Returns a Vec<[MetadataValue]>
-/// 
+///
 ///  # Example
 /// ```
 /// let metadata = metadata![

--- a/rust/crates/sift_rs/src/wrappers/metadata.rs
+++ b/rust/crates/sift_rs/src/wrappers/metadata.rs
@@ -4,37 +4,37 @@ pub use crate::metadata::v1::MetadataValue;
 pub use crate::metadata::v1::metadata_value::Value as MetadataEnumValue;
 
 impl From<f64> for MetadataEnumValue {
-    fn from(value: f64) -> Self {
+    fn from(value: f64) -> MetadataEnumValue {
         MetadataEnumValue::NumberValue(value)
     }
 }
 
 impl From<bool> for MetadataEnumValue {
-    fn from(value: bool) -> Self {
+    fn from(value: bool) -> MetadataEnumValue {
         MetadataEnumValue::BooleanValue(value)
     }
 }
 
 impl From<String> for MetadataEnumValue {
-    fn from(value: String) -> Self {
+    fn from(value: String) -> MetadataEnumValue {
         MetadataEnumValue::StringValue(value)
     }
 }
 
 impl From<&str> for MetadataEnumValue {
-    fn from(value: &str) -> Self {
+    fn from(value: &str) -> MetadataEnumValue {
         MetadataEnumValue::StringValue(value.to_string())
     }
 }
 
 impl<T: Into<MetadataEnumValue>> From<(String, T)> for MetadataValue {
-    fn from((name, value): (String, T)) -> Self {
+    fn from((name, value): (String, T)) -> MetadataValue {
         MetadataValue::from((name.as_str(), value))
     }
 }
 
 impl<T: Into<MetadataEnumValue>> From<(&str, T)> for MetadataValue {
-    fn from((name, value): (&str, T)) -> Self {
+    fn from((name, value): (&str, T)) -> MetadataValue {
         let enum_value: MetadataEnumValue = value.into();
         let key_type = match enum_value {
             MetadataEnumValue::NumberValue(_) => MetadataKeyType::Number,

--- a/rust/crates/sift_rs/src/wrappers/metadata.rs
+++ b/rust/crates/sift_rs/src/wrappers/metadata.rs
@@ -1,0 +1,76 @@
+use crate::metadata::v1::{MetadataKey, MetadataKeyType};
+
+pub use crate::metadata::v1::metadata_value::Value as MetadataEnumValue;
+pub use crate::metadata::v1::MetadataValue;
+
+
+impl From<f64> for MetadataEnumValue {
+    fn from(value: f64) -> Self {
+        MetadataEnumValue::NumberValue(value)
+    }
+}
+
+impl From<bool> for MetadataEnumValue {
+    fn from(value: bool) -> Self {
+        MetadataEnumValue::BooleanValue(value)
+    }
+}
+
+impl From<String> for MetadataEnumValue {
+    fn from(value: String) -> Self {
+        MetadataEnumValue::StringValue(value)
+    }
+}
+
+impl From<&str> for MetadataEnumValue {
+    fn from(value: &str) -> Self {
+        MetadataEnumValue::StringValue(value.to_string())
+    }
+}
+
+impl<T: Into<MetadataEnumValue>> From<(String, T)> for MetadataValue {
+    fn from((name, value): (String, T)) -> Self {
+        MetadataValue::from((name.as_str(), value))
+    }
+}
+
+impl<T: Into<MetadataEnumValue>> From<(&str, T)> for MetadataValue {
+    fn from((name, value): (&str, T)) -> Self {
+        let enum_value: MetadataEnumValue = value.into();
+        let key_type = match enum_value {
+            MetadataEnumValue::NumberValue(_) => MetadataKeyType::Number,
+            MetadataEnumValue::BooleanValue(_) => MetadataKeyType::Boolean,
+            MetadataEnumValue::StringValue(_) => MetadataKeyType::String,
+        };
+
+        let key = MetadataKey {
+            name: name.to_string(),
+            r#type: key_type.into(),
+            archived_date: None,
+        };
+
+        MetadataValue {
+            key: Some(key),
+            value: Some(enum_value),
+            archived_date: None,
+        }
+    }
+}
+
+/// A macro for easily creating an array of metadata to be provided to Sift. 
+/// Returns a Vec<[MetadataValue]>
+/// 
+///  # Example
+/// ```
+/// let metadata = metadata![
+///        ("test_number", 5.0),
+///        ("is_simulation", true),
+///        ("location", "SiftHQ"),
+/// ];
+/// ```
+#[macro_export]
+macro_rules! metadata {
+    ( $( ($k:expr, $v:expr) ),* $(,)? ) => {
+        vec![ $( ($k, $v).into() ),* ]
+    }
+}

--- a/rust/crates/sift_rs/src/wrappers/mod.rs
+++ b/rust/crates/sift_rs/src/wrappers/mod.rs
@@ -4,6 +4,9 @@ pub mod assets;
 /// Offers a wrapper over Sift's ingestion configs API.
 pub mod ingestion_configs;
 
+/// Offers a wrapper over Sift's metadata API.
+pub mod metadata;
+
 /// Offers a wrapper over Sift's runs API.
 pub mod runs;
 

--- a/rust/crates/sift_rs/src/wrappers/runs.rs
+++ b/rust/crates/sift_rs/src/wrappers/runs.rs
@@ -32,13 +32,13 @@ pub trait RunServiceWrapper: Deref<Target = RunServiceClient<SiftChannel>> + Der
     ) -> Result<Run>;
 
     /// Update a run. The `updated_run` is expected to contain the `run_id` or `client_key` used to
-    /// identify the run to update. The `field_mask` is a list of snake_cased field names used to
+    /// identify the run to update. The `update_mask` is a list of snake_cased field names used to
     /// indicate which fields should actually be updated. A list of valid field names can be found
-    /// at [`this link`]. The [Run] returned is the updated run. If `field_masks` is empty, then no
+    /// at [`this link`]. The [Run] returned is the updated run. If `update_mask` is empty, then no
     /// update is required and the `updated_run` is simply returned.
     ///
     /// [`this link`]: https://docs.siftstack.com/docs/api/grpc/protocol-buffers/runs#updaterunrequest
-    async fn try_update_run(&mut self, updated_run: Run, field_masks: &[String]) -> Result<Run>;
+    async fn try_update_run(&mut self, updated_run: Run, update_mask: &[String]) -> Result<Run>;
 
     /// Retrieve a run by ID.
     async fn try_get_run_by_id(&mut self, run_id: &str) -> Result<Run>;
@@ -130,21 +130,21 @@ impl RunServiceWrapper for RunServiceWrapperImpl {
     }
 
     /// Update a run. The `updated_run` is expected to contain the `run_id` or `client_key` used to
-    /// identify the run to update. The `field_mask` is a list of snake_cased field names used to
+    /// identify the run to update. The `update_mask` is a list of snake_cased field names used to
     /// indicate which fields should actually be updated. A list of valid field names can be found
-    /// at [`this link`]. The [Run] returned is the updated run. If `field_masks` is empty, then no
+    /// at [`this link`]. The [Run] returned is the updated run. If `update_mask` is empty, then no
     /// update is required and the `updated_run` is simply returned.
     ///
     /// [`this link`]: https://docs.siftstack.com/docs/api/grpc/protocol-buffers/runs#updaterunrequest
-    async fn try_update_run(&mut self, updated_run: Run, field_masks: &[String]) -> Result<Run> {
-        if field_masks.is_empty() {
+    async fn try_update_run(&mut self, updated_run: Run, update_mask: &[String]) -> Result<Run> {
+        if update_mask.is_empty() {
             return Ok(updated_run);
         }
 
         let run = self
             .update_run(UpdateRunRequest {
                 update_mask: Some(FieldMask {
-                    paths: field_masks.to_vec(),
+                    paths: update_mask.to_vec(),
                 }),
                 run: Some(updated_run),
             })

--- a/rust/crates/sift_rs/src/wrappers/runs.rs
+++ b/rust/crates/sift_rs/src/wrappers/runs.rs
@@ -1,7 +1,10 @@
 use super::ResourceIdentifier;
-use crate::runs::v2::{
-    CreateRunRequest, GetRunRequest, ListRunsRequest, Run, UpdateRunRequest,
-    run_service_client::RunServiceClient,
+use crate::{
+    metadata::v1::MetadataValue,
+    runs::v2::{
+        CreateRunRequest, GetRunRequest, ListRunsRequest, Run, UpdateRunRequest,
+        run_service_client::RunServiceClient,
+    },
 };
 use async_trait::async_trait;
 use pbjson_types::FieldMask;
@@ -25,6 +28,7 @@ pub trait RunServiceWrapper: Deref<Target = RunServiceClient<SiftChannel>> + Der
         client_key: &str,
         description: &str,
         tags: &[String],
+        metadata: &[MetadataValue],
     ) -> Result<Run>;
 
     /// Update a run. The `updated_run` is expected to contain the `run_id` or `client_key` used to
@@ -94,8 +98,10 @@ impl RunServiceWrapper for RunServiceWrapperImpl {
         client_key: &str,
         description: &str,
         tags: &[String],
+        metadata: &[MetadataValue],
     ) -> Result<Run> {
         let tags = tags.to_vec();
+        let metadata = metadata.to_vec();
 
         if name.is_empty() {
             return Err(Error::new_arg_error("run name cannot be blank"));
@@ -110,6 +116,7 @@ impl RunServiceWrapper for RunServiceWrapperImpl {
                 description: description.to_string(),
                 tags,
                 client_key: Some(client_key.to_string()),
+                metadata,
                 ..Default::default()
             })
             .await

--- a/rust/crates/sift_stream/examples/quick-start/main.rs
+++ b/rust/crates/sift_stream/examples/quick-start/main.rs
@@ -1,3 +1,4 @@
+use sift_rs::metadata;
 use sift_stream::{
     ChannelConfig, ChannelDataType, ChannelValue, Credentials, Flow, FlowConfig,
     IngestionConfigForm, RecoveryStrategy, RunForm, SiftStreamBuilder, TimeValue,
@@ -53,12 +54,20 @@ async fn run() -> Result<(), Box<dyn Error>> {
         .map(|d| d.as_millis())
         .unwrap();
 
+    // Create metadata using the metadata macro
+    let metadata = metadata![
+        ("test_number", 5.0),
+        ("is_simulation", true),
+        ("location", "SiftHQ"),
+    ];
+
     // Define an optional run to group together data for this period of telemetry ingestion.
     let run = RunForm {
         name: format!("[MarsRover0].{ts}"),
         client_key: format!("mars-rover-sim-{ts}"),
         description: Some("simulation run".into()),
         tags: Some(vec!["simulation".into()]),
+        metadata: Some(metadata),
     };
 
     // Initialize your Sift Stream

--- a/rust/crates/sift_stream/src/stream/builder.rs
+++ b/rust/crates/sift_stream/src/stream/builder.rs
@@ -325,15 +325,14 @@ impl SiftStreamBuilder<IngestionConfigMode> {
             }
         };
 
-        if self.asset_tags.is_some() || self.asset_metadata.is_some() {
-            Self::update_asset_tags_and_metadata(
-                asset,
-                self.asset_tags,
-                self.asset_metadata,
-                channel.clone(),
-            )
-            .await?;
-        }
+        // Try updating tags or metadata. Update only occurs if either asset_tags or asset_metadata is Some
+        Self::update_asset_tags_and_metadata(
+            asset,
+            self.asset_tags,
+            self.asset_metadata,
+            channel.clone(),
+        )
+        .await?;
 
         let mut backups_manager = None;
         let mut policy = None;

--- a/rust/crates/sift_stream/src/stream/builder.rs
+++ b/rust/crates/sift_stream/src/stream/builder.rs
@@ -12,7 +12,9 @@ use crate::backup::{
 use sift_connect::{Credentials, SiftChannel, SiftChannelBuilder};
 use sift_error::prelude::*;
 use sift_rs::{
+    assets::v1::Asset,
     ingestion_configs::v2::{FlowConfig, IngestionConfig as IngestionConfigPb},
+    metadata::v1::MetadataValue,
     ping::v1::{PingRequest, ping_service_client::PingServiceClient},
     wrappers::{
         assets::{AssetServiceWrapper, new_asset_service},
@@ -50,6 +52,8 @@ pub struct SiftStreamBuilder<C> {
     ingestion_config: Option<IngestionConfigForm>,
     enable_tls: bool,
     kind: PhantomData<C>,
+    asset_tags: Option<Vec<String>>,
+    asset_metadata: Option<Vec<MetadataValue>>,
 
     // Either `run` or `run_id`. If both are provided then the `run_id` will be prioritized.
     run: Option<RunForm>,
@@ -127,6 +131,7 @@ pub struct RunForm {
     pub client_key: String,
     pub description: Option<String>,
     pub tags: Option<Vec<String>>,
+    pub metadata: Option<Vec<MetadataValue>>,
 }
 
 impl Default for RecoveryStrategy {
@@ -208,6 +213,23 @@ where
         self.enable_tls = false;
         self
     }
+
+    /// Creates or updates the asset tags. If Some is provided, asset tags will be replaced
+    /// with the tags provided. If None, no update to tags will occur.
+    pub fn add_asset_tags(mut self, tags: Option<Vec<String>>) -> SiftStreamBuilder<C> {
+        self.asset_tags = tags;
+        self
+    }
+
+    /// Creates or updates the asset metadata. If Some is provided, asset metadata will be replaced
+    /// with the key:value pairs provided. If None, no update to metadata will occur.
+    pub fn add_asset_metadata(
+        mut self,
+        metadata: Option<Vec<MetadataValue>>,
+    ) -> SiftStreamBuilder<C> {
+        self.asset_metadata = metadata;
+        self
+    }
 }
 
 /// Builds a [SiftStream] specifically for ingestion-config based streaming.
@@ -224,6 +246,8 @@ impl SiftStreamBuilder<IngestionConfigMode> {
             kind: PhantomData,
             checkpoint_interval: DEFAULT_CHECKPOINT_INTERVAL,
             recovery_strategy: None,
+            asset_tags: None,
+            asset_metadata: None,
         }
     }
 
@@ -239,6 +263,8 @@ impl SiftStreamBuilder<IngestionConfigMode> {
             kind: PhantomData,
             checkpoint_interval: DEFAULT_CHECKPOINT_INTERVAL,
             recovery_strategy: None,
+            asset_tags: None,
+            asset_metadata: None,
         }
     }
 
@@ -286,7 +312,7 @@ impl SiftStreamBuilder<IngestionConfigMode> {
             .context("failed to connect to Sift")
             .help("ensure that your API key and Sift gRPC API URL is correct and TLS is configured properly")?;
 
-        let (ingestion_config, flows) =
+        let (ingestion_config, flows, asset) =
             Self::load_ingestion_config(channel.clone(), ingestion_config).await?;
 
         let run = {
@@ -298,6 +324,16 @@ impl SiftStreamBuilder<IngestionConfigMode> {
                 None
             }
         };
+
+        if self.asset_tags.is_some() || self.asset_metadata.is_some() {
+            Self::update_asset_tags_and_metadata(
+                asset,
+                self.asset_tags,
+                self.asset_metadata,
+                channel.clone(),
+            )
+            .await?;
+        }
 
         let mut backups_manager = None;
         let mut policy = None;
@@ -388,7 +424,7 @@ impl SiftStreamBuilder<IngestionConfigMode> {
     async fn load_ingestion_config(
         grpc_channel: SiftChannel,
         ingestion_config: IngestionConfigForm,
-    ) -> Result<(IngestionConfigPb, Vec<FlowConfig>)> {
+    ) -> Result<(IngestionConfigPb, Vec<FlowConfig>, Asset)> {
         #[cfg(feature = "tracing")]
         tracing::info_span!("load_ingestion_config");
 
@@ -420,6 +456,11 @@ impl SiftStreamBuilder<IngestionConfigMode> {
                     }
                 };
 
+                let asset = asset_service
+                    .try_get_asset_by_id(&ingestion_config.asset_id)
+                    .await
+                    .context("failed to retrieve asset specified by ingestion config")?;
+
                 #[cfg(feature = "tracing")]
                 {
                     if !new_flows.is_empty() {
@@ -435,7 +476,7 @@ impl SiftStreamBuilder<IngestionConfigMode> {
                         );
                     }
                 }
-                Ok((ingestion_config, flows))
+                Ok((ingestion_config, flows, asset))
             }
             Err(err) => Err(err),
 
@@ -528,9 +569,37 @@ impl SiftStreamBuilder<IngestionConfigMode> {
                     flows = sift_flows;
                 }
 
-                Ok((ingestion_config, flows))
+                Ok((ingestion_config, flows, asset))
             }
         }
+    }
+
+    async fn update_asset_tags_and_metadata(
+        mut asset: Asset,
+        asset_tags: Option<Vec<String>>,
+        asset_metadata: Option<Vec<MetadataValue>>,
+        channel: SiftChannel,
+    ) -> Result<()> {
+        let mut update_mask = Vec::new();
+
+        if let Some(asset_tags) = asset_tags {
+            asset.tags = asset_tags;
+            update_mask.push("tags".to_string());
+        }
+
+        if let Some(asset_metadata) = asset_metadata {
+            asset.metadata = asset_metadata;
+            update_mask.push("metadata".to_string());
+        }
+
+        if update_mask.is_empty() {
+            return Ok(());
+        }
+
+        let mut asset_service = new_asset_service(channel);
+        let _ = asset_service.try_update_asset(asset, update_mask).await?;
+
+        Ok(())
     }
 }
 

--- a/rust/crates/sift_stream/src/stream/run.rs
+++ b/rust/crates/sift_stream/src/stream/run.rs
@@ -163,3 +163,622 @@ pub(super) async fn load_run_by_form(grpc_channel: SiftChannel, run_form: RunFor
         }
     }
 }
+
+
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sift_rs::{
+        metadata::v1::{metadata_value::Value, MetadataKey, MetadataValue},
+        runs::v2::{
+            CreateRunRequest, GetRunRequest, ListRunsRequest, UpdateRunRequest,
+            CreateAdhocRunRequest, CreateAdhocRunResponse,
+            StopRunRequest, StopRunResponse,
+            CreateAutomaticRunAssociationForAssetsRequest, CreateAutomaticRunAssociationForAssetsResponse,
+        },
+    };
+    use sift_connect::{SiftChannel, grpc::interceptor::AuthInterceptor};
+    use hyper_util::rt::TokioIo;
+    use std::sync::{Arc, Mutex};
+    use tokio::task::JoinHandle;
+    use tonic::{
+        transport::{Endpoint, Server, Uri},
+        Request, Response, Status,
+    };
+    use tower::{ServiceBuilder, service_fn};
+    /// Mock run service that captures calls to verify correct data is sent to try_update_run
+    #[derive(Clone)]
+    struct MockRunService {
+        runs: Arc<Mutex<HashMap<String, Run>>>, // client_key -> Run
+        update_calls: Arc<Mutex<Vec<UpdateCall>>>, // Track update calls
+    }
+
+    #[derive(Debug, Clone)]
+    struct UpdateCall {
+        #[allow(dead_code)]
+        run_name: String,
+        field_mask: Vec<String>,
+        updated_run: Run,
+    }
+
+    impl MockRunService {
+        fn new() -> Self {
+            Self {
+                runs: Arc::new(Mutex::new(HashMap::new())),
+                update_calls: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn add_existing_run(&self, client_key: &str, mut run: Run) {
+            run.client_key = Some(client_key.to_string());
+            self.runs.lock().unwrap().insert(client_key.to_string(), run);
+        }
+
+        fn get_update_calls(&self) -> Vec<UpdateCall> {
+            self.update_calls.lock().unwrap().clone()
+        }
+    }
+
+    #[tonic::async_trait]
+    impl sift_rs::runs::v2::run_service_server::RunService for MockRunService {
+        async fn create_run(
+            &self,
+            request: Request<CreateRunRequest>,
+        ) -> std::result::Result<Response<sift_rs::runs::v2::CreateRunResponse>, Status> {
+            let req = request.into_inner();
+            let run_id = format!("run_id_{}", req.name.replace(' ', "_"));
+            let client_key = req.client_key.clone().unwrap_or_default();
+            
+            let run = Run {
+                run_id: run_id.clone(),
+                name: req.name,
+                description: req.description,
+                tags: req.tags,
+                metadata: req.metadata,
+                client_key: req.client_key,
+                ..Default::default()
+            };
+
+            self.runs.lock().unwrap().insert(client_key, run.clone());
+
+            Ok(Response::new(sift_rs::runs::v2::CreateRunResponse {
+                run: Some(run),
+            }))
+        }
+
+        async fn get_run(
+            &self,
+            _request: Request<GetRunRequest>,
+        ) -> std::result::Result<Response<sift_rs::runs::v2::GetRunResponse>, Status> {
+            Err(Status::unimplemented("get_run not needed for these tests"))
+        }
+
+        async fn list_runs(
+            &self,
+            request: Request<ListRunsRequest>,
+        ) -> std::result::Result<Response<sift_rs::runs::v2::ListRunsResponse>, Status> {
+            let req = request.into_inner();
+
+            // Parse the filter to extract client_key
+            if let Some(client_key) = parse_client_key_filter(&req.filter)
+                && let Some(run) = self.runs.lock().unwrap().get(&client_key) {
+                    return Ok(Response::new(sift_rs::runs::v2::ListRunsResponse {
+                        runs: vec![run.clone()],
+                        ..Default::default()
+                    }));
+                }
+
+            Ok(Response::new(sift_rs::runs::v2::ListRunsResponse {
+                runs: vec![],
+                ..Default::default()
+            }))
+        }
+
+        async fn update_run(
+            &self,
+            request: Request<UpdateRunRequest>,
+        ) -> std::result::Result<Response<sift_rs::runs::v2::UpdateRunResponse>, Status> {
+            let req = request.into_inner();
+            let updated_run = req.run.ok_or_else(|| Status::invalid_argument("run is required"))?;
+            let field_mask = req.update_mask.unwrap_or_default();
+
+            // Capture the update call for verification
+            let update_call = UpdateCall {
+                run_name: updated_run.name.clone(),
+                field_mask: field_mask.paths.clone(),
+                updated_run: updated_run.clone(),
+            };
+            
+            self.update_calls.lock().unwrap().push(update_call);
+
+            // Update the run in our storage
+            if let Some(client_key) = &updated_run.client_key {
+                self.runs
+                    .lock()
+                    .unwrap()
+                    .insert(client_key.clone(), updated_run.clone());
+            }
+
+            Ok(Response::new(sift_rs::runs::v2::UpdateRunResponse {
+                run: Some(updated_run),
+            }))
+        }
+
+        async fn delete_run(
+            &self,
+            _request: Request<sift_rs::runs::v2::DeleteRunRequest>,
+        ) -> std::result::Result<Response<sift_rs::runs::v2::DeleteRunResponse>, Status> {
+            Err(Status::unimplemented("delete_run not needed for these tests"))
+        }
+
+        async fn create_adhoc_run(
+            &self,
+            _request: Request<CreateAdhocRunRequest>,
+        ) -> std::result::Result<Response<CreateAdhocRunResponse>, Status> {
+            Err(Status::unimplemented("create_adhoc_run not needed for these tests"))
+        }
+
+        async fn stop_run(
+            &self,
+            _request: Request<StopRunRequest>,
+        ) -> std::result::Result<Response<StopRunResponse>, Status> {
+            Err(Status::unimplemented("stop_run not needed for these tests"))
+        }
+
+        async fn create_automatic_run_association_for_assets(
+            &self,
+            _request: Request<CreateAutomaticRunAssociationForAssetsRequest>,
+        ) -> std::result::Result<Response<CreateAutomaticRunAssociationForAssetsResponse>, Status> {
+            Err(Status::unimplemented("create_automatic_run_association_for_assets not needed for these tests"))
+        }
+    }
+
+    fn parse_client_key_filter(filter: &str) -> Option<String> {
+        if let Some(start) = filter.find("client_key == '") {
+            let start_idx = start + "client_key == '".len();
+            if let Some(end_idx) = filter[start_idx..].find('\'') {
+                return Some(filter[start_idx..start_idx + end_idx].to_string());
+            }
+        }
+        None
+    }
+
+    async fn start_mock_run_service(service: MockRunService) -> (SiftChannel, JoinHandle<()>) {
+        use std::io::Error as IoError;
+        
+        let (client, server) = tokio::io::duplex(1024);
+
+        let server = tokio::spawn(async move {
+            Server::builder()
+                .add_service(sift_rs::runs::v2::run_service_server::RunServiceServer::new(service))
+                .serve_with_incoming(tokio_stream::once(Ok::<_, IoError>(server)))
+                .await
+                .unwrap();
+        });
+
+        let mut client = Some(client);
+        let channel = Endpoint::try_from("http://[::]:50051")
+            .unwrap()
+            .connect_with_connector(service_fn(move |_: Uri| {
+                let client = client.take();
+                async move {
+                    if let Some(client) = client {
+                        Ok(TokioIo::new(client))
+                    } else {
+                        Err(std::io::Error::other("Client already taken"))
+                    }
+                }
+            }))
+            .await
+            .unwrap();
+
+        let sift_channel: SiftChannel = ServiceBuilder::new()
+            .layer(tonic::service::interceptor(AuthInterceptor {
+                apikey: "test_api_key".to_string(),
+            }))
+            .service(channel);
+
+        (sift_channel, server)
+    }
+
+    fn create_metadata_value(key: &str, string_value: &str) -> MetadataValue {
+        MetadataValue {
+            key: Some(MetadataKey {
+                name: key.to_string(),
+                ..Default::default()
+            }),
+            value: Some(Value::StringValue(string_value.to_string())),
+            archived_date: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_load_run_by_form_adds_tags_when_none_exist() {
+        let mock_service = MockRunService::new();
+        
+        // Add an existing run with no tags
+        let existing_run = Run {
+            run_id: "test_run_1".to_string(),
+            name: "Test Run".to_string(),
+            description: "Original description".to_string(),
+            tags: vec![], // No existing tags
+            metadata: vec![],
+            client_key: Some("test_client_key".to_string()),
+            ..Default::default()
+        };
+        
+        mock_service.add_existing_run("test_client_key", existing_run);
+        
+        let (channel, server) = start_mock_run_service(mock_service.clone()).await;
+        
+        let run_form = RunForm {
+            name: "Test Run".to_string(),
+            client_key: "test_client_key".to_string(),
+            description: Some("Updated description".to_string()),
+            tags: Some(vec!["tag1".to_string(), "tag2".to_string()]),
+            metadata: None,
+        };
+        
+        let result = load_run_by_form(channel, run_form).await;
+        assert!(result.is_ok());
+        
+        let updated_run = result.unwrap();
+        assert_eq!(updated_run.tags, vec!["tag1", "tag2"]);
+        
+        // Verify update_run was called with correct field mask
+        let update_calls = mock_service.get_update_calls();
+        assert_eq!(update_calls.len(), 1);
+        assert!(update_calls[0].field_mask.contains(&"tags".to_string()));
+        assert!(update_calls[0].field_mask.contains(&"description".to_string()));
+        assert_eq!(update_calls[0].updated_run.tags, vec!["tag1", "tag2"]);
+        
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_load_run_by_form_adds_metadata_when_none_exist() {
+        let mock_service = MockRunService::new();
+        
+        // Add an existing run with no metadata
+        let existing_run = Run {
+            run_id: "test_run_2".to_string(),
+            name: "Test Run Metadata".to_string(),
+            description: "Original description".to_string(),
+            tags: vec![],
+            metadata: vec![], // No existing metadata
+            client_key: Some("metadata_test_key".to_string()),
+            ..Default::default()
+        };
+        
+        mock_service.add_existing_run("metadata_test_key", existing_run);
+        
+        let (channel, server) = start_mock_run_service(mock_service.clone()).await;
+        
+        let run_form = RunForm {
+            name: "Test Run Metadata".to_string(),
+            client_key: "metadata_test_key".to_string(),
+            description: None,
+            tags: None,
+            metadata: Some(vec![
+                create_metadata_value("env", "production"),
+                create_metadata_value("version", "1.0"),
+            ]),
+        };
+        
+        let result = load_run_by_form(channel, run_form).await;
+        assert!(result.is_ok());
+        
+        let updated_run = result.unwrap();
+        assert_eq!(updated_run.metadata.len(), 2);
+        
+        // Verify update_run was called with correct field mask
+        let update_calls = mock_service.get_update_calls();
+        assert_eq!(update_calls.len(), 1);
+        assert!(update_calls[0].field_mask.contains(&"metadata".to_string()));
+        assert_eq!(update_calls[0].updated_run.metadata.len(), 2);
+        
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_load_run_by_form_same_tags_no_update() {
+        let mock_service = MockRunService::new();
+        
+        // Add an existing run with same tags
+        let existing_run = Run {
+            run_id: "test_run_3".to_string(),
+            name: "Test Run Same Tags".to_string(),
+            description: "Original description".to_string(),
+            tags: vec!["tag1".to_string(), "tag2".to_string()],
+            metadata: vec![],
+            client_key: Some("same_tags_key".to_string()),
+            ..Default::default()
+        };
+        
+        mock_service.add_existing_run("same_tags_key", existing_run);
+        
+        let (channel, server) = start_mock_run_service(mock_service.clone()).await;
+        
+        let run_form = RunForm {
+            name: "Test Run Same Tags".to_string(),
+            client_key: "same_tags_key".to_string(),
+            description: Some("Original description".to_string()),
+            tags: Some(vec!["tag1".to_string(), "tag2".to_string()]), // Same tags
+            metadata: None,
+        };
+        
+        let result = load_run_by_form(channel, run_form).await;
+        assert!(result.is_ok());
+        
+        // Verify NO update_run was called since nothing changed
+        let update_calls = mock_service.get_update_calls();
+        assert_eq!(update_calls.len(), 0);
+        
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_load_run_by_form_same_metadata_no_update() {
+        let mock_service = MockRunService::new();
+        
+        // Add an existing run with same metadata
+        let existing_run = Run {
+            run_id: "test_run_4".to_string(),
+            name: "Test Run Same Metadata".to_string(),
+            description: "Original description".to_string(),
+            tags: vec![],
+            metadata: vec![
+                create_metadata_value("env", "production"),
+                create_metadata_value("version", "1.0"),
+            ],
+            client_key: Some("same_metadata_key".to_string()),
+            ..Default::default()
+        };
+        
+        mock_service.add_existing_run("same_metadata_key", existing_run);
+        
+        let (channel, server) = start_mock_run_service(mock_service.clone()).await;
+        
+        let run_form = RunForm {
+            name: "Test Run Same Metadata".to_string(),
+            client_key: "same_metadata_key".to_string(),
+            description: Some("Original description".to_string()),
+            tags: None,
+            metadata: Some(vec![
+                create_metadata_value("env", "production"),
+                create_metadata_value("version", "1.0"),
+            ]), // Same metadata
+        };
+        
+        let result = load_run_by_form(channel, run_form).await;
+        assert!(result.is_ok());
+        
+        // Verify NO update_run was called since nothing changed
+        let update_calls = mock_service.get_update_calls();
+        assert_eq!(update_calls.len(), 0);
+        
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_load_run_by_form_replaces_existing_tags() {
+        let mock_service = MockRunService::new();
+        
+        // Add an existing run with existing tags
+        let existing_run = Run {
+            run_id: "test_run_5".to_string(),
+            name: "Test Run Replace Tags".to_string(),
+            description: "Original description".to_string(),
+            tags: vec!["old_tag1".to_string(), "old_tag2".to_string()],
+            metadata: vec![],
+            client_key: Some("replace_tags_key".to_string()),
+            ..Default::default()
+        };
+        
+        mock_service.add_existing_run("replace_tags_key", existing_run);
+        
+        let (channel, server) = start_mock_run_service(mock_service.clone()).await;
+        
+        let run_form = RunForm {
+            name: "Test Run Replace Tags".to_string(),
+            client_key: "replace_tags_key".to_string(),
+            description: Some("Original description".to_string()),
+            tags: Some(vec!["new_tag1".to_string(), "new_tag2".to_string(), "new_tag3".to_string()]),
+            metadata: None,
+        };
+        
+        let result = load_run_by_form(channel, run_form).await;
+        assert!(result.is_ok());
+        
+        let updated_run = result.unwrap();
+        // Verify that the old tags are completely replaced with new tags
+        assert_eq!(updated_run.tags, vec!["new_tag1", "new_tag2", "new_tag3"]);
+        assert!(!updated_run.tags.contains(&"old_tag1".to_string()));
+        assert!(!updated_run.tags.contains(&"old_tag2".to_string()));
+        
+        // Verify update_run was called with correct field mask and data
+        let update_calls = mock_service.get_update_calls();
+        assert_eq!(update_calls.len(), 1);
+        assert!(update_calls[0].field_mask.contains(&"tags".to_string()));
+        assert_eq!(update_calls[0].updated_run.tags, vec!["new_tag1", "new_tag2", "new_tag3"]);
+        
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_load_run_by_form_replaces_existing_metadata() {
+        let mock_service = MockRunService::new();
+        
+        // Add an existing run with existing metadata
+        let existing_run = Run {
+            run_id: "test_run_6".to_string(),
+            name: "Test Run Replace Metadata".to_string(),
+            description: "Original description".to_string(),
+            tags: vec![],
+            metadata: vec![
+                create_metadata_value("old_key1", "old_value1"),
+                create_metadata_value("old_key2", "old_value2"),
+            ],
+            client_key: Some("replace_metadata_key".to_string()),
+            ..Default::default()
+        };
+        
+        mock_service.add_existing_run("replace_metadata_key", existing_run);
+        
+        let (channel, server) = start_mock_run_service(mock_service.clone()).await;
+        
+        let run_form = RunForm {
+            name: "Test Run Replace Metadata".to_string(),
+            client_key: "replace_metadata_key".to_string(),
+            description: Some("Original description".to_string()),
+            tags: None,
+            metadata: Some(vec![
+                create_metadata_value("new_key1", "new_value1"),
+                create_metadata_value("new_key2", "new_value2"),
+                create_metadata_value("new_key3", "new_value3"),
+            ]),
+        };
+        
+        let result = load_run_by_form(channel, run_form).await;
+        assert!(result.is_ok());
+        
+        let updated_run = result.unwrap();
+        assert_eq!(updated_run.metadata.len(), 3);
+        
+        // Verify that the old metadata is completely replaced with new metadata
+        let metadata_keys: Vec<String> = updated_run.metadata
+            .iter()
+            .filter_map(|m| m.key.as_ref().map(|k| k.name.clone()))
+            .collect();
+        
+        assert!(metadata_keys.contains(&"new_key1".to_string()));
+        assert!(metadata_keys.contains(&"new_key2".to_string()));
+        assert!(metadata_keys.contains(&"new_key3".to_string()));
+        assert!(!metadata_keys.contains(&"old_key1".to_string()));
+        assert!(!metadata_keys.contains(&"old_key2".to_string()));
+        
+        // Verify update_run was called with correct field mask and data
+        let update_calls = mock_service.get_update_calls();
+        assert_eq!(update_calls.len(), 1);
+        assert!(update_calls[0].field_mask.contains(&"metadata".to_string()));
+        assert_eq!(update_calls[0].updated_run.metadata.len(), 3);
+        
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_load_run_by_form_metadata_key_value_change() {
+        let mock_service = MockRunService::new();
+        
+        // Add an existing run with existing metadata
+        let existing_run = Run {
+            run_id: "test_run_8".to_string(),
+            name: "Test Run Metadata Change".to_string(),
+            description: "Original description".to_string(),
+            tags: vec![],
+            metadata: vec![
+                create_metadata_value("env", "staging"),
+                create_metadata_value("version", "1.0"),
+                create_metadata_value("region", "us-east-1"),
+            ],
+            client_key: Some("metadata_change_key".to_string()),
+            ..Default::default()
+        };
+        
+        mock_service.add_existing_run("metadata_change_key", existing_run);
+        
+        let (channel, server) = start_mock_run_service(mock_service.clone()).await;
+        
+        let run_form = RunForm {
+            name: "Test Run Metadata Change".to_string(),
+            client_key: "metadata_change_key".to_string(),
+            description: Some("Original description".to_string()),
+            tags: None,
+            metadata: Some(vec![
+                create_metadata_value("env", "production"), // Same key, different value
+                create_metadata_value("version", "1.0"), // Same key-value pair
+                create_metadata_value("build", "123"), // New key-value pair
+            ]),
+        };
+        
+        let result = load_run_by_form(channel, run_form).await;
+        assert!(result.is_ok());
+        
+        let updated_run = result.unwrap();
+        assert_eq!(updated_run.metadata.len(), 3);
+        
+        // Verify that metadata is completely replaced
+        let metadata_map: std::collections::HashMap<String, String> = updated_run.metadata
+            .iter()
+            .filter_map(|m| {
+                if let (Some(key), Some(Value::StringValue(s))) = (&m.key, &m.value) {
+                    Some((key.name.clone(), s.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        
+        assert_eq!(metadata_map.get("env"), Some(&"production".to_string()));
+        assert_eq!(metadata_map.get("version"), Some(&"1.0".to_string()));
+        assert_eq!(metadata_map.get("build"), Some(&"123".to_string()));
+        assert!(!metadata_map.contains_key("region")); // Old key should be gone
+        
+        // Verify update_run was called due to different metadata
+        let update_calls = mock_service.get_update_calls();
+        assert_eq!(update_calls.len(), 1);
+        assert!(update_calls[0].field_mask.contains(&"metadata".to_string()));
+        
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_load_run_by_form_add_both_tags_and_metadata_to_existing() {
+        let mock_service = MockRunService::new();
+        
+        // Add an existing run with both tags and metadata
+        let existing_run = Run {
+            run_id: "test_run_9".to_string(),
+            name: "Test Run Both Fields".to_string(),
+            description: "Original description".to_string(),
+            tags: vec!["old_tag".to_string()],
+            metadata: vec![create_metadata_value("old_key", "old_value")],
+            client_key: Some("both_fields_key".to_string()),
+            ..Default::default()
+        };
+        
+        mock_service.add_existing_run("both_fields_key", existing_run);
+        
+        let (channel, server) = start_mock_run_service(mock_service.clone()).await;
+        
+        let run_form = RunForm {
+            name: "Test Run Both Fields".to_string(),
+            client_key: "both_fields_key".to_string(),
+            description: Some("Updated description".to_string()),
+            tags: Some(vec!["new_tag1".to_string(), "new_tag2".to_string()]),
+            metadata: Some(vec![
+                create_metadata_value("new_key1", "new_value1"),
+                create_metadata_value("new_key2", "new_value2"),
+            ]),
+        };
+        
+        let result = load_run_by_form(channel, run_form).await;
+        assert!(result.is_ok());
+        
+        let updated_run = result.unwrap();
+        assert_eq!(updated_run.tags, vec!["new_tag1", "new_tag2"]);
+        assert_eq!(updated_run.metadata.len(), 2);
+        assert_eq!(updated_run.description, "Updated description");
+        
+        // Verify update_run was called with all three field masks
+        let update_calls = mock_service.get_update_calls();
+        assert_eq!(update_calls.len(), 1);
+        assert!(update_calls[0].field_mask.contains(&"tags".to_string()));
+        assert!(update_calls[0].field_mask.contains(&"metadata".to_string()));
+        assert!(update_calls[0].field_mask.contains(&"description".to_string()));
+        
+        server.abort();
+    }
+}

--- a/rust/crates/sift_stream/src/stream/run.rs
+++ b/rust/crates/sift_stream/src/stream/run.rs
@@ -490,7 +490,11 @@ mod tests {
         // Verify update_run was called with correct field mask
         let update_calls = mock_service.get_update_calls();
         assert_eq!(update_calls.len(), 1);
-        assert!(update_calls[0].update_mask.contains(&"metadata".to_string()));
+        assert!(
+            update_calls[0]
+                .update_mask
+                .contains(&"metadata".to_string())
+        );
         assert_eq!(update_calls[0].updated_run.metadata.len(), 2);
 
         server.abort();
@@ -684,7 +688,11 @@ mod tests {
         // Verify update_run was called with correct field mask and data
         let update_calls = mock_service.get_update_calls();
         assert_eq!(update_calls.len(), 1);
-        assert!(update_calls[0].update_mask.contains(&"metadata".to_string()));
+        assert!(
+            update_calls[0]
+                .update_mask
+                .contains(&"metadata".to_string())
+        );
         assert_eq!(update_calls[0].updated_run.metadata.len(), 3);
 
         server.abort();
@@ -752,7 +760,11 @@ mod tests {
         // Verify update_run was called due to different metadata
         let update_calls = mock_service.get_update_calls();
         assert_eq!(update_calls.len(), 1);
-        assert!(update_calls[0].update_mask.contains(&"metadata".to_string()));
+        assert!(
+            update_calls[0]
+                .update_mask
+                .contains(&"metadata".to_string())
+        );
 
         server.abort();
     }
@@ -799,7 +811,11 @@ mod tests {
         let update_calls = mock_service.get_update_calls();
         assert_eq!(update_calls.len(), 1);
         assert!(update_calls[0].update_mask.contains(&"tags".to_string()));
-        assert!(update_calls[0].update_mask.contains(&"metadata".to_string()));
+        assert!(
+            update_calls[0]
+                .update_mask
+                .contains(&"metadata".to_string())
+        );
         assert!(
             update_calls[0]
                 .update_mask

--- a/rust/crates/sift_stream/src/stream/run.rs
+++ b/rust/crates/sift_stream/src/stream/run.rs
@@ -196,7 +196,7 @@ mod tests {
     struct UpdateCall {
         #[allow(dead_code)]
         run_name: String,
-        field_mask: Vec<String>,
+        update_mask: Vec<String>,
         updated_run: Run,
     }
 
@@ -285,12 +285,12 @@ mod tests {
             let updated_run = req
                 .run
                 .ok_or_else(|| Status::invalid_argument("run is required"))?;
-            let field_mask = req.update_mask.unwrap_or_default();
+            let update_mask = req.update_mask.unwrap_or_default();
 
             // Capture the update call for verification
             let update_call = UpdateCall {
                 run_name: updated_run.name.clone(),
-                field_mask: field_mask.paths.clone(),
+                update_mask: update_mask.paths.clone(),
                 updated_run: updated_run.clone(),
             };
 
@@ -440,10 +440,10 @@ mod tests {
         // Verify update_run was called with correct field mask
         let update_calls = mock_service.get_update_calls();
         assert_eq!(update_calls.len(), 1);
-        assert!(update_calls[0].field_mask.contains(&"tags".to_string()));
+        assert!(update_calls[0].update_mask.contains(&"tags".to_string()));
         assert!(
             update_calls[0]
-                .field_mask
+                .update_mask
                 .contains(&"description".to_string())
         );
         assert_eq!(update_calls[0].updated_run.tags, vec!["tag1", "tag2"]);
@@ -490,7 +490,7 @@ mod tests {
         // Verify update_run was called with correct field mask
         let update_calls = mock_service.get_update_calls();
         assert_eq!(update_calls.len(), 1);
-        assert!(update_calls[0].field_mask.contains(&"metadata".to_string()));
+        assert!(update_calls[0].update_mask.contains(&"metadata".to_string()));
         assert_eq!(update_calls[0].updated_run.metadata.len(), 2);
 
         server.abort();
@@ -619,7 +619,7 @@ mod tests {
         // Verify update_run was called with correct field mask and data
         let update_calls = mock_service.get_update_calls();
         assert_eq!(update_calls.len(), 1);
-        assert!(update_calls[0].field_mask.contains(&"tags".to_string()));
+        assert!(update_calls[0].update_mask.contains(&"tags".to_string()));
         assert_eq!(
             update_calls[0].updated_run.tags,
             vec!["new_tag1", "new_tag2", "new_tag3"]
@@ -684,7 +684,7 @@ mod tests {
         // Verify update_run was called with correct field mask and data
         let update_calls = mock_service.get_update_calls();
         assert_eq!(update_calls.len(), 1);
-        assert!(update_calls[0].field_mask.contains(&"metadata".to_string()));
+        assert!(update_calls[0].update_mask.contains(&"metadata".to_string()));
         assert_eq!(update_calls[0].updated_run.metadata.len(), 3);
 
         server.abort();
@@ -752,7 +752,7 @@ mod tests {
         // Verify update_run was called due to different metadata
         let update_calls = mock_service.get_update_calls();
         assert_eq!(update_calls.len(), 1);
-        assert!(update_calls[0].field_mask.contains(&"metadata".to_string()));
+        assert!(update_calls[0].update_mask.contains(&"metadata".to_string()));
 
         server.abort();
     }
@@ -798,11 +798,11 @@ mod tests {
         // Verify update_run was called with all three field masks
         let update_calls = mock_service.get_update_calls();
         assert_eq!(update_calls.len(), 1);
-        assert!(update_calls[0].field_mask.contains(&"tags".to_string()));
-        assert!(update_calls[0].field_mask.contains(&"metadata".to_string()));
+        assert!(update_calls[0].update_mask.contains(&"tags".to_string()));
+        assert!(update_calls[0].update_mask.contains(&"metadata".to_string()));
         assert!(
             update_calls[0]
-                .field_mask
+                .update_mask
                 .contains(&"description".to_string())
         );
 

--- a/rust/crates/sift_stream/src/stream/run.rs
+++ b/rust/crates/sift_stream/src/stream/run.rs
@@ -201,8 +201,8 @@ mod tests {
     }
 
     impl MockRunService {
-        fn new() -> Self {
-            Self {
+        fn new() -> MockRunService {
+            MockRunService {
                 runs: Arc::new(Mutex::new(HashMap::new())),
                 update_calls: Arc::new(Mutex::new(Vec::new())),
             }

--- a/rust/crates/sift_stream_bindings/src/stream/config.rs
+++ b/rust/crates/sift_stream_bindings/src/stream/config.rs
@@ -85,6 +85,7 @@ impl From<RunFormPy> for RunForm {
             client_key: form.client_key,
             description: form.description,
             tags: form.tags,
+            metadata: None
         }
     }
 }

--- a/rust/crates/sift_stream_bindings/src/stream/config.rs
+++ b/rust/crates/sift_stream_bindings/src/stream/config.rs
@@ -85,7 +85,7 @@ impl From<RunFormPy> for RunForm {
             client_key: form.client_key,
             description: form.description,
             tags: form.tags,
-            metadata: None
+            metadata: None,
         }
     }
 }


### PR DESCRIPTION
- Adds ability to include metadata in SiftStream when creating a run with a new `RunForm` field `metadata`.
- Adds `add_asset_metadata()` and `add_asset_tags()` to `SiftStreamBuilder` which can be used to add tags or metadata to an asset.
- Fixes bug with existing `RunForm` tag field which did not correctly replace tags on a run if the run had existing tags
- Adds metadata macro to `sift_rs` to improve QoL when creating metadata

**Example usage for a run**
```
// Create metadata using the metadata macro
let metadata = metadata![
    ("test_number", 5.0),
    ("is_simulation", true),
    ("location", "SiftHQ"),
];

// Define an optional run to group together data for this period of telemetry ingestion.
let run = RunForm {
    name: format!("[MarsRover0].{ts}"),
    client_key: format!("mars-rover-sim-{ts}"),
    description: Some("simulation run".into()),
    tags: Some(vec!["simulation".into()]),
    metadata: Some(metadata),
};
```

**Verification**
- Unit testing of run tag/metadata behavior
- Verified locally with soak test application that tags and metadata are correctly added/updated on both runs and assets