### PR TITLE
rust(feat): Use flow descriptor/builder for sift-stream metrics

### DIFF
--- a/rust/crates/sift_stream/src/metrics/mod.rs
+++ b/rust/crates/sift_stream/src/metrics/mod.rs
@@ -15,9 +15,10 @@ use std::{
 #[cfg(feature = "metrics-unstable")]
 use serde::Serialize;
 
+use sift_error::prelude::*;
 use sift_rs::{common::r#type::v1::ChannelDataType, ingestion_configs::v2::ChannelConfig};
 
-use crate::stream::channel::ChannelValue;
+use crate::stream::flow::{ChannelIndex, FlowBuilder, FlowDescriptor};
 
 /// **Unstable Feature:** API may change at any time
 ///
@@ -755,198 +756,323 @@ impl SiftStreamMetricsSnapshot {
         ]
     }
 
-    pub(crate) fn channel_values(&self, channel_prefix: &str) -> Vec<ChannelValue> {
-        vec![
-            ChannelValue::new(&format!("{channel_prefix}.elapsed_secs"), self.elapsed_secs),
-            ChannelValue::new(&format!("{channel_prefix}.loaded_flows"), self.loaded_flows),
-            ChannelValue::new(
-                &format!("{channel_prefix}.unique_flows_received"),
-                self.unique_flows_received,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.messages_received"),
-                self.messages_received,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.messages_sent"),
-                self.messages_sent,
-            ),
-            ChannelValue::new(&format!("{channel_prefix}.message_rate"), self.message_rate),
-            ChannelValue::new(&format!("{channel_prefix}.bytes_sent"), self.bytes_sent),
-            ChannelValue::new(&format!("{channel_prefix}.byte_rate"), self.byte_rate),
-            ChannelValue::new(
-                &format!("{channel_prefix}.messages_sent_to_backup"),
-                self.messages_sent_to_backup,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.old_messages_dropped_for_ingestion"),
-                self.old_messages_dropped_for_ingestion,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.old_messages_failed_adding_to_backup"),
-                self.old_messages_failed_adding_to_backup,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.cur_retry_count"),
-                self.cur_retry_count,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.grpc_status_counts.ok"),
-                self.grpc_status_counts[0],
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.grpc_status_counts.cancelled"),
-                self.grpc_status_counts[1],
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.grpc_status_counts.unknown"),
-                self.grpc_status_counts[2],
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.grpc_status_counts.invalid_argument"),
-                self.grpc_status_counts[3],
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.grpc_status_counts.deadline_exceeded"),
-                self.grpc_status_counts[4],
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.grpc_status_counts.not_found"),
-                self.grpc_status_counts[5],
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.grpc_status_counts.already_exists"),
-                self.grpc_status_counts[6],
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.grpc_status_counts.permission_denied"),
-                self.grpc_status_counts[7],
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.grpc_status_counts.resource_exhausted"),
-                self.grpc_status_counts[8],
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.grpc_status_counts.failed_precondition"),
-                self.grpc_status_counts[9],
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.grpc_status_counts.aborted"),
-                self.grpc_status_counts[10],
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.grpc_status_counts.out_of_range"),
-                self.grpc_status_counts[11],
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.grpc_status_counts.unimplemented"),
-                self.grpc_status_counts[12],
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.grpc_status_counts.internal"),
-                self.grpc_status_counts[13],
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.grpc_status_counts.unavailable"),
-                self.grpc_status_counts[14],
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.grpc_status_counts.data_loss"),
-                self.grpc_status_counts[15],
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.grpc_status_counts.unauthenticated"),
-                self.grpc_status_counts[16],
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.grpc_status_counts.unknown_grpc_code"),
-                self.grpc_status_counts[17],
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.ingestion_channel_depth"),
-                self.ingestion_channel_depth,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.backup_channel_depth"),
-                self.backup_channel_depth,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.checkpoint.count"),
-                self.checkpoint.checkpoint_count,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.checkpoint.failed_count"),
-                self.checkpoint.failed_checkpoint_count,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.checkpoint.timer_reached_count"),
-                self.checkpoint.checkpoint_timer_reached_cnt,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.checkpoint.manually_reached_count"),
-                self.checkpoint.checkpoint_manually_reached_cnt,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.checkpoint.cur_elapsed_secs"),
-                self.checkpoint.cur_elapsed_secs,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.checkpoint.cur_messages_sent"),
-                self.checkpoint.cur_messages_sent,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.checkpoint.cur_message_rate"),
-                self.checkpoint.cur_message_rate,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.checkpoint.cur_bytes_sent"),
-                self.checkpoint.cur_bytes_sent,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.checkpoint.cur_byte_rate"),
-                self.checkpoint.cur_byte_rate,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.backups.cur_checkpoint_file_count"),
-                self.backups.cur_checkpoint_file_count,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.backups.cur_checkpoint_cur_file_size"),
-                self.backups.cur_checkpoint_cur_file_size,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.backups.cur_checkpoint_bytes"),
-                self.backups.cur_checkpoint_bytes,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.backups.cur_checkpoint_messages"),
-                self.backups.cur_checkpoint_messages,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.backups.total_file_count"),
-                self.backups.total_file_count,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.backups.total_bytes"),
-                self.backups.total_bytes,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.backups.total_messages"),
-                self.backups.total_messages,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.backups.files_pending_ingestion"),
-                self.backups.files_pending_ingestion,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.backups.files_ingested"),
-                self.backups.files_ingested,
-            ),
-            ChannelValue::new(
-                &format!("{channel_prefix}.backups.cur_ingest_retries"),
-                self.backups.cur_ingest_retries,
-            ),
-        ]
+    /// Populates a [`FlowBuilder`] with the current snapshot values using pre-resolved
+    /// [`MetricsFlowIndices`], avoiding per-call string allocations and hash lookups.
+    pub(crate) fn populate_flow(
+        &self,
+        indices: &MetricsFlowIndices,
+        builder: &mut FlowBuilder<'_, String>,
+    ) -> Result<()> {
+        builder.set(indices.elapsed_secs, self.elapsed_secs)?;
+        builder.set(indices.loaded_flows, self.loaded_flows)?;
+        builder.set(indices.unique_flows_received, self.unique_flows_received)?;
+        builder.set(indices.messages_received, self.messages_received)?;
+        builder.set(indices.messages_sent, self.messages_sent)?;
+        builder.set(indices.message_rate, self.message_rate)?;
+        builder.set(indices.bytes_sent, self.bytes_sent)?;
+        builder.set(indices.byte_rate, self.byte_rate)?;
+        builder.set(
+            indices.messages_sent_to_backup,
+            self.messages_sent_to_backup,
+        )?;
+        builder.set(
+            indices.old_messages_dropped_for_ingestion,
+            self.old_messages_dropped_for_ingestion,
+        )?;
+        builder.set(
+            indices.old_messages_failed_adding_to_backup,
+            self.old_messages_failed_adding_to_backup,
+        )?;
+        builder.set(indices.cur_retry_count, self.cur_retry_count)?;
+        builder.set(indices.grpc_status_counts.ok, self.grpc_status_counts[0])?;
+        builder.set(
+            indices.grpc_status_counts.cancelled,
+            self.grpc_status_counts[1],
+        )?;
+        builder.set(
+            indices.grpc_status_counts.unknown,
+            self.grpc_status_counts[2],
+        )?;
+        builder.set(
+            indices.grpc_status_counts.invalid_argument,
+            self.grpc_status_counts[3],
+        )?;
+        builder.set(
+            indices.grpc_status_counts.deadline_exceeded,
+            self.grpc_status_counts[4],
+        )?;
+        builder.set(
+            indices.grpc_status_counts.not_found,
+            self.grpc_status_counts[5],
+        )?;
+        builder.set(
+            indices.grpc_status_counts.already_exists,
+            self.grpc_status_counts[6],
+        )?;
+        builder.set(
+            indices.grpc_status_counts.permission_denied,
+            self.grpc_status_counts[7],
+        )?;
+        builder.set(
+            indices.grpc_status_counts.resource_exhausted,
+            self.grpc_status_counts[8],
+        )?;
+        builder.set(
+            indices.grpc_status_counts.failed_precondition,
+            self.grpc_status_counts[9],
+        )?;
+        builder.set(
+            indices.grpc_status_counts.aborted,
+            self.grpc_status_counts[10],
+        )?;
+        builder.set(
+            indices.grpc_status_counts.out_of_range,
+            self.grpc_status_counts[11],
+        )?;
+        builder.set(
+            indices.grpc_status_counts.unimplemented,
+            self.grpc_status_counts[12],
+        )?;
+        builder.set(
+            indices.grpc_status_counts.internal,
+            self.grpc_status_counts[13],
+        )?;
+        builder.set(
+            indices.grpc_status_counts.unavailable,
+            self.grpc_status_counts[14],
+        )?;
+        builder.set(
+            indices.grpc_status_counts.data_loss,
+            self.grpc_status_counts[15],
+        )?;
+        builder.set(
+            indices.grpc_status_counts.unauthenticated,
+            self.grpc_status_counts[16],
+        )?;
+        builder.set(
+            indices.grpc_status_counts.unknown_grpc_code,
+            self.grpc_status_counts[17],
+        )?;
+        builder.set(
+            indices.ingestion_channel_depth,
+            self.ingestion_channel_depth,
+        )?;
+        builder.set(indices.backup_channel_depth, self.backup_channel_depth)?;
+        builder.set(indices.checkpoint.count, self.checkpoint.checkpoint_count)?;
+        builder.set(
+            indices.checkpoint.failed_count,
+            self.checkpoint.failed_checkpoint_count,
+        )?;
+        builder.set(
+            indices.checkpoint.timer_reached_count,
+            self.checkpoint.checkpoint_timer_reached_cnt,
+        )?;
+        builder.set(
+            indices.checkpoint.manually_reached_count,
+            self.checkpoint.checkpoint_manually_reached_cnt,
+        )?;
+        builder.set(
+            indices.checkpoint.cur_elapsed_secs,
+            self.checkpoint.cur_elapsed_secs,
+        )?;
+        builder.set(
+            indices.checkpoint.cur_messages_sent,
+            self.checkpoint.cur_messages_sent,
+        )?;
+        builder.set(
+            indices.checkpoint.cur_message_rate,
+            self.checkpoint.cur_message_rate,
+        )?;
+        builder.set(
+            indices.checkpoint.cur_bytes_sent,
+            self.checkpoint.cur_bytes_sent,
+        )?;
+        builder.set(
+            indices.checkpoint.cur_byte_rate,
+            self.checkpoint.cur_byte_rate,
+        )?;
+        builder.set(
+            indices.backups.cur_checkpoint_file_count,
+            self.backups.cur_checkpoint_file_count,
+        )?;
+        builder.set(
+            indices.backups.cur_checkpoint_cur_file_size,
+            self.backups.cur_checkpoint_cur_file_size,
+        )?;
+        builder.set(
+            indices.backups.cur_checkpoint_bytes,
+            self.backups.cur_checkpoint_bytes,
+        )?;
+        builder.set(
+            indices.backups.cur_checkpoint_messages,
+            self.backups.cur_checkpoint_messages,
+        )?;
+        builder.set(
+            indices.backups.total_file_count,
+            self.backups.total_file_count,
+        )?;
+        builder.set(indices.backups.total_bytes, self.backups.total_bytes)?;
+        builder.set(indices.backups.total_messages, self.backups.total_messages)?;
+        builder.set(
+            indices.backups.files_pending_ingestion,
+            self.backups.files_pending_ingestion,
+        )?;
+        builder.set(indices.backups.files_ingested, self.backups.files_ingested)?;
+        builder.set(
+            indices.backups.cur_ingest_retries,
+            self.backups.cur_ingest_retries,
+        )?;
+        Ok(())
+    }
+}
+
+/// Pre-resolved [`ChannelIndex`] values for gRPC status count channels.
+pub(crate) struct MetricsGrpcStatusIndices {
+    pub ok: ChannelIndex,
+    pub cancelled: ChannelIndex,
+    pub unknown: ChannelIndex,
+    pub invalid_argument: ChannelIndex,
+    pub deadline_exceeded: ChannelIndex,
+    pub not_found: ChannelIndex,
+    pub already_exists: ChannelIndex,
+    pub permission_denied: ChannelIndex,
+    pub resource_exhausted: ChannelIndex,
+    pub failed_precondition: ChannelIndex,
+    pub aborted: ChannelIndex,
+    pub out_of_range: ChannelIndex,
+    pub unimplemented: ChannelIndex,
+    pub internal: ChannelIndex,
+    pub unavailable: ChannelIndex,
+    pub data_loss: ChannelIndex,
+    pub unauthenticated: ChannelIndex,
+    pub unknown_grpc_code: ChannelIndex,
+}
+
+/// Pre-resolved [`ChannelIndex`] values for checkpoint metric channels.
+pub(crate) struct MetricsCheckpointFlowIndices {
+    pub count: ChannelIndex,
+    pub failed_count: ChannelIndex,
+    pub timer_reached_count: ChannelIndex,
+    pub manually_reached_count: ChannelIndex,
+    pub cur_elapsed_secs: ChannelIndex,
+    pub cur_messages_sent: ChannelIndex,
+    pub cur_message_rate: ChannelIndex,
+    pub cur_bytes_sent: ChannelIndex,
+    pub cur_byte_rate: ChannelIndex,
+}
+
+/// Pre-resolved [`ChannelIndex`] values for backup metric channels.
+pub(crate) struct MetricsBackupFlowIndices {
+    pub cur_checkpoint_file_count: ChannelIndex,
+    pub cur_checkpoint_cur_file_size: ChannelIndex,
+    pub cur_checkpoint_bytes: ChannelIndex,
+    pub cur_checkpoint_messages: ChannelIndex,
+    pub total_file_count: ChannelIndex,
+    pub total_bytes: ChannelIndex,
+    pub total_messages: ChannelIndex,
+    pub files_pending_ingestion: ChannelIndex,
+    pub files_ingested: ChannelIndex,
+    pub cur_ingest_retries: ChannelIndex,
+}
+
+/// Pre-resolved [`ChannelIndex`] values for all metrics channels, built once from the
+/// [`FlowDescriptor`] after stream initialization. Used with [`FlowBuilder`] to populate
+/// a metrics flow without per-call string allocations or hash lookups.
+pub(crate) struct MetricsFlowIndices {
+    pub elapsed_secs: ChannelIndex,
+    pub loaded_flows: ChannelIndex,
+    pub unique_flows_received: ChannelIndex,
+    pub messages_received: ChannelIndex,
+    pub messages_sent: ChannelIndex,
+    pub message_rate: ChannelIndex,
+    pub bytes_sent: ChannelIndex,
+    pub byte_rate: ChannelIndex,
+    pub messages_sent_to_backup: ChannelIndex,
+    pub old_messages_dropped_for_ingestion: ChannelIndex,
+    pub old_messages_failed_adding_to_backup: ChannelIndex,
+    pub cur_retry_count: ChannelIndex,
+    pub grpc_status_counts: MetricsGrpcStatusIndices,
+    pub ingestion_channel_depth: ChannelIndex,
+    pub backup_channel_depth: ChannelIndex,
+    pub checkpoint: MetricsCheckpointFlowIndices,
+    pub backups: MetricsBackupFlowIndices,
+}
+
+impl MetricsFlowIndices {
+    pub(crate) fn new(descriptor: &FlowDescriptor<String>, prefix: &str) -> Result<Self> {
+        let m = descriptor.mapping();
+
+        macro_rules! idx {
+            ($suffix:literal) => {{
+                let key = format!("{prefix}.{}", $suffix);
+                *m.get(&key).ok_or_else(|| {
+                    Error::new_msg(
+                        ErrorKind::NotFoundError,
+                        format!("metrics channel '{key}' not found in flow descriptor"),
+                    )
+                })?
+            }};
+        }
+
+        Ok(Self {
+            elapsed_secs: idx!("elapsed_secs"),
+            loaded_flows: idx!("loaded_flows"),
+            unique_flows_received: idx!("unique_flows_received"),
+            messages_received: idx!("messages_received"),
+            messages_sent: idx!("messages_sent"),
+            message_rate: idx!("message_rate"),
+            bytes_sent: idx!("bytes_sent"),
+            byte_rate: idx!("byte_rate"),
+            messages_sent_to_backup: idx!("messages_sent_to_backup"),
+            old_messages_dropped_for_ingestion: idx!("old_messages_dropped_for_ingestion"),
+            old_messages_failed_adding_to_backup: idx!("old_messages_failed_adding_to_backup"),
+            cur_retry_count: idx!("cur_retry_count"),
+            grpc_status_counts: MetricsGrpcStatusIndices {
+                ok: idx!("grpc_status_counts.ok"),
+                cancelled: idx!("grpc_status_counts.cancelled"),
+                unknown: idx!("grpc_status_counts.unknown"),
+                invalid_argument: idx!("grpc_status_counts.invalid_argument"),
+                deadline_exceeded: idx!("grpc_status_counts.deadline_exceeded"),
+                not_found: idx!("grpc_status_counts.not_found"),
+                already_exists: idx!("grpc_status_counts.already_exists"),
+                permission_denied: idx!("grpc_status_counts.permission_denied"),
+                resource_exhausted: idx!("grpc_status_counts.resource_exhausted"),
+                failed_precondition: idx!("grpc_status_counts.failed_precondition"),
+                aborted: idx!("grpc_status_counts.aborted"),
+                out_of_range: idx!("grpc_status_counts.out_of_range"),
+                unimplemented: idx!("grpc_status_counts.unimplemented"),
+                internal: idx!("grpc_status_counts.internal"),
+                unavailable: idx!("grpc_status_counts.unavailable"),
+                data_loss: idx!("grpc_status_counts.data_loss"),
+                unauthenticated: idx!("grpc_status_counts.unauthenticated"),
+                unknown_grpc_code: idx!("grpc_status_counts.unknown_grpc_code"),
+            },
+            ingestion_channel_depth: idx!("ingestion_channel_depth"),
+            backup_channel_depth: idx!("backup_channel_depth"),
+            checkpoint: MetricsCheckpointFlowIndices {
+                count: idx!("checkpoint.count"),
+                failed_count: idx!("checkpoint.failed_count"),
+                timer_reached_count: idx!("checkpoint.timer_reached_count"),
+                manually_reached_count: idx!("checkpoint.manually_reached_count"),
+                cur_elapsed_secs: idx!("checkpoint.cur_elapsed_secs"),
+                cur_messages_sent: idx!("checkpoint.cur_messages_sent"),
+                cur_message_rate: idx!("checkpoint.cur_message_rate"),
+                cur_bytes_sent: idx!("checkpoint.cur_bytes_sent"),
+                cur_byte_rate: idx!("checkpoint.cur_byte_rate"),
+            },
+            backups: MetricsBackupFlowIndices {
+                cur_checkpoint_file_count: idx!("backups.cur_checkpoint_file_count"),
+                cur_checkpoint_cur_file_size: idx!("backups.cur_checkpoint_cur_file_size"),
+                cur_checkpoint_bytes: idx!("backups.cur_checkpoint_bytes"),
+                cur_checkpoint_messages: idx!("backups.cur_checkpoint_messages"),
+                total_file_count: idx!("backups.total_file_count"),
+                total_bytes: idx!("backups.total_bytes"),
+                total_messages: idx!("backups.total_messages"),
+                files_pending_ingestion: idx!("backups.files_pending_ingestion"),
+                files_ingested: idx!("backups.files_ingested"),
+                cur_ingest_retries: idx!("backups.cur_ingest_retries"),
+            },
+        })
     }
 }
 
@@ -969,5 +1095,138 @@ impl Default for SiftStreamMetrics {
             checkpoint: CheckpointMetrics::default(),
             backups: BackupMetrics::default(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{TimeValue, stream::flow::FlowBuilder};
+    use sift_rs::{
+        ingest::v1::ingest_with_config_data_channel_value::Type, ingestion_configs::v2::FlowConfig,
+    };
+
+    fn build_test_descriptor(prefix: &str) -> FlowDescriptor<String> {
+        let flow_config = FlowConfig {
+            name: "test-flow".to_string(),
+            channels: SiftStreamMetricsSnapshot::channel_configs(prefix),
+        };
+        FlowDescriptor::try_from(("test-ic-id", flow_config)).unwrap()
+    }
+
+    /// Verifies that MetricsFlowIndices::new succeeds when the descriptor is built from
+    /// channel_configs — i.e. every channel name resolves to a valid index.
+    #[test]
+    fn test_metrics_flow_indices_new_succeeds() {
+        let descriptor = build_test_descriptor("test");
+        assert!(MetricsFlowIndices::new(&descriptor, "test").is_ok());
+    }
+
+    /// Verifies that populate_flow maps every snapshot field to the correct channel slot.
+    ///
+    /// Each metric value is set to a distinct number so that a mis-mapping (two fields swapped)
+    /// or a missing call (channel left as Empty) will cause the test to fail.
+    #[test]
+    fn test_populate_flow_maps_all_values_correctly() {
+        let prefix = "test";
+        let descriptor = build_test_descriptor(prefix);
+        let indices = MetricsFlowIndices::new(&descriptor, prefix).unwrap();
+
+        let snapshot = SiftStreamMetricsSnapshot {
+            elapsed_secs: 1.0,
+            loaded_flows: 2,
+            unique_flows_received: 3,
+            messages_received: 4,
+            messages_sent: 5,
+            message_rate: 6.0,
+            bytes_sent: 7,
+            byte_rate: 8.0,
+            messages_sent_to_backup: 9,
+            old_messages_dropped_for_ingestion: 10,
+            old_messages_failed_adding_to_backup: 11,
+            cur_retry_count: 12,
+            // grpc_status_counts[0..=17] => 13..=30
+            grpc_status_counts: [
+                13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+            ],
+            ingestion_channel_depth: 30,
+            backup_channel_depth: 31,
+            checkpoint: CheckpointMetricsSnapshot {
+                checkpoint_count: 32,
+                failed_checkpoint_count: 33,
+                checkpoint_timer_reached_cnt: 34,
+                checkpoint_manually_reached_cnt: 35,
+                cur_elapsed_secs: 36.0,
+                cur_messages_sent: 37,
+                cur_message_rate: 38.0,
+                cur_bytes_sent: 39,
+                cur_byte_rate: 40.0,
+            },
+            backups: BackupMetricsSnapshot {
+                cur_checkpoint_file_count: 41,
+                cur_checkpoint_cur_file_size: 42,
+                cur_checkpoint_bytes: 43,
+                cur_checkpoint_messages: 44,
+                total_file_count: 45,
+                total_bytes: 46,
+                total_messages: 47,
+                committed_message_id: 0,
+                queued_checkpoints: 0,
+                queued_file_ctxs: 0,
+                files_pending_ingestion: 48,
+                files_ingested: 49,
+                cur_ingest_retries: 50,
+            },
+        };
+
+        let mut builder = FlowBuilder::new(&descriptor);
+        snapshot.populate_flow(&indices, &mut builder).unwrap();
+        let req = builder.request(TimeValue::now());
+
+        // Channel count must match channel_configs exactly.
+        let expected_count = SiftStreamMetricsSnapshot::channel_configs(prefix).len();
+        assert_eq!(req.channel_values.len(), expected_count);
+
+        // No channel should be left as Empty — catches any missing populate_flow call.
+        let m = descriptor.mapping();
+        let empty: Vec<&str> = m
+            .iter()
+            .filter(|(_, idx)| {
+                matches!(
+                    req.channel_values[idx.as_usize()].r#type,
+                    Some(Type::Empty(_))
+                )
+            })
+            .map(|(name, _)| name.as_str())
+            .collect();
+        assert!(empty.is_empty(), "channels left unpopulated: {empty:?}");
+
+        // Spot-check representative fields from each logical group.
+        macro_rules! assert_val {
+            ($key:expr, $expected:expr) => {
+                assert_eq!(
+                    req.channel_values[m[&format!("{prefix}.{}", $key)].as_usize()].r#type,
+                    Some($expected),
+                    "wrong value for channel '{prefix}.{}'",
+                    $key,
+                )
+            };
+        }
+
+        assert_val!("elapsed_secs", Type::Double(1.0));
+        assert_val!("loaded_flows", Type::Uint64(2));
+        assert_val!("message_rate", Type::Double(6.0));
+        assert_val!("byte_rate", Type::Double(8.0));
+        assert_val!("cur_retry_count", Type::Uint64(12));
+        assert_val!("grpc_status_counts.ok", Type::Uint64(13));
+        assert_val!("grpc_status_counts.unauthenticated", Type::Uint64(29));
+        assert_val!("ingestion_channel_depth", Type::Uint64(30));
+        assert_val!("backup_channel_depth", Type::Uint64(31));
+        assert_val!("checkpoint.count", Type::Uint64(32));
+        assert_val!("checkpoint.cur_elapsed_secs", Type::Double(36.0));
+        assert_val!("checkpoint.cur_message_rate", Type::Double(38.0));
+        assert_val!("backups.cur_checkpoint_file_count", Type::Uint64(41));
+        assert_val!("backups.files_ingested", Type::Uint64(49));
+        assert_val!("backups.cur_ingest_retries", Type::Uint64(50));
     }
 }

--- a/rust/crates/sift_stream/src/stream/flow/mod.rs
+++ b/rust/crates/sift_stream/src/stream/flow/mod.rs
@@ -21,6 +21,13 @@ use crate::{TimeValue, Value};
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct ChannelIndex(usize);
 
+#[cfg(test)]
+impl ChannelIndex {
+    pub(crate) fn as_usize(self) -> usize {
+        self.0
+    }
+}
+
 /// Describes the schema of a flow, providing a convenient, performant, and correct way to
 /// build the flow being described.
 ///

--- a/rust/crates/sift_stream/src/stream/tasks/metrics.rs
+++ b/rust/crates/sift_stream/src/stream/tasks/metrics.rs
@@ -1,7 +1,7 @@
 use crate::{
-    Flow, FlowConfig, IngestionConfigForm, LiveStreamingWithBackups, SiftStream, SiftStreamBuilder,
-    TimeValue,
-    metrics::{SiftStreamMetrics, SiftStreamMetricsSnapshot},
+    FlowBuilder, FlowConfig, FlowDescriptor, IngestionConfigForm, LiveStreamingWithBackups,
+    SiftStream, SiftStreamBuilder,
+    metrics::{MetricsFlowIndices, SiftStreamMetrics, SiftStreamMetricsSnapshot},
     stream::{mode::ingestion_config::IngestionConfigEncoder, tasks::ControlMessage},
 };
 use sift_connect::SiftChannel;
@@ -21,9 +21,10 @@ const METRICS_STREAMING_FLOW_NAME: &str = "sift-stream-metrics-flow";
 pub(crate) struct MetricsStreamingTask {
     stream: SiftStream<IngestionConfigEncoder, LiveStreamingWithBackups>,
     control_rx: broadcast::Receiver<ControlMessage>,
-    session_name: String,
     interval: Duration,
     metrics: Arc<SiftStreamMetrics>,
+    flow_descriptor: FlowDescriptor<String>,
+    flow_indices: MetricsFlowIndices,
 }
 
 impl MetricsStreamingTask {
@@ -89,12 +90,16 @@ impl MetricsStreamingTask {
 
         let stream = stream_fut.await?;
 
+        let flow_descriptor = stream.get_flow_descriptor(METRICS_STREAMING_FLOW_NAME)?;
+        let flow_indices = MetricsFlowIndices::new(&flow_descriptor, &session_name)?;
+
         Ok(Self {
             stream,
             control_rx,
-            session_name,
             interval,
             metrics,
+            flow_descriptor,
+            flow_indices,
         })
     }
 
@@ -104,10 +109,12 @@ impl MetricsStreamingTask {
         loop {
             select! {
                 _ = interval.tick() => {
-                    let metrics = self.metrics.snapshot();
-                    let values = metrics.channel_values(&self.session_name);
-                    let flow = Flow::new(METRICS_STREAMING_FLOW_NAME, TimeValue::now(), &values);
-                    self.stream.send(flow).await.map_err(|e| {
+                    let snapshot = self.metrics.snapshot();
+                    let mut builder = FlowBuilder::new(&self.flow_descriptor);
+                    snapshot.populate_flow(&self.flow_indices, &mut builder).map_err(|e| {
+                        Error::new_msg(ErrorKind::StreamError, e.to_string())
+                    })?;
+                    self.stream.send(builder).await.map_err(|e| {
                         Error::new_msg(ErrorKind::StreamError, e.to_string())
                     })?;
                 }


### PR DESCRIPTION
Migrates the metrics task for `SiftStream` to the `FlowBuilder` pattern of ingestion in order to reduce the amount of dynamic memory allocations that occur when using the `ChannelValue` (due to the channel name strings).