### PR TITLE
rust(feat): Optimize flow conversion into gRPC request.

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -42,6 +42,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +209,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +244,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +319,73 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "dirs"
@@ -455,6 +592,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +618,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -627,6 +780,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -860,6 +1033,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,7 +1096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eea3058763d6e656105d1403cb04e0a41b7bbac6362d413e7c33be0c32279c9"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.13.0",
  "prost",
  "prost-types",
 ]
@@ -986,6 +1165,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,7 +1252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -1065,7 +1272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1166,7 +1373,7 @@ dependencies = [
  "either",
  "indexmap 2.7.1",
  "inventory",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "maplit",
  "num-complex",
@@ -1261,6 +1468,26 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "rdrand"
@@ -1443,6 +1670,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,6 +1740,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1582,11 +1836,13 @@ dependencies = [
  "bytesize",
  "chrono",
  "crc32fast",
+ "criterion",
  "dirs",
  "futures-core",
  "hyper-util",
  "pbjson-types",
  "prost",
+ "rand 0.8.5",
  "sift_connect",
  "sift_error",
  "sift_rs",
@@ -1715,6 +1971,16 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2024,6 +2290,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2106,6 +2382,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,6 +2415,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/rust/crates/sift_stream/Cargo.toml
+++ b/rust/crates/sift_stream/Cargo.toml
@@ -30,6 +30,7 @@ uuid = { version = "1.16.0", features = ["v4"] }
 [features]
 default = ["tracing"]
 tracing = ["dep:tracing", "dep:bytesize"]
+unstable = []
 
 [dev-dependencies]
 async-trait = "^0.1"
@@ -42,3 +43,10 @@ tracing-subscriber = { version = "0.3.19", features = ["fmt", "env-filter"] }
 tokio = { version = "1.43.0", features = ["rt", "rt-multi-thread", "sync", "time"] }
 uuid = { version = "1.16.0", features = ["v4"] }
 tracing-test = { version = "0.2.5", features = ["no-env-filter"] }
+criterion = { version = "0.5", features = ["html_reports"] }
+rand = "0.8"
+
+[[bench]]
+name = "message_to_ingest_req"
+harness = false
+required-features = ["unstable"]

--- a/rust/crates/sift_stream/benches/message_to_ingest_req.rs
+++ b/rust/crates/sift_stream/benches/message_to_ingest_req.rs
@@ -1,0 +1,243 @@
+//! Benchmark for the `message_to_ingest_req` function.
+//!
+//! This benchmark tests the performance of the `message_to_ingest_req` function under different
+//! scenarios:
+//! 1. **Ordered channel values**: The channel values in the message are in the same order as
+//!    the corresponding FlowConfig channels (optimal case).
+//! 2. **Randomized channel values**: The channel values in the message are in random order
+//!    (worst case for the matching algorithm).
+//! 3. **Varying sizes**: Tests both scenarios with different numbers of channels (5, 10, 20, 50, 100).
+//!
+//! The benchmark creates a configurable number of FlowConfigs and tests the function's ability
+//! to match a message against the appropriate flow configuration.
+//!
+//! **Note**: This benchmark requires the `unstable` feature to be enabled:
+//! ```bash
+//! cargo bench --bench message_to_ingest_req --features unstable
+//! ```
+
+// Ensure this benchmark only compiles when the unstable feature is enabled
+#[cfg(not(feature = "unstable"))]
+compile_error!(
+    "This benchmark requires the 'unstable' feature to be enabled. Run with: cargo bench --bench message_to_ingest_req --features unstable"
+);
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+use std::hint::black_box;
+
+use sift_rs::ingestion_configs::v2::{ChannelConfig, FlowConfig};
+use sift_stream::stream::mode::ingestion_config::Flow;
+use sift_stream::{
+    ChannelDataType, ChannelValue, TimeValue, Value,
+    stream::mode::bench::{message_to_ingest_req, message_to_ingest_req_direct},
+};
+
+/// Creates a FlowConfig with a given name and number of channels.
+fn flow_config(name: &str, num_channels: usize) -> FlowConfig {
+    let mut channels = Vec::with_capacity(num_channels);
+
+    for i in 0..num_channels {
+        let data_type = (i as i32 % 11) + 1; // Avoid 0 (Unspecified)
+        let channel = ChannelConfig {
+            name: format!("value_{i}"),
+            unit: "unit".to_string(),
+            description: format!("Channel {i} description"),
+            data_type,
+            enum_types: vec![],
+            bit_field_elements: vec![],
+        };
+        channels.push(channel);
+    }
+
+    FlowConfig {
+        name: name.to_string(),
+        channels,
+    }
+}
+
+/// Creates a flow with channel values in the same order as the FlowConfig.
+fn flow_ordered(name: &str, flow_config: &FlowConfig) -> Flow {
+    let ts = TimeValue::from_timestamp_nanos(0);
+    let mut values = Vec::with_capacity(flow_config.channels.len());
+
+    for (i, channel_config) in flow_config.channels.iter().enumerate() {
+        let data_type = ChannelDataType::try_from(channel_config.data_type).unwrap();
+        let value = match data_type {
+            ChannelDataType::Double => Value::Double(i as f64),
+            ChannelDataType::String => Value::String(format!("{i}")),
+            ChannelDataType::Float => Value::Float(i as f32),
+            ChannelDataType::Bool => Value::Bool(i % 2 == 0),
+            ChannelDataType::Int32 => Value::Int32(i as i32),
+            ChannelDataType::Int64 => Value::Int64(i as i64),
+            ChannelDataType::Uint32 => Value::Uint32(i as u32),
+            ChannelDataType::Uint64 => Value::Uint64(i as u64),
+            ChannelDataType::Enum => Value::Enum(i as u32),
+            ChannelDataType::BitField => Value::BitField(vec![i as u8]),
+            ChannelDataType::Unspecified => Value::String(format!("{i}")),
+            ChannelDataType::Bytes => Value::BitField(vec![i as u8]),
+        };
+
+        values.push(ChannelValue::new(&channel_config.name, value));
+    }
+
+    Flow::new(name, ts, &values)
+}
+
+/// Creates a flow with channel values in randomized order.
+fn flow_randomized(name: &str, flow_config: &FlowConfig) -> Flow {
+    let ts = TimeValue::from_timestamp_nanos(0);
+    let mut values = Vec::with_capacity(flow_config.channels.len());
+
+    for (i, channel_config) in flow_config.channels.iter().enumerate() {
+        let data_type = ChannelDataType::try_from(channel_config.data_type).unwrap();
+        let value = match data_type {
+            ChannelDataType::Double => Value::Double(i as f64),
+            ChannelDataType::String => Value::String(format!("{i}")),
+            ChannelDataType::Float => Value::Float(i as f32),
+            ChannelDataType::Bool => Value::Bool(i % 2 == 0),
+            ChannelDataType::Int32 => Value::Int32(i as i32),
+            ChannelDataType::Int64 => Value::Int64(i as i64),
+            ChannelDataType::Uint32 => Value::Uint32(i as u32),
+            ChannelDataType::Uint64 => Value::Uint64(i as u64),
+            ChannelDataType::Enum => Value::Enum(i as u32),
+            ChannelDataType::BitField => Value::BitField(vec![i as u8]),
+            ChannelDataType::Unspecified => Value::String(format!("{i}")),
+            ChannelDataType::Bytes => Value::BitField(vec![i as u8]),
+        };
+
+        values.push(ChannelValue::new(&channel_config.name, value));
+    }
+
+    // Randomize the order of values
+    let mut rng = thread_rng();
+    values.shuffle(&mut rng);
+
+    Flow::new(name, ts, &values)
+}
+
+// Configuration constants - these can be adjusted to test different scenarios
+const NUM_FLOWS: usize = 10; // Number of flow configs to create
+const NUM_CHANNELS_PER_FLOW: usize = 2000; // Number of channels per flow
+const INGESTION_CONFIG_ID: &str = "benchmark-config";
+const RUN_ID: Option<String> = None;
+const FLOW_TO_RANDOMIZE: usize = 8;
+
+fn benchmark_message_to_ingest_req_direct(c: &mut Criterion) {
+    // Create a flow with ordered channel values (matching the first flow config)
+    let message = flow_ordered("flow_0", &flow_config("flow_0", NUM_CHANNELS_PER_FLOW));
+
+    c.bench_function("message_to_ingest_req_direct", |b| {
+        b.iter(|| {
+            black_box(message_to_ingest_req_direct(
+                &message,
+                INGESTION_CONFIG_ID,
+                RUN_ID.clone(),
+            ))
+        })
+    });
+}
+
+fn benchmark_message_to_ingest_req_ordered(c: &mut Criterion) {
+    // Create flow configs
+    let mut flow_configs = Vec::with_capacity(NUM_FLOWS);
+    for i in 0..NUM_FLOWS {
+        flow_configs.push(flow_config(&format!("flow_{i}"), NUM_CHANNELS_PER_FLOW));
+    }
+
+    // Create a flow with ordered channel values (matching the first flow config)
+    let message = flow_ordered("flow_0", &flow_configs[FLOW_TO_RANDOMIZE]);
+
+    c.bench_function("message_to_ingest_req_ordered", |b| {
+        b.iter(|| {
+            black_box(message_to_ingest_req(
+                &message,
+                INGESTION_CONFIG_ID,
+                RUN_ID.clone(),
+                &flow_configs,
+            ))
+        })
+    });
+}
+
+fn benchmark_message_to_ingest_req_randomized(c: &mut Criterion) {
+    // Create flow configs
+    let mut flow_configs = Vec::with_capacity(NUM_FLOWS);
+    for i in 0..NUM_FLOWS {
+        flow_configs.push(flow_config(&format!("flow_{i}"), NUM_CHANNELS_PER_FLOW));
+    }
+
+    // Create a flow with randomized channel values (matching the first flow config)
+    let message = flow_randomized("flow_0", &flow_configs[FLOW_TO_RANDOMIZE]);
+
+    c.bench_function("message_to_ingest_req_randomized", |b| {
+        b.iter(|| {
+            black_box(message_to_ingest_req(
+                &message,
+                INGESTION_CONFIG_ID,
+                RUN_ID.clone(),
+                &flow_configs,
+            ))
+        })
+    });
+}
+
+fn benchmark_message_to_ingest_req_varying_sizes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("message_to_ingest_req_varying_sizes");
+
+    for &num_channels in &[5, 10, 100, 1000, 5000] {
+        // Create flow configs with varying channel counts
+        let mut flow_configs = Vec::with_capacity(NUM_FLOWS);
+        for i in 0..NUM_FLOWS {
+            flow_configs.push(flow_config(&format!("flow_{i}"), num_channels));
+        }
+
+        // Test direct scenario
+        let message_ordered = flow_ordered("flow_0", &flow_configs[FLOW_TO_RANDOMIZE]);
+        group.bench_function(&format!("direct_{num_channels}_channels"), |b| {
+            b.iter(|| {
+                black_box(message_to_ingest_req_direct(
+                    &message_ordered,
+                    INGESTION_CONFIG_ID,
+                    RUN_ID.clone(),
+                ))
+            })
+        });
+
+        group.bench_function(&format!("ordered_{num_channels}_channels"), |b| {
+            b.iter(|| {
+                black_box(message_to_ingest_req(
+                    &message_ordered,
+                    INGESTION_CONFIG_ID,
+                    RUN_ID.clone(),
+                    &flow_configs,
+                ))
+            })
+        });
+
+        // Test randomized scenario
+        let message_randomized = flow_randomized("flow_0", &flow_configs[FLOW_TO_RANDOMIZE]);
+        group.bench_function(&format!("randomized_{num_channels}_channels"), |b| {
+            b.iter(|| {
+                black_box(message_to_ingest_req(
+                    &message_randomized,
+                    INGESTION_CONFIG_ID,
+                    RUN_ID.clone(),
+                    &flow_configs,
+                ))
+            })
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    benchmark_message_to_ingest_req_direct,
+    benchmark_message_to_ingest_req_ordered,
+    benchmark_message_to_ingest_req_randomized,
+    benchmark_message_to_ingest_req_varying_sizes
+);
+criterion_main!(benches);

--- a/rust/crates/sift_stream/src/stream/mode/bench.rs
+++ b/rust/crates/sift_stream/src/stream/mode/bench.rs
@@ -1,0 +1,32 @@
+use crate::stream::mode::ingestion_config::Flow;
+use crate::{IngestionConfigMode, SiftStream};
+use sift_rs::ingestion_configs::v2::FlowConfig;
+
+/// TODO: Remove me. Used only for benchmarking purposes.
+#[inline]
+pub fn message_to_ingest_req(
+    message: &Flow,
+    ingestion_config_id: &str,
+    run_id: Option<String>,
+    flows: &[FlowConfig],
+) -> Option<sift_rs::ingest::v1::IngestWithConfigDataStreamRequest> {
+    SiftStream::<IngestionConfigMode>::message_to_ingest_req(
+        message,
+        ingestion_config_id,
+        run_id,
+        flows,
+    )
+}
+/// TODO: Remove me. Used only for benchmarking purposes.
+#[inline]
+pub fn message_to_ingest_req_direct(
+    message: &Flow,
+    ingestion_config_id: &str,
+    run_id: Option<String>,
+) -> sift_rs::ingest::v1::IngestWithConfigDataStreamRequest {
+    SiftStream::<IngestionConfigMode>::message_to_ingest_req_direct(
+        message,
+        ingestion_config_id,
+        run_id,
+    )
+}

--- a/rust/crates/sift_stream/src/stream/mode/bench.rs
+++ b/rust/crates/sift_stream/src/stream/mode/bench.rs
@@ -2,7 +2,7 @@ use crate::stream::mode::ingestion_config::Flow;
 use crate::{IngestionConfigMode, SiftStream};
 use sift_rs::ingestion_configs::v2::FlowConfig;
 
-/// TODO: Remove me. Used only for benchmarking purposes.
+/// Unstable wrapper around [SiftStream::message_to_ingest_req] used for benchmarking purposes.
 #[inline]
 pub fn message_to_ingest_req(
     message: &Flow,
@@ -17,7 +17,8 @@ pub fn message_to_ingest_req(
         flows,
     )
 }
-/// TODO: Remove me. Used only for benchmarking purposes.
+
+/// Unstable wrapper around [SiftStream::message_to_ingest_req_direct] used for benchmarking purposes.
 #[inline]
 pub fn message_to_ingest_req_direct(
     message: &Flow,

--- a/rust/crates/sift_stream/src/stream/mode/mod.rs
+++ b/rust/crates/sift_stream/src/stream/mode/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "unstable")]
+pub mod bench;
+
 #[cfg(test)]
 mod test;
 


### PR DESCRIPTION
* Optimizes the `message_to_ingest_req` function.
* Adds benchmarking infrastructure used for optimizing the `message_to_ingest_req` function.
* Adds "unstable" feature flag needed to support benchmarking a non-public function.

For a flow of 5000 channels, local benchmarks indicate the `message_to_ingest_req` performance has gone from taking on average 167ms to 75us, showing substantial improvements (many orders of magnitude).

The benchmark can be ran with the following cargo command:
```shell
cargo bench --bench message_to_ingest_req --features unstable
``` 

The behavior of the function remains unchanged, so existing tests still properly validate expectations.