### PR TITLE
rust(feat): SiftStream Metrics

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -673,13 +673,14 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -687,6 +688,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1724,18 +1726,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1744,14 +1756,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1839,10 +1852,13 @@ dependencies = [
  "criterion",
  "dirs",
  "futures-core",
+ "hyper",
  "hyper-util",
  "pbjson-types",
  "prost",
  "rand 0.8.5",
+ "serde",
+ "serde_json",
  "sift_connect",
  "sift_error",
  "sift_rs",

--- a/rust/crates/sift_error/src/lib.rs
+++ b/rust/crates/sift_error/src/lib.rs
@@ -148,6 +148,8 @@ pub enum ErrorKind {
     BackupIntegrityError,
     /// When backup file/buffer limit has been reached.
     BackupLimitReached,
+    /// Errors with the SiftStream Metrics Server
+    SiftStreamMetricsServerError,
     /// General errors that are rarely returned.
     GeneralError,
 }
@@ -219,6 +221,7 @@ impl fmt::Display for ErrorKind {
             Self::IncompatibleIngestionConfigChange => {
                 write!(f, "IncompatibleIngestionConfigChange")
             }
+            Self::SiftStreamMetricsServerError => write!(f, "SiftStreamMetricsServerError"),
         }
     }
 }

--- a/rust/crates/sift_error/src/test.rs
+++ b/rust/crates/sift_error/src/test.rs
@@ -6,7 +6,7 @@ use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 pub fn test_error_formatting() {
     let inner_error = IoError::new(IoErrorKind::NotFound, "I am the root cause");
     let sift_error: Result<()> = Err(Error::new(ErrorKind::IoError, inner_error));
-    let actual = format!("{}", sift_error.unwrap_err());
+    let actual = format!("{}", sift_error.err().unwrap());
     let expected = indoc! {"
         [IoError]
 

--- a/rust/crates/sift_stream/Cargo.toml
+++ b/rust/crates/sift_stream/Cargo.toml
@@ -11,6 +11,10 @@ license = { workspace = true }
 categories = { workspace = true }
 readme = "README.md"
 
+[package.metadata.docs.rs]
+features = ["metrics-unstable"]
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 sift_connect = { workspace = true }
 sift_error = { workspace = true }

--- a/rust/crates/sift_stream/Cargo.toml
+++ b/rust/crates/sift_stream/Cargo.toml
@@ -26,14 +26,15 @@ prost = "^0.13"
 dirs = "6.0.0"
 crc32fast = "1.4.2"
 uuid = { version = "1.16.0", features = ["v4"] }
-hyper = { version = "1.7.0", features = ["server", "http1"] }
-hyper-util = { version = "0.1.10", features = ["service", "server", "tokio"] }
-serde = "1.0.226"
-serde_json = "1.0.145"
+hyper = { version = "1.7.0", features = ["server", "http1"], optional = true }
+hyper-util = { version = "0.1.10", features = ["service", "server", "tokio"], optional = true }
+serde = { version = "1.0.226", optional = true }
+serde_json = { version = "1.0.145", optional = true }
 
 [features]
 default = ["tracing"]
 tracing = ["dep:tracing", "dep:bytesize"]
+metrics-unstable = ["dep:serde", "dep:serde_json", "dep:hyper", "dep:hyper-util"]
 unstable = []
 
 [dev-dependencies]

--- a/rust/crates/sift_stream/Cargo.toml
+++ b/rust/crates/sift_stream/Cargo.toml
@@ -26,6 +26,10 @@ prost = "^0.13"
 dirs = "6.0.0"
 crc32fast = "1.4.2"
 uuid = { version = "1.16.0", features = ["v4"] }
+hyper = { version = "1.7.0", features = ["server", "http1"] }
+hyper-util = { version = "0.1.10", features = ["service", "server", "tokio"] }
+serde = "1.0.226"
+serde_json = "1.0.145"
 
 [features]
 default = ["tracing"]

--- a/rust/crates/sift_stream/src/backup/disk/async_manager.rs
+++ b/rust/crates/sift_stream/src/backup/disk/async_manager.rs
@@ -312,6 +312,8 @@ impl AsyncBackupsManager<IngestWithConfigDataStreamRequest> {
     /// Restart the backup task. Clears the current list of unprocessed backup files, and deleting them
     /// if allowed by the retain policy. Unpauses the backup task if the backups were full.
     pub(crate) async fn restart(&mut self) -> Result<()> {
+        self.metrics.backups.log_restart();
+        
         // Flush the current file
         // We don't want to get stuck here, and proceeding before the flush is complete won't cause any harm
         // so keep the timeout small
@@ -350,8 +352,6 @@ impl AsyncBackupsManager<IngestWithConfigDataStreamRequest> {
             }
         }
         backup_files_guard.clear();
-
-        self.metrics.backups.log_restart();
 
         if self.backup_task.is_some() {
             if self.backup_full.swap(false, Ordering::Relaxed) {

--- a/rust/crates/sift_stream/src/backup/disk/async_manager.rs
+++ b/rust/crates/sift_stream/src/backup/disk/async_manager.rs
@@ -181,8 +181,6 @@ impl AsyncBackupsManager<IngestWithConfigDataStreamRequest> {
                             cur_bytes_processed += CHECKSUM_HEADER_LEN + BATCH_SIZE_LEN;
 
                             if cur_bytes_processed >= backup_info.max_size {
-                                metrics.backups.log_new_file();
-
                                 #[cfg(feature = "tracing")]
                                 tracing::debug!(
                                     cur_backup_file = format!("{}", cur_backup_file_path.display()),
@@ -212,12 +210,11 @@ impl AsyncBackupsManager<IngestWithConfigDataStreamRequest> {
                                 cur_bytes_processed = 0;
                                 (cur_backup_file_path, cur_backup_file) =
                                     Self::create_backup_file(&backup_info)?;
+                                metrics.backups.log_new_file();
                             }
                         }
                     }
                     Message::Flush => {
-                        metrics.backups.log_new_file();
-
                         #[cfg(feature = "tracing")]
                         tracing::debug!(
                             cur_backup_file = format!("{}", cur_backup_file_path.display()),
@@ -248,10 +245,9 @@ impl AsyncBackupsManager<IngestWithConfigDataStreamRequest> {
                         cur_bytes_processed = 0;
                         (cur_backup_file_path, cur_backup_file) =
                             Self::create_backup_file(&backup_info)?;
+                        metrics.backups.log_new_file();
                     }
                     Message::Complete => {
-                        metrics.backups.log_new_file();
-
                         #[cfg(feature = "tracing")]
                         tracing::debug!(
                             cur_backup_file = format!("{}", cur_backup_file_path.display()),

--- a/rust/crates/sift_stream/src/backup/test.rs
+++ b/rust/crates/sift_stream/src/backup/test.rs
@@ -1,10 +1,12 @@
 use super::DiskBackupPolicy;
+use crate::metrics::SiftStreamMetrics;
 use crate::backup::disk::AsyncBackupsManager;
 use crate::{TimeValue, backup::sanitize_name};
 use sift_rs::ingest::v1::{
     IngestWithConfigDataChannelValue, IngestWithConfigDataStreamRequest,
     ingest_with_config_data_channel_value::Type,
 };
+use std::{fs, sync::Arc};
 use tempdir::TempDir;
 
 #[test]
@@ -55,6 +57,7 @@ async fn test_async_backups_manager_retrieve_data_with_graceful_termination() {
         disk_backup_policy,
         backup_retry_policy,
         grpc_channel,
+        Arc::new(SiftStreamMetrics::new())
     )
     .expect("failed to start backups manager");
 
@@ -134,6 +137,7 @@ async fn test_async_backups_manager_discard_data_with_graceful_termination() {
         disk_backup_policy,
         backup_retry_policy,
         grpc_channel,
+        Arc::new(SiftStreamMetrics::new())
     )
     .expect("failed to start backups manager");
 

--- a/rust/crates/sift_stream/src/backup/test.rs
+++ b/rust/crates/sift_stream/src/backup/test.rs
@@ -1,6 +1,6 @@
 use super::DiskBackupPolicy;
-use crate::metrics::SiftStreamMetrics;
 use crate::backup::disk::AsyncBackupsManager;
+use crate::metrics::SiftStreamMetrics;
 use crate::{TimeValue, backup::sanitize_name};
 use sift_rs::ingest::v1::{
     IngestWithConfigDataChannelValue, IngestWithConfigDataStreamRequest,
@@ -57,7 +57,7 @@ async fn test_async_backups_manager_retrieve_data_with_graceful_termination() {
         disk_backup_policy,
         backup_retry_policy,
         grpc_channel,
-        Arc::new(SiftStreamMetrics::new())
+        Arc::new(SiftStreamMetrics::new()),
     )
     .expect("failed to start backups manager");
 
@@ -137,7 +137,7 @@ async fn test_async_backups_manager_discard_data_with_graceful_termination() {
         disk_backup_policy,
         backup_retry_policy,
         grpc_channel,
-        Arc::new(SiftStreamMetrics::new())
+        Arc::new(SiftStreamMetrics::new()),
     )
     .expect("failed to start backups manager");
 

--- a/rust/crates/sift_stream/src/lib.rs
+++ b/rust/crates/sift_stream/src/lib.rs
@@ -366,6 +366,22 @@
 //! cargo add sift_stream --no-default-features
 //! ```
 //!
+//! ## Metrics
+//! SiftStream records metrics related to the performance and operational status separately for each SiftStream instance.
+//! While some metrics are provided through [tracing](#tracing), users may expose the ability to access these metrics
+//! by enabled the optional `metrics-unstable` feature flag.
+//! 
+//! Metrics are currently considered an unstable feature, and future updates may break the existing metrics API.
+//! 
+//! When the `metrics-unstable` feature flag is enabled, users may currently access metrics through one of two methods:
+//! - [SiftStream::metrics] returns a [SiftStreamMetricsSnapshot]
+//! - Enable the light weight HTTP metrics server using [metrics::start_metrics_server], which exposes the `/` and `/metrics`
+//!   endpoints, providing a JSON formatted struct of each sift-stream-id and its [SiftStreamMetricsSnapshot]
+//! 
+//! Snapshots of the metrics are taken at any time the user calls [SiftStream::metrics] or sends a GET request to the metrics
+//! server endpoints. Metrics are internally updated atomically, and calls to get metric snapshots are non-blocking to SiftStream
+//! operaration.
+//! 
 //! ## Tokio
 //!
 //! Because [tonic](https://docs.rs/tonic/latest/tonic/) is an underlying dependency, the

--- a/rust/crates/sift_stream/src/lib.rs
+++ b/rust/crates/sift_stream/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
 //! The `sift_stream` crate is primarily focused on streaming telemetry to Sift in a robust manner.
 //!
 //! Here are some features highlights:
@@ -374,7 +375,7 @@
 //! Metrics are currently considered an unstable feature, and future updates may break the existing metrics API.
 //! 
 //! When the `metrics-unstable` feature flag is enabled, users may currently access metrics through one of two methods:
-//! - [SiftStream::metrics] returns a [SiftStreamMetricsSnapshot]
+//! - [SiftStream::get_metrics_snapshot] returns a [SiftStreamMetricsSnapshot]
 //! - Enable the light weight HTTP metrics server using [metrics::start_metrics_server], which exposes the `/` and `/metrics`
 //!   endpoints, providing a JSON formatted struct of each sift-stream-id and its [SiftStreamMetricsSnapshot]
 //! 
@@ -390,6 +391,13 @@
 //!
 //! This crate is compatible with both the current and multi-threaded Tokio runtimes. Performance
 //! is expected to be better generally using the multi-threaded runtime.
+//! 
+//! ## Feature flags
+//! 
+//! - `default`: Includes the `tracing` feature flag
+//! - `tracing`: Enables logging of SiftStream through the Tracing crate. See [tracing](#tracing)
+//! - `metrics-unstable`: Enables the ability for the user to access SiftStream metrics from each [SiftStream] instance,
+//!   or through a light-weight HTML metrics server, if enabled. See [metrics](#metrics)
 
 /// Concerned with streaming telemetry into Sift.
 pub mod stream;

--- a/rust/crates/sift_stream/src/lib.rs
+++ b/rust/crates/sift_stream/src/lib.rs
@@ -379,7 +379,7 @@
 //! - Enable the light weight HTTP metrics server using [metrics::start_metrics_server], which exposes the `/` and `/metrics`
 //!   endpoints, providing a JSON formatted struct of each sift-stream-id and its [SiftStreamMetricsSnapshot]
 //! 
-//! Snapshots of the metrics are taken at any time the user calls [SiftStream::metrics] or sends a GET request to the metrics
+//! Snapshots of the metrics are taken at any time the user calls [SiftStream::get_metrics_snapshot] or sends a GET request to the metrics
 //! server endpoints. Metrics are internally updated atomically, and calls to get metric snapshots are non-blocking to SiftStream
 //! operaration.
 //! 

--- a/rust/crates/sift_stream/src/lib.rs
+++ b/rust/crates/sift_stream/src/lib.rs
@@ -397,7 +397,9 @@ pub use sift_connect::grpc::{Credentials, SiftChannel};
 
 /// Concerned with metrics for SiftStream
 pub mod metrics;
-pub use metrics::SiftStreamMetrics;
+
+#[cfg(feature = "metrics-unstable")]
+pub use metrics::SiftStreamMetricsSnapshot;
 
 #[cfg(test)]
 mod test;

--- a/rust/crates/sift_stream/src/lib.rs
+++ b/rust/crates/sift_stream/src/lib.rs
@@ -395,5 +395,9 @@ pub use backup::DiskBackupPolicy;
 
 pub use sift_connect::grpc::{Credentials, SiftChannel};
 
+/// Concerned with metrics for SiftStream
+pub mod metrics;
+pub use metrics::SiftStreamMetrics;
+
 #[cfg(test)]
 mod test;

--- a/rust/crates/sift_stream/src/lib.rs
+++ b/rust/crates/sift_stream/src/lib.rs
@@ -371,18 +371,18 @@
 //! SiftStream records metrics related to the performance and operational status separately for each SiftStream instance.
 //! While some metrics are provided through [tracing](#tracing), users may expose the ability to access these metrics
 //! by enabled the optional `metrics-unstable` feature flag.
-//! 
+//!
 //! Metrics are currently considered an unstable feature, and future updates may break the existing metrics API.
-//! 
+//!
 //! When the `metrics-unstable` feature flag is enabled, users may currently access metrics through one of two methods:
 //! - [SiftStream::get_metrics_snapshot] returns a [SiftStreamMetricsSnapshot]
 //! - Enable the light weight HTTP metrics server using [metrics::start_metrics_server], which exposes the `/` and `/metrics`
 //!   endpoints, providing a JSON formatted struct of each sift-stream-id and its [SiftStreamMetricsSnapshot]
-//! 
+//!
 //! Snapshots of the metrics are taken at any time the user calls [SiftStream::get_metrics_snapshot] or sends a GET request to the metrics
 //! server endpoints. Metrics are internally updated atomically, and calls to get metric snapshots are non-blocking to SiftStream
 //! operaration.
-//! 
+//!
 //! ## Tokio
 //!
 //! Because [tonic](https://docs.rs/tonic/latest/tonic/) is an underlying dependency, the
@@ -391,9 +391,9 @@
 //!
 //! This crate is compatible with both the current and multi-threaded Tokio runtimes. Performance
 //! is expected to be better generally using the multi-threaded runtime.
-//! 
+//!
 //! ## Feature flags
-//! 
+//!
 //! - `default`: Includes the `tracing` feature flag
 //! - `tracing`: Enables logging of SiftStream through the Tracing crate. See [tracing](#tracing)
 //! - `metrics-unstable`: Enables the ability for the user to access SiftStream metrics from each [SiftStream] instance,

--- a/rust/crates/sift_stream/src/metrics/mod.rs
+++ b/rust/crates/sift_stream/src/metrics/mod.rs
@@ -186,7 +186,7 @@ impl AtomicInstant {
     pub fn new(init: Instant) -> AtomicInstant {
         AtomicInstant {
             init_instant: init,
-            offset_ns: AtomicU64::new(0)
+            offset_ns: AtomicU64::new(0),
         }
     }
 
@@ -356,8 +356,7 @@ impl SiftStreamMetrics {
         let messages_sent_to_backup = self.messages_sent_to_backup.get();
         let cur_retry_count = self.cur_retry_count.get();
 
-        let stats =
-            StreamingStats::calculate(self.creation_time, messages_sent, bytes_sent);
+        let stats = StreamingStats::calculate(self.creation_time, messages_sent, bytes_sent);
 
         SiftStreamMetricsSnapshot {
             elapsed_secs: stats.elapsed_secs,
@@ -376,10 +375,7 @@ impl SiftStreamMetrics {
     }
 
     pub(crate) fn get_checkpoint_stats(&self) -> StreamingStats {
-        let start_time = self
-            .checkpoint
-            .checkpoint_start_time
-            .get();
+        let start_time = self.checkpoint.checkpoint_start_time.get();
         let messages_sent = self.checkpoint.cur_messages_sent.0.load(Ordering::Relaxed);
         let bytes_sent = self.checkpoint.cur_bytes_sent.0.load(Ordering::Relaxed);
 

--- a/rust/crates/sift_stream/src/metrics/mod.rs
+++ b/rust/crates/sift_stream/src/metrics/mod.rs
@@ -14,7 +14,7 @@ use serde::Serialize;
 
 #[cfg(feature = "metrics-unstable")]
 /// **Unstable Feature:** API may change at any time
-/// 
+///
 /// Snapshot of checkpoint-related metrics.
 ///
 /// Tracks checkpoint operations, success/failure rates, and current checkpoint performance.
@@ -35,7 +35,7 @@ pub struct CheckpointMetricsSnapshot {
 
 #[cfg(feature = "metrics-unstable")]
 /// **Unstable Feature:** API may change at any time
-/// 
+///
 /// Snapshot of backup-related metrics.
 ///
 /// Tracks file counts, byte totals, and ingestion status if backups are enabled.
@@ -57,7 +57,7 @@ pub struct BackupMetricsSnapshot {
 
 #[cfg(feature = "metrics-unstable")]
 /// **Unstable Feature:** API may change at any time
-/// 
+///
 /// Snapshot of all sift stream metrics at a point in time.
 ///
 /// Contains performance and operational metrics for a given SiftStream instance

--- a/rust/crates/sift_stream/src/metrics/mod.rs
+++ b/rust/crates/sift_stream/src/metrics/mod.rs
@@ -2,7 +2,7 @@ mod server;
 pub(crate) use server::register_metrics;
 
 #[cfg(feature = "metrics-unstable")]
-pub use server::start_metrics_server;
+pub use server::MetricsServerBuilder;
 
 use std::{
     sync::atomic::{AtomicU64, Ordering},

--- a/rust/crates/sift_stream/src/metrics/mod.rs
+++ b/rust/crates/sift_stream/src/metrics/mod.rs
@@ -1,3 +1,8 @@
+mod server;
+pub use server::start_metrics_server;
+pub(crate) use server::register_metrics;
+
+use serde::Serialize;
 use std::{
     sync::atomic::{AtomicU64, Ordering},
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -34,7 +39,7 @@ impl StreamingStats {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Serialize)]
 pub(crate) struct U64Counter(AtomicU64);
 
 impl U64Counter {
@@ -55,7 +60,7 @@ impl U64Counter {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Serialize)]
 pub(crate) struct U64Signal(AtomicU64);
 
 impl U64Signal {
@@ -72,7 +77,7 @@ impl U64Signal {
     // }
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Serialize)]
 pub(crate) struct BackupMetrics {
     pub cur_checkpoint_file_count: U64Counter,
     pub cur_checkpoint_cur_file_size: U64Counter,
@@ -110,7 +115,7 @@ impl BackupMetrics {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Serialize)]
 pub(crate) struct CheckpointMetrics {
     pub checkpoint_count: U64Counter,
     pub failed_checkpoint_count: U64Counter,
@@ -140,7 +145,7 @@ impl CheckpointMetrics {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Serialize)]
 pub struct SiftStreamMetrics {
     creation_time_epoch_ms: u64,
     pub(crate) loaded_flows: U64Counter,

--- a/rust/crates/sift_stream/src/metrics/mod.rs
+++ b/rust/crates/sift_stream/src/metrics/mod.rs
@@ -1,4 +1,6 @@
 mod server;
+
+#[cfg(feature = "metrics-unstable")]
 pub(crate) use server::register_metrics;
 
 #[cfg(feature = "metrics-unstable")]

--- a/rust/crates/sift_stream/src/metrics/mod.rs
+++ b/rust/crates/sift_stream/src/metrics/mod.rs
@@ -34,7 +34,7 @@ impl StreamingStats {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub(crate) struct U64Counter(AtomicU64);
 
 impl U64Counter {
@@ -55,7 +55,7 @@ impl U64Counter {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub(crate) struct U64Signal(AtomicU64);
 
 impl U64Signal {
@@ -72,7 +72,7 @@ impl U64Signal {
     // }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub(crate) struct BackupMetrics {
     pub cur_checkpoint_file_count: U64Counter,
     pub cur_checkpoint_cur_file_size: U64Counter,
@@ -110,7 +110,7 @@ impl BackupMetrics {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub(crate) struct CheckpointMetrics {
     pub checkpoint_count: U64Counter,
     pub failed_checkpoint_count: U64Counter,
@@ -140,7 +140,7 @@ impl CheckpointMetrics {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SiftStreamMetrics {
     creation_time_epoch_ms: u64,
     pub(crate) loaded_flows: U64Counter,

--- a/rust/crates/sift_stream/src/metrics/mod.rs
+++ b/rust/crates/sift_stream/src/metrics/mod.rs
@@ -13,6 +13,11 @@ use std::{
 use serde::Serialize;
 
 #[cfg(feature = "metrics-unstable")]
+/// **Unstable Feature:** API may change at any time
+/// 
+/// Snapshot of checkpoint-related metrics.
+///
+/// Tracks checkpoint operations, success/failure rates, and current checkpoint performance.
 #[derive(Clone, Copy, Debug, Serialize)]
 #[non_exhaustive]
 pub struct CheckpointMetricsSnapshot {
@@ -29,6 +34,11 @@ pub struct CheckpointMetricsSnapshot {
 }
 
 #[cfg(feature = "metrics-unstable")]
+/// **Unstable Feature:** API may change at any time
+/// 
+/// Snapshot of backup-related metrics.
+///
+/// Tracks file counts, byte totals, and ingestion status if backups are enabled.
 #[derive(Clone, Copy, Debug, Serialize)]
 #[non_exhaustive]
 pub struct BackupMetricsSnapshot {
@@ -46,6 +56,11 @@ pub struct BackupMetricsSnapshot {
 }
 
 #[cfg(feature = "metrics-unstable")]
+/// **Unstable Feature:** API may change at any time
+/// 
+/// Snapshot of all sift stream metrics at a point in time.
+///
+/// Contains performance and operational metrics for a given SiftStream instance
 #[derive(Clone, Copy, Debug, Serialize)]
 #[non_exhaustive]
 pub struct SiftStreamMetricsSnapshot {
@@ -249,6 +264,10 @@ impl CheckpointMetrics {
     }
 }
 
+/// Primary metrics collection struct for sift stream operations.
+///
+/// This struct is managed internally and users should never need to create this,
+/// instead using the [crate::SiftStreamBuilder]
 #[derive(Default, Debug)]
 pub struct SiftStreamMetrics {
     creation_time_epoch_ms: u64,
@@ -264,6 +283,8 @@ pub struct SiftStreamMetrics {
 }
 
 impl SiftStreamMetrics {
+    /// Creates a new SiftStreamMetrics instance with current timestamp. Users should
+    /// never need to call this and should instead use [crate::SiftStreamBuilder]
     pub fn new() -> SiftStreamMetrics {
         SiftStreamMetrics {
             creation_time_epoch_ms: SystemTime::now()
@@ -307,17 +328,7 @@ impl SiftStreamMetrics {
         }
     }
 
-    // pub(crate) fn get_stream_stats(&self) -> StreamingStats {
-    //     // TODO: Look into other ordering to try and avoid atomics writes until all three of these are complete
-    //     let start_time_ms = self.creation_time_epoch_ms;
-    //     let messages_sent = self.messages_sent.0.load(Ordering::Relaxed);
-    //     let bytes_sent = self.bytes_sent.0.load(Ordering::Relaxed);
-
-    //     StreamingStats::calculate(start_time_ms, messages_sent, bytes_sent)
-    // }
-
     pub(crate) fn get_checkpoint_stats(&self) -> StreamingStats {
-        // TODO: Look into other ordering to try and avoid atomics writes until all three of these are complete
         let start_time_ms = self
             .checkpoint
             .checkpoint_start_time_epoch_ms

--- a/rust/crates/sift_stream/src/metrics/mod.rs
+++ b/rust/crates/sift_stream/src/metrics/mod.rs
@@ -40,7 +40,7 @@ impl StreamingStats {
 }
 
 #[derive(Default, Debug, Serialize)]
-pub(crate) struct U64Counter(AtomicU64);
+pub struct U64Counter(pub AtomicU64);
 
 impl U64Counter {
     pub fn increment(&self) -> u64 {
@@ -61,7 +61,7 @@ impl U64Counter {
 }
 
 #[derive(Default, Debug, Serialize)]
-pub(crate) struct U64Signal(AtomicU64);
+pub struct U64Signal(pub AtomicU64);
 
 impl U64Signal {
     pub fn set(&self, val: u64) {
@@ -78,7 +78,7 @@ impl U64Signal {
 }
 
 #[derive(Default, Debug, Serialize)]
-pub(crate) struct BackupMetrics {
+pub struct BackupMetrics {
     pub cur_checkpoint_file_count: U64Counter,
     pub cur_checkpoint_cur_file_size: U64Counter,
     pub cur_checkpoint_bytes: U64Counter,
@@ -116,7 +116,7 @@ impl BackupMetrics {
 }
 
 #[derive(Default, Debug, Serialize)]
-pub(crate) struct CheckpointMetrics {
+pub struct CheckpointMetrics {
     pub checkpoint_count: U64Counter,
     pub failed_checkpoint_count: U64Counter,
     pub checkpoint_timer_reached_cnt: U64Counter,
@@ -148,15 +148,15 @@ impl CheckpointMetrics {
 #[derive(Default, Debug, Serialize)]
 pub struct SiftStreamMetrics {
     creation_time_epoch_ms: u64,
-    pub(crate) loaded_flows: U64Counter,
-    pub(crate) unique_flows_received: U64Counter,
-    pub(crate) messages_received: U64Counter,
-    pub(crate) messages_sent: U64Counter,
-    pub(crate) bytes_sent: U64Counter,
-    pub(crate) checkpoint: CheckpointMetrics,
-    pub(crate) messages_sent_to_backup: U64Counter,
-    pub(crate) cur_retry_count: U64Signal,
-    pub(crate) backups: BackupMetrics,
+    pub loaded_flows: U64Counter,
+    pub unique_flows_received: U64Counter,
+    pub messages_received: U64Counter,
+    pub messages_sent: U64Counter,
+    pub bytes_sent: U64Counter,
+    pub checkpoint: CheckpointMetrics,
+    pub messages_sent_to_backup: U64Counter,
+    pub cur_retry_count: U64Signal,
+    pub backups: BackupMetrics,
 }
 
 

--- a/rust/crates/sift_stream/src/metrics/mod.rs
+++ b/rust/crates/sift_stream/src/metrics/mod.rs
@@ -1,0 +1,190 @@
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+pub struct StreamingStats {
+    pub elapsed_secs: f64,
+    pub messages_sent: u64,
+    pub message_rate: f64,
+    pub bytes_sent: u64,
+    pub byte_rate: f64,
+}
+
+impl StreamingStats {
+    pub(crate) fn calculate(start_time_ms: u64, messages_sent: u64, bytes_sent: u64) -> StreamingStats {
+        let cur_time_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_else(|_| {
+                #[cfg(feature = "tracing")]
+                tracing::warn!("System time was before unix epoch");
+                Duration::default()
+            })
+            .as_millis() as u64;
+
+        let elapsed_secs = (cur_time_ms.saturating_sub(start_time_ms) as f64) / 1000.0;
+
+        StreamingStats {
+            elapsed_secs,
+            messages_sent,
+            message_rate: (messages_sent as f64) / elapsed_secs,
+            bytes_sent,
+            byte_rate: (bytes_sent as f64) / elapsed_secs,
+        }
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct U64Counter(AtomicU64);
+
+impl U64Counter {
+    pub fn increment(&self) -> u64 {
+        self.0.fetch_add(1, Ordering::Relaxed)
+    }
+
+    pub fn add(&self, val: u64) -> u64 {
+        self.0.fetch_add(val, Ordering::Relaxed)
+    }
+
+    pub fn reset(&self) {
+        self.0.store(0, Ordering::Relaxed);
+    }
+
+    pub fn get(&self) -> u64 {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct U64Signal(AtomicU64);
+
+impl U64Signal {
+    pub fn set(&self, val: u64) {
+        self.0.store(val, Ordering::Relaxed);
+    }
+
+    pub fn add(&self, val: u64) -> u64 {
+        self.0.fetch_add(val, Ordering::Relaxed)
+    }
+
+    // pub fn get(&self) -> u64 {
+    //     self.0.load(Ordering::Relaxed)
+    // }
+}
+
+#[derive(Default)]
+pub(crate) struct BackupMetrics {
+    pub cur_checkpoint_file_count: U64Counter,
+    pub cur_checkpoint_cur_file_size: U64Counter,
+    pub cur_checkpoint_bytes: U64Counter,
+    pub cur_checkpoint_messages: U64Counter,
+    pub total_file_count: U64Counter,
+    pub total_bytes: U64Counter,
+    pub total_messages: U64Counter,
+
+    pub files_pending_ingestion: U64Signal,
+    pub files_ingested: U64Counter,
+    pub cur_ingest_retries: U64Signal,
+}
+
+impl BackupMetrics {
+    pub fn log_message(&self, msg_size: u64) {
+        self.cur_checkpoint_messages.increment();
+        self.total_messages.increment();
+        self.cur_checkpoint_cur_file_size.add(msg_size);
+        self.cur_checkpoint_bytes.add(msg_size);
+        self.total_bytes.add(msg_size);
+    }
+
+    pub fn log_new_file(&self) {
+        self.cur_checkpoint_file_count.increment();
+        self.total_file_count.increment();
+        self.cur_checkpoint_cur_file_size.reset();
+    }
+
+    pub fn log_restart(&self) {
+        self.cur_checkpoint_messages.reset();
+        self.cur_checkpoint_cur_file_size.reset();
+        self.cur_checkpoint_bytes.reset();
+        self.cur_checkpoint_file_count.reset();
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct CheckpointMetrics {
+    pub checkpoint_count: U64Counter,
+    pub failed_checkpoint_count: U64Counter,
+    pub checkpoint_timer_reached_cnt: U64Counter,
+    pub checkpoint_manually_reached_cnt: U64Counter,
+    
+    checkpoint_start_time_epoch_ms: AtomicU64,
+    pub cur_messages_sent: U64Counter,
+    pub cur_bytes_sent: U64Counter,
+}
+
+impl CheckpointMetrics {
+    pub fn next_checkpoint(&self) {
+        self.checkpoint_count.increment();
+        self.cur_bytes_sent.reset();
+        self.cur_messages_sent.reset();
+        self.checkpoint_start_time_epoch_ms.store(SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_else(|_| {
+                #[cfg(feature = "tracing")]
+                tracing::warn!("System time was before unix epoch");
+                Duration::default()
+            })
+            .as_millis() as u64,
+            Ordering::Relaxed
+        );
+    }
+}
+
+#[derive(Default)]
+pub struct SiftStreamMetrics {
+    creation_time_epoch_ms: u64,
+    pub(crate) loaded_flows: U64Counter,
+    pub(crate) unique_flows_received: U64Counter,
+    pub(crate) messages_received: U64Counter,
+    pub(crate) messages_sent: U64Counter,
+    pub(crate) bytes_sent: U64Counter,
+    pub(crate) checkpoint: CheckpointMetrics,
+    pub(crate) messages_sent_to_backup: U64Counter,
+    pub(crate) cur_retry_count: U64Signal,
+    pub(crate) backups: BackupMetrics,
+}
+
+
+impl SiftStreamMetrics {
+    pub fn new() -> SiftStreamMetrics {
+        SiftStreamMetrics {
+            creation_time_epoch_ms: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_else(|_| {
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!("System time was before unix epoch");
+                    Duration::default()
+                })
+                .as_millis() as u64,
+            ..Default::default()
+        }
+    }
+
+    pub fn get_stream_stats(&self) -> StreamingStats {
+        // TODO: Look into other ordering to try and avoid atomics writes until all three of these are complete
+        let start_time_ms = self.creation_time_epoch_ms;
+        let messages_sent = self.messages_sent.0.load(Ordering::Relaxed);
+        let bytes_sent = self.bytes_sent.0.load(Ordering::Relaxed);
+
+        StreamingStats::calculate(start_time_ms, messages_sent, bytes_sent)
+    }
+
+    pub fn get_checkpoint_stats(&self) -> StreamingStats {
+        // TODO: Look into other ordering to try and avoid atomics writes until all three of these are complete
+        let start_time_ms = self.checkpoint.checkpoint_start_time_epoch_ms.load(Ordering::Relaxed);
+        let messages_sent = self.checkpoint.cur_messages_sent.0.load(Ordering::Relaxed);
+        let bytes_sent = self.checkpoint.cur_bytes_sent.0.load(Ordering::Relaxed);
+
+        StreamingStats::calculate(start_time_ms, messages_sent, bytes_sent)
+    }
+}

--- a/rust/crates/sift_stream/src/metrics/mod.rs
+++ b/rust/crates/sift_stream/src/metrics/mod.rs
@@ -1,14 +1,69 @@
 mod server;
-pub use server::start_metrics_server;
 pub(crate) use server::register_metrics;
 
-use serde::Serialize;
+#[cfg(feature = "metrics-unstable")]
+pub use server::start_metrics_server;
+
 use std::{
     sync::atomic::{AtomicU64, Ordering},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-pub struct StreamingStats {
+#[cfg(feature = "metrics-unstable")]
+use serde::Serialize;
+
+#[cfg(feature = "metrics-unstable")]
+#[derive(Clone, Copy, Debug, Serialize)]
+#[non_exhaustive]
+pub struct CheckpointMetricsSnapshot {
+    pub checkpoint_count: u64,
+    pub failed_checkpoint_count: u64,
+    pub checkpoint_timer_reached_cnt: u64,
+    pub checkpoint_manually_reached_cnt: u64,
+
+    pub cur_elapsed_secs: f64,
+    pub cur_messages_sent: u64,
+    pub cur_message_rate: f64,
+    pub cur_bytes_sent: u64,
+    pub cur_byte_rate: f64,
+}
+
+#[cfg(feature = "metrics-unstable")]
+#[derive(Clone, Copy, Debug, Serialize)]
+#[non_exhaustive]
+pub struct BackupMetricsSnapshot {
+    pub cur_checkpoint_file_count: u64,
+    pub cur_checkpoint_cur_file_size: u64,
+    pub cur_checkpoint_bytes: u64,
+    pub cur_checkpoint_messages: u64,
+    pub total_file_count: u64,
+    pub total_bytes: u64,
+    pub total_messages: u64,
+
+    pub files_pending_ingestion: u64,
+    pub files_ingested: u64,
+    pub cur_ingest_retries: u64,
+}
+
+#[cfg(feature = "metrics-unstable")]
+#[derive(Clone, Copy, Debug, Serialize)]
+#[non_exhaustive]
+pub struct SiftStreamMetricsSnapshot {
+    pub elapsed_secs: f64,
+    pub loaded_flows: u64,
+    pub unique_flows_received: u64,
+    pub messages_received: u64,
+    pub messages_sent: u64,
+    pub message_rate: f64,
+    pub bytes_sent: u64,
+    pub byte_rate: f64,
+    pub messages_sent_to_backup: u64,
+    pub cur_retry_count: u64,
+    pub checkpoint: CheckpointMetricsSnapshot,
+    pub backups: BackupMetricsSnapshot,
+}
+
+pub(crate) struct StreamingStats {
     pub elapsed_secs: f64,
     pub messages_sent: u64,
     pub message_rate: f64,
@@ -17,7 +72,11 @@ pub struct StreamingStats {
 }
 
 impl StreamingStats {
-    pub(crate) fn calculate(start_time_ms: u64, messages_sent: u64, bytes_sent: u64) -> StreamingStats {
+    pub(crate) fn calculate(
+        start_time_ms: u64,
+        messages_sent: u64,
+        bytes_sent: u64,
+    ) -> StreamingStats {
         let cur_time_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_else(|_| {
@@ -39,8 +98,8 @@ impl StreamingStats {
     }
 }
 
-#[derive(Default, Debug, Serialize)]
-pub struct U64Counter(pub AtomicU64);
+#[derive(Default, Debug)]
+pub(crate) struct U64Counter(pub AtomicU64);
 
 impl U64Counter {
     pub fn increment(&self) -> u64 {
@@ -60,8 +119,8 @@ impl U64Counter {
     }
 }
 
-#[derive(Default, Debug, Serialize)]
-pub struct U64Signal(pub AtomicU64);
+#[derive(Default, Debug)]
+pub(crate) struct U64Signal(pub AtomicU64);
 
 impl U64Signal {
     pub fn set(&self, val: u64) {
@@ -72,13 +131,13 @@ impl U64Signal {
         self.0.fetch_add(val, Ordering::Relaxed)
     }
 
-    // pub fn get(&self) -> u64 {
-    //     self.0.load(Ordering::Relaxed)
-    // }
+    pub fn get(&self) -> u64 {
+        self.0.load(Ordering::Relaxed)
+    }
 }
 
-#[derive(Default, Debug, Serialize)]
-pub struct BackupMetrics {
+#[derive(Default, Debug)]
+pub(crate) struct BackupMetrics {
     pub cur_checkpoint_file_count: U64Counter,
     pub cur_checkpoint_cur_file_size: U64Counter,
     pub cur_checkpoint_bytes: U64Counter,
@@ -93,6 +152,22 @@ pub struct BackupMetrics {
 }
 
 impl BackupMetrics {
+    #[cfg(feature = "metrics-unstable")]
+    pub fn snapshot(&self) -> BackupMetricsSnapshot {
+        BackupMetricsSnapshot {
+            cur_checkpoint_file_count: self.cur_checkpoint_file_count.get(),
+            cur_checkpoint_cur_file_size: self.cur_checkpoint_cur_file_size.get(),
+            cur_checkpoint_bytes: self.cur_checkpoint_bytes.get(),
+            cur_checkpoint_messages: self.cur_checkpoint_messages.get(),
+            total_file_count: self.total_file_count.get(),
+            total_bytes: self.total_bytes.get(),
+            total_messages: self.total_messages.get(),
+            files_pending_ingestion: self.files_pending_ingestion.get(),
+            files_ingested: self.files_ingested.get(),
+            cur_ingest_retries: self.cur_ingest_retries.get(),
+        }
+    }
+
     pub fn log_message(&self, msg_size: u64) {
         self.cur_checkpoint_messages.increment();
         self.total_messages.increment();
@@ -115,50 +190,78 @@ impl BackupMetrics {
     }
 }
 
-#[derive(Default, Debug, Serialize)]
-pub struct CheckpointMetrics {
+#[derive(Default, Debug)]
+pub(crate) struct CheckpointMetrics {
     pub checkpoint_count: U64Counter,
     pub failed_checkpoint_count: U64Counter,
     pub checkpoint_timer_reached_cnt: U64Counter,
     pub checkpoint_manually_reached_cnt: U64Counter,
-    
+
     checkpoint_start_time_epoch_ms: AtomicU64,
     pub cur_messages_sent: U64Counter,
     pub cur_bytes_sent: U64Counter,
 }
 
 impl CheckpointMetrics {
+    #[cfg(feature = "metrics-unstable")]
+    pub fn snapshot(&self) -> CheckpointMetricsSnapshot {
+        let checkpoint_count = self.checkpoint_count.get();
+        let failed_checkpoint_count = self.failed_checkpoint_count.get();
+        let checkpoint_timer_reached_cnt = self.checkpoint_timer_reached_cnt.get();
+        let checkpoint_manually_reached_cnt = self.checkpoint_manually_reached_cnt.get();
+        let cur_messages_sent = self.cur_messages_sent.get();
+        let cur_bytes_sent = self.cur_bytes_sent.get();
+
+        let stats = StreamingStats::calculate(
+            self.checkpoint_start_time_epoch_ms.load(Ordering::Relaxed),
+            cur_messages_sent,
+            cur_bytes_sent,
+        );
+
+        CheckpointMetricsSnapshot {
+            checkpoint_count,
+            failed_checkpoint_count,
+            checkpoint_timer_reached_cnt,
+            checkpoint_manually_reached_cnt,
+            cur_elapsed_secs: stats.elapsed_secs,
+            cur_messages_sent,
+            cur_message_rate: stats.message_rate,
+            cur_bytes_sent,
+            cur_byte_rate: stats.byte_rate,
+        }
+    }
+
     pub fn next_checkpoint(&self) {
         self.checkpoint_count.increment();
         self.cur_bytes_sent.reset();
         self.cur_messages_sent.reset();
-        self.checkpoint_start_time_epoch_ms.store(SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_else(|_| {
-                #[cfg(feature = "tracing")]
-                tracing::warn!("System time was before unix epoch");
-                Duration::default()
-            })
-            .as_millis() as u64,
-            Ordering::Relaxed
+        self.checkpoint_start_time_epoch_ms.store(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_else(|_| {
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!("System time was before unix epoch");
+                    Duration::default()
+                })
+                .as_millis() as u64,
+            Ordering::Relaxed,
         );
     }
 }
 
-#[derive(Default, Debug, Serialize)]
+#[derive(Default, Debug)]
 pub struct SiftStreamMetrics {
     creation_time_epoch_ms: u64,
-    pub loaded_flows: U64Counter,
-    pub unique_flows_received: U64Counter,
-    pub messages_received: U64Counter,
-    pub messages_sent: U64Counter,
-    pub bytes_sent: U64Counter,
-    pub checkpoint: CheckpointMetrics,
-    pub messages_sent_to_backup: U64Counter,
-    pub cur_retry_count: U64Signal,
-    pub backups: BackupMetrics,
+    pub(crate) loaded_flows: U64Counter,
+    pub(crate) unique_flows_received: U64Counter,
+    pub(crate) messages_received: U64Counter,
+    pub(crate) messages_sent: U64Counter,
+    pub(crate) bytes_sent: U64Counter,
+    pub(crate) messages_sent_to_backup: U64Counter,
+    pub(crate) cur_retry_count: U64Signal,
+    pub(crate) checkpoint: CheckpointMetrics,
+    pub(crate) backups: BackupMetrics,
 }
-
 
 impl SiftStreamMetrics {
     pub fn new() -> SiftStreamMetrics {
@@ -175,18 +278,50 @@ impl SiftStreamMetrics {
         }
     }
 
-    pub fn get_stream_stats(&self) -> StreamingStats {
-        // TODO: Look into other ordering to try and avoid atomics writes until all three of these are complete
-        let start_time_ms = self.creation_time_epoch_ms;
-        let messages_sent = self.messages_sent.0.load(Ordering::Relaxed);
-        let bytes_sent = self.bytes_sent.0.load(Ordering::Relaxed);
+    #[cfg(feature = "metrics-unstable")]
+    pub(crate) fn snapshot(&self) -> SiftStreamMetricsSnapshot {
+        let loaded_flows = self.loaded_flows.get();
+        let unique_flows_received = self.unique_flows_received.get();
+        let messages_received = self.messages_received.get();
+        let messages_sent = self.messages_sent.get();
+        let bytes_sent = self.bytes_sent.get();
+        let messages_sent_to_backup = self.messages_sent_to_backup.get();
+        let cur_retry_count = self.cur_retry_count.get();
 
-        StreamingStats::calculate(start_time_ms, messages_sent, bytes_sent)
+        let stats =
+            StreamingStats::calculate(self.creation_time_epoch_ms, messages_sent, bytes_sent);
+
+        SiftStreamMetricsSnapshot {
+            elapsed_secs: stats.elapsed_secs,
+            loaded_flows,
+            unique_flows_received,
+            messages_received,
+            messages_sent,
+            message_rate: stats.message_rate,
+            bytes_sent,
+            byte_rate: stats.byte_rate,
+            messages_sent_to_backup,
+            cur_retry_count,
+            checkpoint: self.checkpoint.snapshot(),
+            backups: self.backups.snapshot(),
+        }
     }
 
-    pub fn get_checkpoint_stats(&self) -> StreamingStats {
+    // pub(crate) fn get_stream_stats(&self) -> StreamingStats {
+    //     // TODO: Look into other ordering to try and avoid atomics writes until all three of these are complete
+    //     let start_time_ms = self.creation_time_epoch_ms;
+    //     let messages_sent = self.messages_sent.0.load(Ordering::Relaxed);
+    //     let bytes_sent = self.bytes_sent.0.load(Ordering::Relaxed);
+
+    //     StreamingStats::calculate(start_time_ms, messages_sent, bytes_sent)
+    // }
+
+    pub(crate) fn get_checkpoint_stats(&self) -> StreamingStats {
         // TODO: Look into other ordering to try and avoid atomics writes until all three of these are complete
-        let start_time_ms = self.checkpoint.checkpoint_start_time_epoch_ms.load(Ordering::Relaxed);
+        let start_time_ms = self
+            .checkpoint
+            .checkpoint_start_time_epoch_ms
+            .load(Ordering::Relaxed);
         let messages_sent = self.checkpoint.cur_messages_sent.0.load(Ordering::Relaxed);
         let bytes_sent = self.checkpoint.cur_bytes_sent.0.load(Ordering::Relaxed);
 

--- a/rust/crates/sift_stream/src/metrics/mod.rs
+++ b/rust/crates/sift_stream/src/metrics/mod.rs
@@ -21,15 +21,25 @@ use serde::Serialize;
 #[derive(Clone, Copy, Debug, Serialize)]
 #[non_exhaustive]
 pub struct CheckpointMetricsSnapshot {
+    /// Total number of checkpoints completed
     pub checkpoint_count: u64,
+    /// Number of checkpoints that failed, typically from connection issues
     pub failed_checkpoint_count: u64,
+    /// Number of checkpoints triggered by timer
     pub checkpoint_timer_reached_cnt: u64,
+    /// Number of checkpoints triggered by other Sift Stream events, such as reaching the max
+    /// backup size
     pub checkpoint_manually_reached_cnt: u64,
 
+    /// Elapsed time since current checkpoint started (seconds)
     pub cur_elapsed_secs: f64,
+    /// Messages sent in current checkpoint
     pub cur_messages_sent: u64,
+    /// Message rate for current checkpoint (messages/sec)
     pub cur_message_rate: f64,
+    /// Bytes sent in current checkpoint
     pub cur_bytes_sent: u64,
+    /// Byte rate for current checkpoint (bytes/sec)
     pub cur_byte_rate: f64,
 }
 
@@ -42,16 +52,26 @@ pub struct CheckpointMetricsSnapshot {
 #[derive(Clone, Copy, Debug, Serialize)]
 #[non_exhaustive]
 pub struct BackupMetricsSnapshot {
+    /// Number of files written in current checkpoint
     pub cur_checkpoint_file_count: u64,
+    /// Current file size being written (bytes)
     pub cur_checkpoint_cur_file_size: u64,
+    /// Total bytes written in current checkpoint
     pub cur_checkpoint_bytes: u64,
+    /// Total messages written in current checkpoint
     pub cur_checkpoint_messages: u64,
+    /// Total number of backup files created
     pub total_file_count: u64,
+    /// Total bytes written to backup files
     pub total_bytes: u64,
+    /// Total messages written to backup files
     pub total_messages: u64,
 
+    /// Number of files waiting to be ingested
     pub files_pending_ingestion: u64,
+    /// Number of files successfully ingested
     pub files_ingested: u64,
+    /// Current number of ingestion retries
     pub cur_ingest_retries: u64,
 }
 
@@ -64,17 +84,29 @@ pub struct BackupMetricsSnapshot {
 #[derive(Clone, Copy, Debug, Serialize)]
 #[non_exhaustive]
 pub struct SiftStreamMetricsSnapshot {
+    /// Total elapsed time since SiftStream started (seconds)
     pub elapsed_secs: f64,
+    /// Number of flows loaded from configuration
     pub loaded_flows: u64,
+    /// Number of unique flows that have received data
     pub unique_flows_received: u64,
+    /// Total messages received from data sources
     pub messages_received: u64,
+    /// Total messages sent to destinations
     pub messages_sent: u64,
+    /// Overall message throughput rate (messages/sec)
     pub message_rate: f64,
+    /// Total bytes sent to destinations
     pub bytes_sent: u64,
+    /// Overall byte throughput rate (bytes/sec)
     pub byte_rate: f64,
+    /// Total messages written to backup storage
     pub messages_sent_to_backup: u64,
+    /// Current retry attempt count
     pub cur_retry_count: u64,
+    /// Checkpoint-specific metrics
     pub checkpoint: CheckpointMetricsSnapshot,
+    /// Backup-specific metrics
     pub backups: BackupMetricsSnapshot,
 }
 

--- a/rust/crates/sift_stream/src/metrics/server.rs
+++ b/rust/crates/sift_stream/src/metrics/server.rs
@@ -1,9 +1,13 @@
 use super::SiftStreamMetrics;
+use sift_error::prelude::*;
 use std::{
     collections::HashMap,
     sync::{Arc, LazyLock},
 };
 use tokio::sync::RwLock;
+
+#[cfg(feature = "metrics-unstable")]
+use std::net::SocketAddr;
 
 static METRICS: LazyLock<RwLock<HashMap<String, Arc<SiftStreamMetrics>>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
@@ -14,64 +18,115 @@ pub(crate) async fn register_metrics(uuid: String, metrics: Arc<SiftStreamMetric
 }
 
 #[cfg(feature = "metrics-unstable")]
-/// Starts a light weight HTTP metrics server on the specified port.
+/// Builder for a light weight HTTP metrics server.
 ///
-/// The server exposes metrics as JSON at the `/` and `/metrics` endpoints.
+/// Defaults to 127.0.0.1:8080
+///
+/// Once started, the server exposes metrics as JSON at the `/` and `/metrics` endpoints.
 /// On a GET request, a snapshot metrics for all SiftStream instances are returned
 /// in a JSON format, organized by sift_stream_id
 ///
 /// Metric snapshots are taken at the moment the GET request is receieved.
-///
-/// # Arguments
-/// * `port` - The port number to bind the HTTP server to
-pub async fn start_metrics_server(port: u16) {
-    use hyper::{Method, Request, Response};
-    use hyper::{server::conn::http1, service::service_fn};
-    use hyper_util::rt::TokioIo;
-    use std::{convert::Infallible, net::SocketAddr};
-    use tokio::net::TcpListener;
+pub struct MetricsServerBuilder {
+    socket_addr: SocketAddr,
+}
 
-    let addr = SocketAddr::from(([0, 0, 0, 0], port));
-
-    async fn metrics_handle(
-        req: Request<hyper::body::Incoming>,
-    ) -> Result<Response<String>, Infallible> {
-        match (req.method(), req.uri().path()) {
-            (&Method::GET, "/") | (&Method::GET, "/metrics") => {
-                let metrics_json = {
-                    let metrics_guard = METRICS.read().await;
-                    let serializable_map: HashMap<_, _> = metrics_guard
-                        .iter()
-                        .map(|(k, v)| (k, v.snapshot()))
-                        .collect();
-                    serde_json::to_string(&serializable_map).unwrap()
-                };
-
-                Ok(Response::builder()
-                    .status(200)
-                    .header("Content-Type", "application/json")
-                    .body(metrics_json)
-                    .unwrap())
-            }
-            _ => Ok(Response::builder().status(404).body(String::new()).unwrap()),
+impl MetricsServerBuilder {
+    /// Create a new MetricsServerBuilder, with a default address of 127.0.0.1:8080
+    pub fn new() -> MetricsServerBuilder {
+        MetricsServerBuilder {
+            socket_addr: SocketAddr::from(([127, 0, 0, 1], 8080)),
         }
     }
 
-    let listener = TcpListener::bind(addr).await.unwrap();
+    /// Set the socket address of the server
+    pub fn socket(mut self, socket_addr: SocketAddr) -> MetricsServerBuilder {
+        self.socket_addr = socket_addr;
+        self
+    }
 
-    tokio::spawn(async move {
-        loop {
-            let (stream, _) = listener.accept().await.unwrap();
-            let io = TokioIo::new(stream);
+    /// Start up the metrics server
+    pub async fn start_metrics_server(self) -> Result<()> {
+        use hyper::{Method, Request, Response};
+        use hyper::{server::conn::http1, service::service_fn};
+        use hyper_util::rt::TokioIo;
+        use std::convert::Infallible;
+        use tokio::net::TcpListener;
 
-            tokio::task::spawn(async move {
-                if let Err(err) = http1::Builder::new()
-                    .serve_connection(io, service_fn(metrics_handle))
-                    .await
-                {
-                    eprintln!("Error serving connection: {:?}", err);
+        async fn metrics_handle(
+            req: Request<hyper::body::Incoming>,
+        ) -> std::result::Result<Response<String>, Infallible> {
+            match (req.method(), req.uri().path()) {
+                (&Method::GET, "/") | (&Method::GET, "/metrics") => {
+                    let metrics_json = {
+                        let metrics_guard = METRICS.read().await;
+                        let serializable_map: HashMap<_, _> = metrics_guard
+                            .iter()
+                            .map(|(k, v)| (k, v.snapshot()))
+                            .collect();
+                        match serde_json::to_string(&serializable_map) {
+                            Ok(json) => json,
+                            Err(e) => {
+                                #[cfg(feature = "tracing")]
+                                tracing::error!("Failed to serialize metrics: {:?}", e);
+                                "{}".to_string()
+                            }
+                        }
+                    };
+
+                    Ok(Response::builder()
+                        .status(200)
+                        .header("Content-Type", "application/json")
+                        .body(metrics_json)
+                        .unwrap_or_else(|_| {
+                            #[cfg(feature = "tracing")]
+                            tracing::error!("Failed to build response");
+                            Response::new(String::new())
+                        }))
                 }
-            });
+                _ => Ok(Response::builder()
+                    .status(404)
+                    .body(String::new())
+                    .expect("Unable to build 404 response")),
+            }
         }
-    });
+
+        let listener = TcpListener::bind(self.socket_addr)
+            .await
+            .map_err(|e| Error::new(ErrorKind::SiftStreamMetricsServerError, e))
+            .context("unable to bind socket address")?;
+
+        tokio::spawn(async move {
+            loop {
+                let accept_result = listener.accept().await;
+                let stream = match accept_result {
+                    Ok((stream, _)) => stream,
+                    Err(e) => {
+                        #[cfg(feature = "tracing")]
+                        tracing::error!("Failed to accept connection: {:?}", e);
+                        continue;
+                    }
+                };
+                let io = TokioIo::new(stream);
+
+                tokio::task::spawn(async move {
+                    if let Err(err) = http1::Builder::new()
+                        .serve_connection(io, service_fn(metrics_handle))
+                        .await
+                    {
+                        #[cfg(feature = "tracing")]
+                        tracing::error!("Error serving connection: {:?}", err);
+                    }
+                });
+            }
+        });
+
+        Ok(())
+    }
+}
+
+impl Default for MetricsServerBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
 }

--- a/rust/crates/sift_stream/src/metrics/server.rs
+++ b/rust/crates/sift_stream/src/metrics/server.rs
@@ -1,0 +1,68 @@
+use super::SiftStreamMetrics;
+use std::{
+    collections::HashMap,
+    sync::{Arc, LazyLock}
+};
+use tokio::sync::RwLock;
+
+static METRICS: LazyLock<RwLock<HashMap<String, Arc<SiftStreamMetrics>>>> = LazyLock::new(|| RwLock::new(HashMap::new()));
+
+pub(crate) async fn register_metrics(uuid: String, metrics: Arc<SiftStreamMetrics>) {
+    let mut global_metrics_guard = METRICS.write().await;
+    global_metrics_guard.insert(uuid, metrics);
+}
+
+pub async fn start_metrics_server(port: u16) {
+    use hyper::{server::conn::http1, service::service_fn};
+    use hyper::{Request, Response, Method};
+    use hyper_util::rt::TokioIo;
+    use std::{convert::Infallible, net::SocketAddr};
+    use tokio::net::TcpListener;
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+
+    async fn metrics_handle(req: Request<hyper::body::Incoming>) -> Result<Response<String>, Infallible> {
+        match (req.method(), req.uri().path()) {
+            (&Method::GET, "/") | (&Method::GET, "/metrics") => {
+                let metrics_json = {
+                    let metrics_guard = METRICS.read().await;
+                    let serializable_map: HashMap<_, _> = metrics_guard
+                        .iter()
+                        .map(|(k, v)| (k, &**v))
+                        .collect();
+                    serde_json::to_string(&serializable_map).unwrap()
+                };
+
+                Ok(Response::builder()
+                    .status(200)
+                    .header("Content-Type", "application/json")
+                    .body(metrics_json)
+                    .unwrap()
+                )
+            }
+            _ => Ok(Response::builder()
+                .status(404)
+                .body(String::new())
+                .unwrap()
+            )
+        }
+    }
+
+    let listener = TcpListener::bind(addr).await.unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = listener.accept().await.unwrap();
+            let io = TokioIo::new(stream);
+
+            tokio::task::spawn(async move {
+                if let Err(err) = http1::Builder::new()
+                    .serve_connection(io, service_fn(metrics_handle))
+                    .await
+                {
+                    eprintln!("Error serving connection: {:?}", err);
+                }
+            });
+        }
+    });
+}

--- a/rust/crates/sift_stream/src/metrics/server.rs
+++ b/rust/crates/sift_stream/src/metrics/server.rs
@@ -1,34 +1,38 @@
 use super::SiftStreamMetrics;
 use std::{
     collections::HashMap,
-    sync::{Arc, LazyLock}
+    sync::{Arc, LazyLock},
 };
 use tokio::sync::RwLock;
 
-static METRICS: LazyLock<RwLock<HashMap<String, Arc<SiftStreamMetrics>>>> = LazyLock::new(|| RwLock::new(HashMap::new()));
+static METRICS: LazyLock<RwLock<HashMap<String, Arc<SiftStreamMetrics>>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
 
 pub(crate) async fn register_metrics(uuid: String, metrics: Arc<SiftStreamMetrics>) {
     let mut global_metrics_guard = METRICS.write().await;
     global_metrics_guard.insert(uuid, metrics);
 }
 
+#[cfg(feature = "metrics-unstable")]
 pub async fn start_metrics_server(port: u16) {
+    use hyper::{Method, Request, Response};
     use hyper::{server::conn::http1, service::service_fn};
-    use hyper::{Request, Response, Method};
     use hyper_util::rt::TokioIo;
     use std::{convert::Infallible, net::SocketAddr};
     use tokio::net::TcpListener;
 
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
 
-    async fn metrics_handle(req: Request<hyper::body::Incoming>) -> Result<Response<String>, Infallible> {
+    async fn metrics_handle(
+        req: Request<hyper::body::Incoming>,
+    ) -> Result<Response<String>, Infallible> {
         match (req.method(), req.uri().path()) {
             (&Method::GET, "/") | (&Method::GET, "/metrics") => {
                 let metrics_json = {
                     let metrics_guard = METRICS.read().await;
                     let serializable_map: HashMap<_, _> = metrics_guard
                         .iter()
-                        .map(|(k, v)| (k, &**v))
+                        .map(|(k, v)| (k, v.snapshot()))
                         .collect();
                     serde_json::to_string(&serializable_map).unwrap()
                 };
@@ -37,14 +41,9 @@ pub async fn start_metrics_server(port: u16) {
                     .status(200)
                     .header("Content-Type", "application/json")
                     .body(metrics_json)
-                    .unwrap()
-                )
+                    .unwrap())
             }
-            _ => Ok(Response::builder()
-                .status(404)
-                .body(String::new())
-                .unwrap()
-            )
+            _ => Ok(Response::builder().status(404).body(String::new()).unwrap()),
         }
     }
 

--- a/rust/crates/sift_stream/src/metrics/server.rs
+++ b/rust/crates/sift_stream/src/metrics/server.rs
@@ -9,9 +9,11 @@ use tokio::sync::RwLock;
 #[cfg(feature = "metrics-unstable")]
 use std::net::SocketAddr;
 
+#[cfg(feature = "metrics-unstable")]
 static METRICS: LazyLock<RwLock<HashMap<String, Arc<SiftStreamMetrics>>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
+#[cfg(feature = "metrics-unstable")]
 pub(crate) async fn register_metrics(uuid: String, metrics: Arc<SiftStreamMetrics>) {
     let mut global_metrics_guard = METRICS.write().await;
     global_metrics_guard.insert(uuid, metrics);
@@ -31,6 +33,7 @@ pub struct MetricsServerBuilder {
     socket_addr: SocketAddr,
 }
 
+#[cfg(feature = "metrics-unstable")]
 impl MetricsServerBuilder {
     /// Create a new MetricsServerBuilder, with a default address of 127.0.0.1:8080
     pub fn new() -> MetricsServerBuilder {
@@ -125,6 +128,7 @@ impl MetricsServerBuilder {
     }
 }
 
+#[cfg(feature = "metrics-unstable")]
 impl Default for MetricsServerBuilder {
     fn default() -> Self {
         Self::new()

--- a/rust/crates/sift_stream/src/metrics/server.rs
+++ b/rust/crates/sift_stream/src/metrics/server.rs
@@ -19,7 +19,7 @@ pub(crate) async fn register_metrics(uuid: String, metrics: Arc<SiftStreamMetric
 /// The server exposes metrics as JSON at the `/` and `/metrics` endpoints.
 /// On a GET request, a snapshot metrics for all SiftStream instances are returned
 /// in a JSON format, organized by sift_stream_id
-/// 
+///
 /// Metric snapshots are taken at the moment the GET request is receieved.
 ///
 /// # Arguments

--- a/rust/crates/sift_stream/src/metrics/server.rs
+++ b/rust/crates/sift_stream/src/metrics/server.rs
@@ -14,6 +14,16 @@ pub(crate) async fn register_metrics(uuid: String, metrics: Arc<SiftStreamMetric
 }
 
 #[cfg(feature = "metrics-unstable")]
+/// Starts a light weight HTTP metrics server on the specified port.
+///
+/// The server exposes metrics as JSON at the `/` and `/metrics` endpoints.
+/// On a GET request, a snapshot metrics for all SiftStream instances are returned
+/// in a JSON format, organized by sift_stream_id
+/// 
+/// Metric snapshots are taken at the moment the GET request is receieved.
+///
+/// # Arguments
+/// * `port` - The port number to bind the HTTP server to
 pub async fn start_metrics_server(port: u16) {
     use hyper::{Method, Request, Response};
     use hyper::{server::conn::http1, service::service_fn};

--- a/rust/crates/sift_stream/src/stream/builder.rs
+++ b/rust/crates/sift_stream/src/stream/builder.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::{
     backup::{
         disk::{AsyncBackupsManager, DiskBackupPolicy},
-        sanitize_name
+        sanitize_name,
     },
     metrics::SiftStreamMetrics,
 };

--- a/rust/crates/sift_stream/src/stream/builder.rs
+++ b/rust/crates/sift_stream/src/stream/builder.rs
@@ -4,9 +4,12 @@ use super::{
     mode::ingestion_config::IngestionConfigMode,
     run::{load_run_by_form, load_run_by_id},
 };
-use crate::backup::{
-    disk::{AsyncBackupsManager, DiskBackupPolicy},
-    sanitize_name,
+use crate::{
+    backup::{
+        disk::{AsyncBackupsManager, DiskBackupPolicy},
+        sanitize_name
+    },
+    metrics::SiftStreamMetrics,
 };
 use sift_connect::{Credentials, SiftChannel, SiftChannelBuilder};
 use sift_error::prelude::*;
@@ -20,7 +23,7 @@ use sift_rs::{
         ingestion_configs::{IngestionConfigServiceWrapper, new_ingestion_config_service},
     },
 };
-use std::{marker::PhantomData, time::Duration};
+use std::{marker::PhantomData, sync::Arc, time::Duration};
 
 /// The default checkpoint interval (1 minute) to use if left unspecified.
 pub const DEFAULT_CHECKPOINT_INTERVAL: Duration = Duration::from_secs(60);
@@ -281,6 +284,8 @@ impl SiftStreamBuilder<IngestionConfigMode> {
         let mut backups_manager = None;
         let mut policy = None;
 
+        let metrics = Arc::new(SiftStreamMetrics::new());
+
         if let Some(strategy) = recovery_strategy {
             match strategy {
                 RecoveryStrategy::RetryOnly(retry_policy) => {
@@ -301,6 +306,7 @@ impl SiftStreamBuilder<IngestionConfigMode> {
                         disk_backup_policy,
                         retry_policy,
                         channel.clone(),
+                        metrics.clone(),
                     )
                     .context("failed to build backups manager")?;
 
@@ -317,6 +323,7 @@ impl SiftStreamBuilder<IngestionConfigMode> {
             checkpoint_interval,
             policy,
             backups_manager,
+            metrics,
         ))
     }
 

--- a/rust/crates/sift_stream/src/stream/mod.rs
+++ b/rust/crates/sift_stream/src/stream/mod.rs
@@ -1,7 +1,10 @@
+use crate::metrics::SiftStreamMetrics;
 use sift_connect::SiftChannel;
 use sift_rs::runs::v2::Run;
 use std::sync::Arc;
-use crate::metrics::SiftStreamMetrics;
+
+#[cfg(feature = "metrics-unstable")]
+use crate::metrics::SiftStreamMetricsSnapshot;
 
 /// Concerned with building and configuring and instance of [SiftStream].
 pub mod builder;
@@ -42,7 +45,15 @@ mod test;
 pub struct SiftStream<M: SiftStreamMode> {
     grpc_channel: SiftChannel,
     mode: M,
-    metrics: Arc<SiftStreamMetrics>
+    metrics: Arc<SiftStreamMetrics>,
+}
+
+impl<M: SiftStreamMode> SiftStream<M> {
+    #[cfg(feature = "metrics-unstable")]
+    /// Retrieve a snapshot of the current metrics for this stream.
+    pub fn metrics(&self) -> SiftStreamMetricsSnapshot {
+        self.metrics.snapshot()
+    }
 }
 
 /// A trait that defines a particular mode of streaming. Only one more is currently supported.

--- a/rust/crates/sift_stream/src/stream/mod.rs
+++ b/rust/crates/sift_stream/src/stream/mod.rs
@@ -1,5 +1,7 @@
 use sift_connect::SiftChannel;
 use sift_rs::runs::v2::Run;
+use std::sync::Arc;
+use crate::metrics::SiftStreamMetrics;
 
 /// Concerned with building and configuring and instance of [SiftStream].
 pub mod builder;
@@ -40,6 +42,7 @@ mod test;
 pub struct SiftStream<M: SiftStreamMode> {
     grpc_channel: SiftChannel,
     mode: M,
+    metrics: Arc<SiftStreamMetrics>
 }
 
 /// A trait that defines a particular mode of streaming. Only one more is currently supported.

--- a/rust/crates/sift_stream/src/stream/mod.rs
+++ b/rust/crates/sift_stream/src/stream/mod.rs
@@ -51,7 +51,7 @@ pub struct SiftStream<M: SiftStreamMode> {
 impl<M: SiftStreamMode> SiftStream<M> {
     #[cfg(feature = "metrics-unstable")]
     /// Retrieve a snapshot of the current metrics for this stream.
-    pub fn metrics(&self) -> SiftStreamMetricsSnapshot {
+    pub fn get_metrics_snapshot(&self) -> SiftStreamMetricsSnapshot {
         self.metrics.snapshot()
     }
 }

--- a/rust/crates/sift_stream/src/stream/mode/ingestion_config.rs
+++ b/rust/crates/sift_stream/src/stream/mode/ingestion_config.rs
@@ -192,6 +192,10 @@ impl SiftStream<IngestionConfigMode> {
         }
     }
 
+    pub fn get_metrics(&self) -> Arc<SiftStreamMetrics> {
+        self.metrics.clone()
+    }
+
     /// The entry-point to send actual telemetry to Sift in the form of [Flow]s. If a `message` is
     /// sent that doesn't match any flows that [SiftStream] catches locally, the message will
     /// still be transmitted and a warning log emitted. If users are certain that the message

--- a/rust/crates/sift_stream/src/stream/mode/ingestion_config.rs
+++ b/rust/crates/sift_stream/src/stream/mode/ingestion_config.rs
@@ -3,9 +3,13 @@ use super::super::{
 };
 use crate::{
     backup::disk::AsyncBackupsManager,
-    metrics::{SiftStreamMetrics, register_metrics},
+    metrics::SiftStreamMetrics,
     stream::run::{RunSelector, load_run_by_form, load_run_by_id},
 };
+
+#[cfg(feature = "metrics-unstable")]
+use crate::metrics::register_metrics;
+
 use futures_core::Stream;
 use prost::Message;
 use sift_connect::SiftChannel;
@@ -149,6 +153,7 @@ impl SiftStream<IngestionConfigMode> {
         let sift_stream_id = Uuid::new_v4();
 
         // Spawn a task to register metrics without blocking
+        #[cfg(feature = "metrics-unstable")]
         {
             let uuid = sift_stream_id.to_string();
             let metrics = metrics.clone();

--- a/rust/crates/sift_stream/src/stream/mode/ingestion_config.rs
+++ b/rust/crates/sift_stream/src/stream/mode/ingestion_config.rs
@@ -941,7 +941,7 @@ impl Stream for DataStream {
                     self.metrics.messages_sent.increment();
                     self.metrics.checkpoint.cur_messages_sent.increment();
                     self.metrics.bytes_sent.add(message_size);
-                    self.metrics.checkpoint.cur_bytes_sent.increment();
+                    self.metrics.checkpoint.cur_bytes_sent.add(message_size);
                     Poll::Ready(Some(req))
                 }
                 StreamMessage::CheckpointSignal => {

--- a/rust/crates/sift_stream/src/stream/mode/ingestion_config.rs
+++ b/rust/crates/sift_stream/src/stream/mode/ingestion_config.rs
@@ -201,10 +201,6 @@ impl SiftStream<IngestionConfigMode> {
         }
     }
 
-    pub fn get_metrics(&self) -> Arc<SiftStreamMetrics> {
-        self.metrics.clone()
-    }
-
     /// The entry-point to send actual telemetry to Sift in the form of [Flow]s. If a `message` is
     /// sent that doesn't match any flows that [SiftStream] catches locally, the message will
     /// still be transmitted and a warning log emitted. If users are certain that the message

--- a/rust/crates/sift_stream/tests/test_ingestion_config_streaming_checkpointing.rs
+++ b/rust/crates/sift_stream/tests/test_ingestion_config_streaming_checkpointing.rs
@@ -3,7 +3,7 @@ use sift_rs::{
     common::r#type::v1::ChannelDataType,
     ingestion_configs::v2::{ChannelConfig, FlowConfig, IngestionConfig},
 };
-use sift_stream::{ChannelValue, Flow, IngestionConfigMode, SiftStream, TimeValue};
+use sift_stream::{ChannelValue, Flow, IngestionConfigMode, SiftStream, TimeValue, SiftStreamMetrics};
 use std::{
     sync::{
         Arc,
@@ -95,6 +95,7 @@ async fn test_sending_data() {
         Duration::from_secs(30),
         None,
         None,
+        Arc::new(SiftStreamMetrics::new())
     );
 
     let num_messages = 100;
@@ -168,6 +169,7 @@ async fn test_checkpointing() {
         checkpoint_interval,
         None,
         None,
+        Arc::new(SiftStreamMetrics::new())
     );
 
     let (terminate_streaming_tx, mut terminate_streaming_rx) = oneshot::channel::<()>();

--- a/rust/crates/sift_stream/tests/test_ingestion_config_streaming_checkpointing.rs
+++ b/rust/crates/sift_stream/tests/test_ingestion_config_streaming_checkpointing.rs
@@ -3,7 +3,9 @@ use sift_rs::{
     common::r#type::v1::ChannelDataType,
     ingestion_configs::v2::{ChannelConfig, FlowConfig, IngestionConfig},
 };
-use sift_stream::{ChannelValue, Flow, IngestionConfigMode, SiftStream, TimeValue, SiftStreamMetrics};
+use sift_stream::{
+    ChannelValue, Flow, IngestionConfigMode, SiftStream, TimeValue, metrics::SiftStreamMetrics,
+};
 use std::{
     sync::{
         Arc,
@@ -95,7 +97,7 @@ async fn test_sending_data() {
         Duration::from_secs(30),
         None,
         None,
-        Arc::new(SiftStreamMetrics::new())
+        Arc::new(SiftStreamMetrics::new()),
     );
 
     let num_messages = 100;
@@ -169,7 +171,7 @@ async fn test_checkpointing() {
         checkpoint_interval,
         None,
         None,
-        Arc::new(SiftStreamMetrics::new())
+        Arc::new(SiftStreamMetrics::new()),
     );
 
     let (terminate_streaming_tx, mut terminate_streaming_rx) = oneshot::channel::<()>();

--- a/rust/crates/sift_stream/tests/test_ingestion_config_streaming_ingestion.rs
+++ b/rust/crates/sift_stream/tests/test_ingestion_config_streaming_ingestion.rs
@@ -6,7 +6,7 @@ use sift_rs::{
     },
     ingestion_configs::v2::{ChannelConfig, FlowConfig, IngestionConfig},
 };
-use sift_stream::{ChannelValue, Flow, IngestionConfigMode, SiftStream, TimeValue};
+use sift_stream::{ChannelValue, Flow, IngestionConfigMode, SiftStream, TimeValue, SiftStreamMetrics};
 use std::{
     sync::{
         Arc,
@@ -107,6 +107,7 @@ async fn test_sending_raw_ingest_request() {
         Duration::from_secs(30),
         None,
         None,
+        Arc::new(SiftStreamMetrics::new())
     );
 
     let num_messages = 100;
@@ -197,6 +198,7 @@ async fn test_sending_flow() {
         Duration::from_secs(30),
         None,
         None,
+        Arc::new(SiftStreamMetrics::new())
     );
 
     let num_messages = 100;
@@ -284,6 +286,7 @@ async fn test_sending_flow_not_in_flow_cache() {
         Duration::from_secs(30),
         None,
         None,
+        Arc::new(SiftStreamMetrics::new())
     );
 
     let num_messages = 100;
@@ -320,7 +323,7 @@ async fn test_sending_flow_not_in_flow_cache() {
             .expect("failed to send requests");
     }
     assert!(logs_contain(
-        &"flow 'unregistered_flow' not found in local flow cache"
+        "flow 'unregistered_flow' not found in local flow cache"
     ));
 
     sift_stream.finish().await.expect("finish call failed");

--- a/rust/crates/sift_stream/tests/test_ingestion_config_streaming_ingestion.rs
+++ b/rust/crates/sift_stream/tests/test_ingestion_config_streaming_ingestion.rs
@@ -6,7 +6,9 @@ use sift_rs::{
     },
     ingestion_configs::v2::{ChannelConfig, FlowConfig, IngestionConfig},
 };
-use sift_stream::{ChannelValue, Flow, IngestionConfigMode, SiftStream, TimeValue, SiftStreamMetrics};
+use sift_stream::{
+    ChannelValue, Flow, IngestionConfigMode, SiftStream, TimeValue, metrics::SiftStreamMetrics,
+};
 use std::{
     sync::{
         Arc,
@@ -107,7 +109,7 @@ async fn test_sending_raw_ingest_request() {
         Duration::from_secs(30),
         None,
         None,
-        Arc::new(SiftStreamMetrics::new())
+        Arc::new(SiftStreamMetrics::new()),
     );
 
     let num_messages = 100;
@@ -198,7 +200,7 @@ async fn test_sending_flow() {
         Duration::from_secs(30),
         None,
         None,
-        Arc::new(SiftStreamMetrics::new())
+        Arc::new(SiftStreamMetrics::new()),
     );
 
     let num_messages = 100;
@@ -286,7 +288,7 @@ async fn test_sending_flow_not_in_flow_cache() {
         Duration::from_secs(30),
         None,
         None,
-        Arc::new(SiftStreamMetrics::new())
+        Arc::new(SiftStreamMetrics::new()),
     );
 
     let num_messages = 100;

--- a/rust/crates/sift_stream/tests/test_ingestion_config_streaming_retries.rs
+++ b/rust/crates/sift_stream/tests/test_ingestion_config_streaming_retries.rs
@@ -6,8 +6,7 @@ use sift_rs::{
 use sift_stream::backup::DiskBackupPolicy;
 use sift_stream::{
     ChannelValue, Flow, IngestionConfigForm, IngestionConfigMode, RecoveryStrategy, RetryPolicy,
-    SiftStream, SiftStreamBuilder, TimeValue,
-    metrics::SiftStreamMetrics
+    SiftStream, SiftStreamBuilder, TimeValue, metrics::SiftStreamMetrics,
 };
 use std::{
     sync::{

--- a/rust/crates/sift_stream/tests/test_ingestion_config_streaming_retries.rs
+++ b/rust/crates/sift_stream/tests/test_ingestion_config_streaming_retries.rs
@@ -7,7 +7,7 @@ use sift_stream::backup::DiskBackupPolicy;
 use sift_stream::{
     ChannelValue, Flow, IngestionConfigForm, IngestionConfigMode, RecoveryStrategy, RetryPolicy,
     SiftStream, SiftStreamBuilder, TimeValue,
-    SiftStreamMetrics
+    metrics::SiftStreamMetrics
 };
 use std::{
     sync::{
@@ -199,7 +199,7 @@ pub async fn test_retries_exhausted() {
             max_backoff: Duration::from_millis(100),
         }),
         None,
-        Arc::new(SiftStreamMetrics::new())
+        Arc::new(SiftStreamMetrics::new()),
     );
 
     let mut error = None;

--- a/rust/crates/sift_stream/tests/test_ingestion_config_streaming_retries.rs
+++ b/rust/crates/sift_stream/tests/test_ingestion_config_streaming_retries.rs
@@ -7,6 +7,7 @@ use sift_stream::backup::DiskBackupPolicy;
 use sift_stream::{
     ChannelValue, Flow, IngestionConfigForm, IngestionConfigMode, RecoveryStrategy, RetryPolicy,
     SiftStream, SiftStreamBuilder, TimeValue,
+    SiftStreamMetrics
 };
 use std::{
     sync::{
@@ -116,7 +117,7 @@ async fn test_retries_succeed() {
         return_error.swap(false, Ordering::Relaxed);
     });
 
-    let _ = sift_stream.send(messages.next().unwrap()).await.unwrap();
+    sift_stream.send(messages.next().unwrap()).await.unwrap();
 
     loop {
         if let Some(msg) = messages.next() {
@@ -130,7 +131,7 @@ async fn test_retries_succeed() {
         break;
     }
 
-    let _ = sift_stream.finish().await.unwrap();
+    sift_stream.finish().await.unwrap();
 
     assert_eq!(
         num_messages + 1, // We add 1 because 1 redundant request will be sent when trying to
@@ -198,6 +199,7 @@ pub async fn test_retries_exhausted() {
             max_backoff: Duration::from_millis(100),
         }),
         None,
+        Arc::new(SiftStreamMetrics::new())
     );
 
     let mut error = None;


### PR DESCRIPTION
Adds more comprehensive metrics to SiftStream and the ability for users to access those metrics.

- Metrics are all atomics, making updating them non-blocking, and are designed to have a negligible impact on performance
- Accessing metrics by the user is non-blocking for SiftStream
- Metrics are currently gated behind the `metrics-unstable` feature flag. This is primarily driven by the need to update metrics in the near future in likely API breaking ways
- Users can access metrics directly from a SiftStream instance through the get_metrics_snapshot function
- After enabling the metrics HTML server, users can also access metrics process-wide through '/' and '/metrics' endpoints. The server responds with a JSON representation of the `StreamStreamMetricsSnapshot` for each SiftStream instance, organized by the SiftStream Ids

**Metric Server Example Output**

`sift_stream::metrics::start_metrics_server(9100).await;`

```
> curl -s http://localhost:9100 | jq

{
  "27d777a3-56a9-4be8-823e-4412dddd3c06": {
    "elapsed_secs": 174.684,
    "loaded_flows": 2,
    "unique_flows_received": 2,
    "messages_received": 185,
    "messages_sent": 185,
    "message_rate": 1.0590552082617755,
    "bytes_sent": 23495,
    "byte_rate": 134.5000114492455,
    "messages_sent_to_backup": 187,
    "cur_retry_count": 0,
    "checkpoint": {
      "checkpoint_count": 3,
      "failed_checkpoint_count": 0,
      "checkpoint_timer_reached_cnt": 2,
      "checkpoint_manually_reached_cnt": 0,
      "cur_elapsed_secs": 54.669,
      "cur_messages_sent": 59,
      "cur_message_rate": 1.079222228319523,
      "cur_bytes_sent": 7585,
      "cur_byte_rate": 138.74407799667088
    },
    "backups": {
      "cur_checkpoint_file_count": 1,
      "cur_checkpoint_cur_file_size": 7757,
      "cur_checkpoint_bytes": 7757,
      "cur_checkpoint_messages": 59,
      "total_file_count": 3,
      "total_bytes": 24371,
      "total_messages": 187,
      "files_pending_ingestion": 0,
      "files_ingested": 0,
      "cur_ingest_retries": 0
    }
  }
}
```