### PR TITLE
rust(chore) Updated github action workflow

### DIFF
--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -8,6 +8,11 @@ on:
     branches:
       - main
   workflow_call:
+    inputs:
+        ref:
+          description: "Git ref (tag or sha) to check out and test"
+          required: false
+          type: string
 
 jobs:
   lint-rust:
@@ -15,6 +20,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust_release.yaml
+++ b/.github/workflows/rust_release.yaml
@@ -8,9 +8,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags')
     uses: ./.github/workflows/rust_ci.yaml
 
-  publish-to-crates-io-sift_rs:
+  publish-to-crates-io:
     runs-on: ubuntu-latest
-    name: Publish to crates.io for sift_rs
+    name: Publish to crates.io for the sift rust libraries
     needs: rust-ci
     environment:
       name: crates.io
@@ -18,57 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: Publish crate
-        run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
-        working-directory: './rust/crates/sift_rs'
+      - name: Publish crates
+        run: cargo publish --workspace --exclude sift-stream-bindings --manifest-path ./rust/Cargo.toml --locked --token ${CARGO_REGISTRY_TOKEN}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-  publish-to-crates-io-sift_error:
-    runs-on: ubuntu-latest
-    name: Publish to crates.io for sift_error
-    needs: publish-to-crates-io-sift_rs
-    environment:
-      name: crates.io
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Publish crate
-        run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
-        working-directory: './rust/crates/sift_error'
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-  publish-to-crates-io-sift_connect:
-    runs-on: ubuntu-latest
-    name: Publish to crates.io for sift_connect
-    needs: publish-to-crates-io-sift_error
-    environment:
-      name: crates.io
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Publish crate
-        run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
-        working-directory: './rust/crates/sift_connect'
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-  
-  publish-to-crates-io-sift_stream:
-    runs-on: ubuntu-latest
-    name: Publish to crates.io for sift_stream
-    needs: publish-to-crates-io-sift_connect
-    environment:
-      name: crates.io
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Publish crate
-        run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
-        working-directory: './rust/crates/sift_stream'
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-

--- a/.github/workflows/rust_release.yaml
+++ b/.github/workflows/rust_release.yaml
@@ -3,16 +3,16 @@ name: Crates Publish
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Git tag to publish from"
+      ref:
+        description: "Optional git tag or commit SHA to publish from"
         type: string
-        required: true
+        required: false
 
 jobs:
   rust-ci:
     uses: ./.github/workflows/rust_ci.yaml
     with:
-      ref: ${{ github.event.inputs.tag }}
+      ref: ${{ github.event.inputs.ref }}
 
   publish-to-crates-io:
     runs-on: ubuntu-latest
@@ -21,10 +21,10 @@ jobs:
     environment:
       name: crates.io
     steps:
-      - name: Checkout the specified tag
+      - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.tag }}
+          ref: ${{ github.event.inputs.ref || github.sha }}
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Publish crates

--- a/.github/workflows/rust_release.yaml
+++ b/.github/workflows/rust_release.yaml
@@ -2,11 +2,17 @@ name: Crates Publish
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to publish from"
+        type: string
+        required: true
 
 jobs:
   rust-ci:
-    if: github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags')
     uses: ./.github/workflows/rust_ci.yaml
+    with:
+      ref: ${{ github.event.inputs.tag }}
 
   publish-to-crates-io:
     runs-on: ubuntu-latest
@@ -15,7 +21,10 @@ jobs:
     environment:
       name: crates.io
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout the specified tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag }}
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Publish crates

--- a/.github/workflows/rust_release.yaml
+++ b/.github/workflows/rust_release.yaml
@@ -15,63 +15,60 @@ jobs:
     environment:
       name: crates.io
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: katyo/publish-crates@v2
-        with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          path: './rust/crates/sift_rs'
+      - uses: actions/checkout@v4
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Publish crate
+        run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
+        working-directory: './rust/crates/sift_rs'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   publish-to-crates-io-sift_error:
     runs-on: ubuntu-latest
     name: Publish to crates.io for sift_error
-    needs: rust-ci
+    needs: publish-to-crates-io-sift_rs
     environment:
       name: crates.io
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: katyo/publish-crates@v2
-        with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          path: './rust/crates/sift_error'
+      - uses: actions/checkout@v4
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Publish crate
+        run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
+        working-directory: './rust/crates/sift_error'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   publish-to-crates-io-sift_connect:
     runs-on: ubuntu-latest
     name: Publish to crates.io for sift_connect
-    needs: rust-ci
+    needs: publish-to-crates-io-sift_error
     environment:
       name: crates.io
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: katyo/publish-crates@v2
-        with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          path: './rust/crates/sift_connect'
-
+      - uses: actions/checkout@v4
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Publish crate
+        run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
+        working-directory: './rust/crates/sift_connect'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  
   publish-to-crates-io-sift_stream:
     runs-on: ubuntu-latest
     name: Publish to crates.io for sift_stream
-    needs: rust-ci
+    needs: publish-to-crates-io-sift_connect
     environment:
       name: crates.io
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: katyo/publish-crates@v2
-        with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          path: './rust/crates/sift_stream'
+      - uses: actions/checkout@v4
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Publish crate
+        run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
+        working-directory: './rust/crates/sift_stream'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+

--- a/.github/workflows/rust_release_dry_run.yaml
+++ b/.github/workflows/rust_release_dry_run.yaml
@@ -3,16 +3,16 @@ name: Crates Publish (Dry Run)
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Git tag to publish from"
+      ref:
+        description: "Optional git tag or commit SHA to publish from"
         type: string
-        required: true
+        required: false
 
 jobs:
   rust-ci:
     uses: ./.github/workflows/rust_ci.yaml
     with:
-      ref: ${{ github.event.inputs.tag }}
+      ref: ${{ github.event.inputs.ref }}
   
   publish-to-crates-io-dry-run:
     runs-on: ubuntu-latest
@@ -21,10 +21,10 @@ jobs:
     environment:
       name: crates.io (dry run)
     steps:
-      - name: Checkout the specified tag
+      - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.tag }}
+          ref: ${{ github.event.inputs.ref || github.sha }}
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Publish crates (dry run)

--- a/.github/workflows/rust_release_dry_run.yaml
+++ b/.github/workflows/rust_release_dry_run.yaml
@@ -16,16 +16,12 @@ jobs:
     environment:
       name: crates.io (dry run)
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: katyo/publish-crates@v2
-        with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          path: './rust/crates/sift_rs'
-          dry-run: true
+      - uses: actions/checkout@v4
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Publish crate (dry run)
+        run: cargo publish --dry-run
+        working-directory: './rust/crates/sift_rs'
 
   publish-to-crates-io-dry-run-sift_error:
     runs-on: ubuntu-latest
@@ -34,16 +30,12 @@ jobs:
     environment:
       name: crates.io (dry run)
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: katyo/publish-crates@v2
-        with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          path: './rust/crates/sift_error'
-          dry-run: true
+      - uses: actions/checkout@v4
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Publish crate (dry run)
+        run: cargo publish --dry-run
+        working-directory: './rust/crates/sift_error'
 
   publish-to-crates-io-dry-run-sift_connect:
     runs-on: ubuntu-latest
@@ -52,16 +44,12 @@ jobs:
     environment:
       name: crates.io (dry run)
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: katyo/publish-crates@v2
-        with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          path: './rust/crates/sift_connect'
-          dry-run: true
+      - uses: actions/checkout@v4
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Publish crate (dry run)
+        run: cargo publish --dry-run
+        working-directory: './rust/crates/sift_connect'
 
   publish-to-crates-io-dry-run-sift_stream:
     runs-on: ubuntu-latest
@@ -70,13 +58,10 @@ jobs:
     environment:
       name: crates.io (dry run)
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: katyo/publish-crates@v2
-        with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          path: './rust/crates/sift_stream'
-          dry-run: true
+      - uses: actions/checkout@v4
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Publish crate (dry run)
+        run: cargo publish --dry-run
+        working-directory: './rust/crates/sift_stream'
+

--- a/.github/workflows/rust_release_dry_run.yaml
+++ b/.github/workflows/rust_release_dry_run.yaml
@@ -2,12 +2,17 @@ name: Crates Publish (Dry Run)
 
 on:
   workflow_dispatch:
-  workflow_call:
+    inputs:
+      tag:
+        description: "Git tag to publish from"
+        type: string
+        required: true
 
 jobs:
   rust-ci:
-    if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/rust_ci.yaml
+    with:
+      ref: ${{ github.event.inputs.tag }}
   
   publish-to-crates-io-dry-run:
     runs-on: ubuntu-latest
@@ -16,7 +21,10 @@ jobs:
     environment:
       name: crates.io (dry run)
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout the specified tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag }}
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Publish crates (dry run)

--- a/.github/workflows/rust_release_dry_run.yaml
+++ b/.github/workflows/rust_release_dry_run.yaml
@@ -8,10 +8,10 @@ jobs:
   rust-ci:
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/rust_ci.yaml
-
-  publish-to-crates-io-dry-run-sift_rs:
+  
+  publish-to-crates-io-dry-run:
     runs-on: ubuntu-latest
-    name: Do a dry run publish to crates.io for sift_rs
+    name: Do a dry run publish to crates.io for the sift rust libraries
     needs: rust-ci
     environment:
       name: crates.io (dry run)
@@ -19,49 +19,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: Publish crate (dry run)
-        run: cargo publish --dry-run
-        working-directory: './rust/crates/sift_rs'
-
-  publish-to-crates-io-dry-run-sift_error:
-    runs-on: ubuntu-latest
-    name: Do a dry run publish to crates.io for sift_error
-    needs: rust-ci
-    environment:
-      name: crates.io (dry run)
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Publish crate (dry run)
-        run: cargo publish --dry-run
-        working-directory: './rust/crates/sift_error'
-
-  publish-to-crates-io-dry-run-sift_connect:
-    runs-on: ubuntu-latest
-    name: Do a dry run publish to crates.io for sift_connect
-    needs: rust-ci
-    environment:
-      name: crates.io (dry run)
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Publish crate (dry run)
-        run: cargo publish --dry-run
-        working-directory: './rust/crates/sift_connect'
-
-  publish-to-crates-io-dry-run-sift_stream:
-    runs-on: ubuntu-latest
-    name: Do a dry run publish to crates.io for sift_stream
-    needs: rust-ci
-    environment:
-      name: crates.io (dry run)
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Publish crate (dry run)
-        run: cargo publish --dry-run
-        working-directory: './rust/crates/sift_stream'
-
+      - name: Publish crates (dry run)
+        run: cargo publish --workspace --exclude sift-stream-bindings --manifest-path ./rust/Cargo.toml --locked --dry-run


### PR DESCRIPTION
Update publish workflows to use new --workspace feature in rust 1.90 and fix broken automation. Add ability to target specific tag/sha

**Verification**
Dry run verified to work. Publish _should_ work, but can't be tested except on main due to Action restrictions