### PR TITLE
rust(feat): Add tracing scoped dispatch to capture sift-stream logs 

### DIFF
--- a/rust/crates/sift_stream/Cargo.toml
+++ b/rust/crates/sift_stream/Cargo.toml
@@ -36,11 +36,12 @@ sift_pbfs = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync", "time", "macros", "fs"] }
 tokio-stream = { workspace = true, features = ["sync"] }
 tracing = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, optional = true, features = ["registry"] }
 uuid = { workspace = true }
 
 [features]
 default = ["tracing"]
-tracing = ["dep:tracing", "dep:bytesize"]
+tracing = ["dep:tracing", "dep:bytesize", "dep:tracing-subscriber"]
 metrics-unstable = ["dep:serde", "dep:serde_json", "dep:hyper", "dep:hyper-util"]
 unstable = []
 

--- a/rust/crates/sift_stream/src/lib.rs
+++ b/rust/crates/sift_stream/src/lib.rs
@@ -600,5 +600,11 @@ pub mod metrics;
 #[cfg(feature = "metrics-unstable")]
 pub use metrics::{MetricsServerBuilder, SiftStreamMetricsSnapshot};
 
+pub mod logging;
+pub use logging::LogLevel;
+
+#[cfg(feature = "tracing")]
+pub(crate) mod telemetry;
+
 #[cfg(test)]
 mod test;

--- a/rust/crates/sift_stream/src/logging.rs
+++ b/rust/crates/sift_stream/src/logging.rs
@@ -164,8 +164,6 @@ mod tests {
         }
     }
 
-    // ── LogLevel ──────────────────────────────────────────────────────────────
-
     #[test]
     fn log_level_ordering() {
         assert!(LogLevel::Error < LogLevel::Warn);
@@ -192,8 +190,6 @@ mod tests {
         assert_eq!(LogLevel::from(&tracing::Level::DEBUG), LogLevel::Debug);
         assert_eq!(LogLevel::from(&tracing::Level::TRACE), LogLevel::Trace);
     }
-
-    // ── LogDeduplicator ───────────────────────────────────────────────────────
 
     #[test]
     fn dedup_first_event_is_emitted() {

--- a/rust/crates/sift_stream/src/logging.rs
+++ b/rust/crates/sift_stream/src/logging.rs
@@ -1,0 +1,318 @@
+/// Log level for captured tracing events.
+///
+/// Decoupled from `tracing::Level` so that core logic does not require the `tracing` feature.
+/// Ordering: higher discriminant = more verbose. A filter of `Info` passes events where
+/// `event_level <= LogLevel::Info`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[repr(u8)]
+pub enum LogLevel {
+    Error = 1,
+    Warn = 2,
+    #[default]
+    Info = 3,
+    Debug = 4,
+    Trace = 5,
+}
+
+impl LogLevel {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Error => "ERROR",
+            Self::Warn => "WARN",
+            Self::Info => "INFO",
+            Self::Debug => "DEBUG",
+            Self::Trace => "TRACE",
+        }
+    }
+}
+
+#[cfg(feature = "tracing")]
+impl From<&tracing::Level> for LogLevel {
+    fn from(l: &tracing::Level) -> Self {
+        match *l {
+            tracing::Level::ERROR => Self::Error,
+            tracing::Level::WARN => Self::Warn,
+            tracing::Level::INFO => Self::Info,
+            tracing::Level::DEBUG => Self::Debug,
+            tracing::Level::TRACE => Self::Trace,
+        }
+    }
+}
+
+/// A captured log event from the scoped tracing dispatch.
+///
+/// `file` and `line` come from tracing callsite metadata — compile-time constants that
+/// are guaranteed to point to the original call-site. Used for deduplication only.
+pub(crate) struct LogEvent {
+    pub level: LogLevel,
+    /// The target module path of the event (e.g. `sift_stream::stream::tasks::ingestion`).
+    pub target: &'static str,
+    /// Source file name from the callsite (empty string if unavailable).
+    pub file: &'static str,
+    /// Source line number from the callsite (0 if unavailable).
+    pub line: u32,
+    /// The formatted event message.
+    pub message: String,
+    /// Additional structured key-value fields beyond `message`.
+    pub fields: Vec<(String, String)>,
+    /// Wall-clock timestamp when the event was captured.
+    /// Stored for potential future use (e.g. as a flow timestamp channel).
+    #[allow(dead_code)]
+    pub timestamp: std::time::SystemTime,
+}
+
+/// Output from [`LogDeduplicator::process`].
+pub(crate) enum DeduplicatorOutput {
+    /// Event is a repeat of the previous one; suppressed.
+    Suppress,
+    /// A single event to emit.
+    Emit(LogEvent),
+    /// Emit the pending repeat-count summary first, then the new event.
+    EmitSummaryThenEmit(LogEvent, LogEvent),
+}
+
+/// Tracks consecutive repeated log events (same file + line) and collapses them.
+///
+/// Lives as local mutable state inside `MetricsStreamingTask::run()` — single-threaded,
+/// no mutex required.
+#[derive(Default)]
+pub(crate) struct LogDeduplicator {
+    last_file: &'static str,
+    last_line: u32,
+    last_level: LogLevel,
+    last_target: &'static str,
+    repeat_count: u64,
+}
+
+impl LogDeduplicator {
+    /// Process an incoming event. Returns what should be forwarded to Sift.
+    ///
+    /// Pointer equality is valid for `&'static str` dedup: strings from the same callsite
+    /// in the same binary share their static storage address.
+    pub(crate) fn process(&mut self, event: LogEvent) -> DeduplicatorOutput {
+        let is_repeat = std::ptr::eq(event.file, self.last_file) && event.line == self.last_line;
+
+        if is_repeat {
+            self.repeat_count += 1;
+            return DeduplicatorOutput::Suppress;
+        }
+
+        let summary = (self.repeat_count > 0).then(|| LogEvent {
+            level: self.last_level,
+            target: self.last_target,
+            file: self.last_file,
+            line: self.last_line,
+            message: format!(
+                "(previous message repeated {} additional time(s))",
+                self.repeat_count
+            ),
+            fields: vec![],
+            timestamp: std::time::SystemTime::now(),
+        });
+
+        self.last_file = event.file;
+        self.last_line = event.line;
+        self.last_level = event.level;
+        self.last_target = event.target;
+        self.repeat_count = 0;
+
+        match summary {
+            Some(s) => DeduplicatorOutput::EmitSummaryThenEmit(s, event),
+            None => DeduplicatorOutput::Emit(event),
+        }
+    }
+
+    /// Flush any pending repeat-count summary (call at shutdown).
+    pub(crate) fn flush(&mut self) -> Option<LogEvent> {
+        (self.repeat_count > 0).then(|| {
+            let e = LogEvent {
+                level: self.last_level,
+                target: self.last_target,
+                file: self.last_file,
+                line: self.last_line,
+                message: format!(
+                    "(previous message repeated {} additional time(s))",
+                    self.repeat_count
+                ),
+                fields: vec![],
+                timestamp: std::time::SystemTime::now(),
+            };
+            self.repeat_count = 0;
+            e
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Two distinct static string addresses to simulate different source file paths.
+    // Using clearly different content ensures the compiler cannot share their storage.
+    static FILE_A: &str = "crate/src/tasks/module_a.rs";
+    static FILE_B: &str = "crate/src/tasks/module_b.rs";
+
+    fn event(file: &'static str, line: u32, level: LogLevel, msg: &str) -> LogEvent {
+        LogEvent {
+            level,
+            target: "sift_stream::test",
+            file,
+            line,
+            message: msg.to_owned(),
+            fields: vec![],
+            timestamp: std::time::SystemTime::now(),
+        }
+    }
+
+    // ── LogLevel ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn log_level_ordering() {
+        assert!(LogLevel::Error < LogLevel::Warn);
+        assert!(LogLevel::Warn < LogLevel::Info);
+        assert!(LogLevel::Info < LogLevel::Debug);
+        assert!(LogLevel::Debug < LogLevel::Trace);
+    }
+
+    #[test]
+    fn log_level_as_str() {
+        assert_eq!(LogLevel::Error.as_str(), "ERROR");
+        assert_eq!(LogLevel::Warn.as_str(), "WARN");
+        assert_eq!(LogLevel::Info.as_str(), "INFO");
+        assert_eq!(LogLevel::Debug.as_str(), "DEBUG");
+        assert_eq!(LogLevel::Trace.as_str(), "TRACE");
+    }
+
+    #[cfg(feature = "tracing")]
+    #[test]
+    fn log_level_from_tracing_level() {
+        assert_eq!(LogLevel::from(&tracing::Level::ERROR), LogLevel::Error);
+        assert_eq!(LogLevel::from(&tracing::Level::WARN), LogLevel::Warn);
+        assert_eq!(LogLevel::from(&tracing::Level::INFO), LogLevel::Info);
+        assert_eq!(LogLevel::from(&tracing::Level::DEBUG), LogLevel::Debug);
+        assert_eq!(LogLevel::from(&tracing::Level::TRACE), LogLevel::Trace);
+    }
+
+    // ── LogDeduplicator ───────────────────────────────────────────────────────
+
+    #[test]
+    fn dedup_first_event_is_emitted() {
+        let mut d = LogDeduplicator::default();
+        assert!(matches!(
+            d.process(event(FILE_A, 10, LogLevel::Info, "msg")),
+            DeduplicatorOutput::Emit(_)
+        ));
+    }
+
+    #[test]
+    fn dedup_repeat_at_same_callsite_is_suppressed() {
+        let mut d = LogDeduplicator::default();
+        let _ = d.process(event(FILE_A, 10, LogLevel::Info, "msg"));
+        assert!(matches!(
+            d.process(event(FILE_A, 10, LogLevel::Info, "msg")),
+            DeduplicatorOutput::Suppress
+        ));
+    }
+
+    #[test]
+    fn dedup_multiple_consecutive_repeats_are_all_suppressed() {
+        let mut d = LogDeduplicator::default();
+        let _ = d.process(event(FILE_A, 10, LogLevel::Info, "msg"));
+        for _ in 0..5 {
+            assert!(matches!(
+                d.process(event(FILE_A, 10, LogLevel::Info, "msg")),
+                DeduplicatorOutput::Suppress
+            ));
+        }
+    }
+
+    #[test]
+    fn dedup_different_line_emits_without_summary() {
+        let mut d = LogDeduplicator::default();
+        let _ = d.process(event(FILE_A, 10, LogLevel::Info, "first"));
+        // No repeats accumulated, so no summary is needed.
+        assert!(matches!(
+            d.process(event(FILE_A, 20, LogLevel::Info, "second")),
+            DeduplicatorOutput::Emit(_)
+        ));
+    }
+
+    #[test]
+    fn dedup_different_file_emits_without_summary() {
+        let mut d = LogDeduplicator::default();
+        let _ = d.process(event(FILE_A, 10, LogLevel::Info, "first"));
+        assert!(matches!(
+            d.process(event(FILE_B, 10, LogLevel::Info, "second")),
+            DeduplicatorOutput::Emit(_)
+        ));
+    }
+
+    #[test]
+    fn dedup_new_callsite_after_repeats_emits_summary_then_event() {
+        let mut d = LogDeduplicator::default();
+        let _ = d.process(event(FILE_A, 10, LogLevel::Info, "msg"));
+        let _ = d.process(event(FILE_A, 10, LogLevel::Info, "msg")); // suppressed ×1
+        let _ = d.process(event(FILE_A, 10, LogLevel::Info, "msg")); // suppressed ×2
+        assert!(matches!(
+            d.process(event(FILE_B, 5, LogLevel::Warn, "new")),
+            DeduplicatorOutput::EmitSummaryThenEmit(_, _)
+        ));
+    }
+
+    #[test]
+    fn dedup_summary_mentions_correct_repeat_count() {
+        let mut d = LogDeduplicator::default();
+        let _ = d.process(event(FILE_A, 10, LogLevel::Info, "msg"));
+        let _ = d.process(event(FILE_A, 10, LogLevel::Info, "msg")); // +1
+        let _ = d.process(event(FILE_A, 10, LogLevel::Info, "msg")); // +2
+        let _ = d.process(event(FILE_A, 10, LogLevel::Info, "msg")); // +3
+        match d.process(event(FILE_B, 5, LogLevel::Info, "new")) {
+            DeduplicatorOutput::EmitSummaryThenEmit(summary, new_event) => {
+                assert!(
+                    summary.message.contains("3"),
+                    "summary should mention 3 repeats, got: {:?}",
+                    summary.message
+                );
+                assert_eq!(new_event.message, "new");
+            }
+            _ => panic!("expected EmitSummaryThenEmit, got a different variant"),
+        }
+    }
+
+    #[test]
+    fn dedup_flush_on_fresh_state_returns_none() {
+        let mut d = LogDeduplicator::default();
+        assert!(d.flush().is_none());
+    }
+
+    #[test]
+    fn dedup_flush_after_single_emit_returns_none() {
+        let mut d = LogDeduplicator::default();
+        let _ = d.process(event(FILE_A, 10, LogLevel::Info, "msg"));
+        // One event emitted, no pending repeats.
+        assert!(d.flush().is_none());
+    }
+
+    #[test]
+    fn dedup_flush_with_pending_repeats_returns_summary() {
+        let mut d = LogDeduplicator::default();
+        let _ = d.process(event(FILE_A, 10, LogLevel::Info, "msg"));
+        let _ = d.process(event(FILE_A, 10, LogLevel::Info, "msg")); // suppressed
+        let summary = d.flush().expect("expected a summary");
+        assert!(
+            summary.message.contains("1"),
+            "summary should mention 1 repeat, got: {:?}",
+            summary.message
+        );
+    }
+
+    #[test]
+    fn dedup_flush_resets_repeat_count() {
+        let mut d = LogDeduplicator::default();
+        let _ = d.process(event(FILE_A, 10, LogLevel::Info, "msg"));
+        let _ = d.process(event(FILE_A, 10, LogLevel::Info, "msg"));
+        let _ = d.flush();
+        // Second flush should find nothing pending.
+        assert!(d.flush().is_none());
+    }
+}

--- a/rust/crates/sift_stream/src/metrics/mod.rs
+++ b/rust/crates/sift_stream/src/metrics/mod.rs
@@ -1182,35 +1182,35 @@ mod tests {
             grpc_status_counts: [
                 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
             ],
-            ingestion_channel_depth: 30,
-            backup_channel_depth: 31,
-            logs_dropped_channel_full: 32,
-            log_channel_depth: 33,
+            ingestion_channel_depth: 31,
+            backup_channel_depth: 32,
+            logs_dropped_channel_full: 33,
+            log_channel_depth: 34,
             checkpoint: CheckpointMetricsSnapshot {
-                checkpoint_count: 32,
-                failed_checkpoint_count: 33,
-                checkpoint_timer_reached_cnt: 34,
-                checkpoint_manually_reached_cnt: 35,
-                cur_elapsed_secs: 36.0,
-                cur_messages_sent: 37,
-                cur_message_rate: 38.0,
-                cur_bytes_sent: 39,
-                cur_byte_rate: 40.0,
+                checkpoint_count: 35,
+                failed_checkpoint_count: 36,
+                checkpoint_timer_reached_cnt: 37,
+                checkpoint_manually_reached_cnt: 38,
+                cur_elapsed_secs: 39.0,
+                cur_messages_sent: 40,
+                cur_message_rate: 41.0,
+                cur_bytes_sent: 42,
+                cur_byte_rate: 43.0,
             },
             backups: BackupMetricsSnapshot {
-                cur_checkpoint_file_count: 41,
-                cur_checkpoint_cur_file_size: 42,
-                cur_checkpoint_bytes: 43,
-                cur_checkpoint_messages: 44,
-                total_file_count: 45,
-                total_bytes: 46,
-                total_messages: 47,
+                cur_checkpoint_file_count: 44,
+                cur_checkpoint_cur_file_size: 45,
+                cur_checkpoint_bytes: 46,
+                cur_checkpoint_messages: 47,
+                total_file_count: 48,
+                total_bytes: 49,
+                total_messages: 50,
                 committed_message_id: 0,
                 queued_checkpoints: 0,
                 queued_file_ctxs: 0,
-                files_pending_ingestion: 48,
-                files_ingested: 49,
-                cur_ingest_retries: 50,
+                files_pending_ingestion: 51,
+                files_ingested: 52,
+                cur_ingest_retries: 53,
             },
         };
 
@@ -1255,15 +1255,15 @@ mod tests {
         assert_val!("cur_retry_count", Type::Uint64(12));
         assert_val!("grpc_status_counts.ok", Type::Uint64(13));
         assert_val!("grpc_status_counts.unauthenticated", Type::Uint64(29));
-        assert_val!("ingestion_channel_depth", Type::Uint64(30));
-        assert_val!("backup_channel_depth", Type::Uint64(31));
-        assert_val!("logs_dropped_channel_full", Type::Uint64(32));
-        assert_val!("log_channel_depth", Type::Uint64(33));
-        assert_val!("checkpoint.count", Type::Uint64(32));
-        assert_val!("checkpoint.cur_elapsed_secs", Type::Double(36.0));
-        assert_val!("checkpoint.cur_message_rate", Type::Double(38.0));
-        assert_val!("backups.cur_checkpoint_file_count", Type::Uint64(41));
-        assert_val!("backups.files_ingested", Type::Uint64(49));
-        assert_val!("backups.cur_ingest_retries", Type::Uint64(50));
+        assert_val!("ingestion_channel_depth", Type::Uint64(31));
+        assert_val!("backup_channel_depth", Type::Uint64(32));
+        assert_val!("logs_dropped_channel_full", Type::Uint64(33));
+        assert_val!("log_channel_depth", Type::Uint64(34));
+        assert_val!("checkpoint.count", Type::Uint64(35));
+        assert_val!("checkpoint.cur_elapsed_secs", Type::Double(39.0));
+        assert_val!("checkpoint.cur_message_rate", Type::Double(41.0));
+        assert_val!("backups.cur_checkpoint_file_count", Type::Uint64(44));
+        assert_val!("backups.files_ingested", Type::Uint64(52));
+        assert_val!("backups.cur_ingest_retries", Type::Uint64(53));
     }
 }

--- a/rust/crates/sift_stream/src/metrics/mod.rs
+++ b/rust/crates/sift_stream/src/metrics/mod.rs
@@ -129,6 +129,10 @@ pub struct SiftStreamMetricsSnapshot {
     pub ingestion_channel_depth: u64,
     /// Depth of the backup channel
     pub backup_channel_depth: u64,
+    /// Total log events dropped because the log channel was full
+    pub logs_dropped_channel_full: u64,
+    /// Current depth of the log event channel
+    pub log_channel_depth: u64,
     /// Checkpoint-specific metrics
     pub checkpoint: CheckpointMetricsSnapshot,
     /// Backup-specific metrics
@@ -392,6 +396,8 @@ pub struct SiftStreamMetrics {
     pub(crate) grpc_status_counts: [U64Counter; 18],
     pub(crate) ingestion_channel_depth: U64Signal,
     pub(crate) backup_channel_depth: U64Signal,
+    pub(crate) logs_dropped_channel_full: U64Counter,
+    pub(crate) log_channel_depth: U64Signal,
     pub(crate) checkpoint: CheckpointMetrics,
     pub(crate) backups: BackupMetrics,
 }
@@ -418,6 +424,8 @@ impl SiftStreamMetrics {
         let cur_retry_count = self.cur_retry_count.get();
         let ingestion_channel_depth = self.ingestion_channel_depth.get();
         let backup_channel_depth = self.backup_channel_depth.get();
+        let logs_dropped_channel_full = self.logs_dropped_channel_full.get();
+        let log_channel_depth = self.log_channel_depth.get();
 
         let stats = StreamingStats::calculate(self.creation_time, messages_sent, bytes_sent);
 
@@ -437,6 +445,8 @@ impl SiftStreamMetrics {
             grpc_status_counts: std::array::from_fn(|i| self.grpc_status_counts[i].get()),
             ingestion_channel_depth,
             backup_channel_depth,
+            logs_dropped_channel_full,
+            log_channel_depth,
             checkpoint: self.checkpoint.snapshot(),
             backups: self.backups.snapshot(),
         }
@@ -636,6 +646,18 @@ impl SiftStreamMetricsSnapshot {
             ChannelConfig {
                 name: format!("{channel_prefix}.backup_channel_depth"),
                 description: "Backup channel depth".into(),
+                data_type: ChannelDataType::Uint64.into(),
+                ..Default::default()
+            },
+            ChannelConfig {
+                name: format!("{channel_prefix}.logs_dropped_channel_full"),
+                description: "Log events dropped because the log channel was full".into(),
+                data_type: ChannelDataType::Uint64.into(),
+                ..Default::default()
+            },
+            ChannelConfig {
+                name: format!("{channel_prefix}.log_channel_depth"),
+                description: "Current depth of the log event channel".into(),
                 data_type: ChannelDataType::Uint64.into(),
                 ..Default::default()
             },
@@ -858,6 +880,11 @@ impl SiftStreamMetricsSnapshot {
             self.ingestion_channel_depth,
         )?;
         builder.set(indices.backup_channel_depth, self.backup_channel_depth)?;
+        builder.set(
+            indices.logs_dropped_channel_full,
+            self.logs_dropped_channel_full,
+        )?;
+        builder.set(indices.log_channel_depth, self.log_channel_depth)?;
         builder.set(indices.checkpoint.count, self.checkpoint.checkpoint_count)?;
         builder.set(
             indices.checkpoint.failed_count,
@@ -994,6 +1021,8 @@ pub(crate) struct MetricsFlowIndices {
     pub grpc_status_counts: MetricsGrpcStatusIndices,
     pub ingestion_channel_depth: ChannelIndex,
     pub backup_channel_depth: ChannelIndex,
+    pub logs_dropped_channel_full: ChannelIndex,
+    pub log_channel_depth: ChannelIndex,
     pub checkpoint: MetricsCheckpointFlowIndices,
     pub backups: MetricsBackupFlowIndices,
 }
@@ -1049,6 +1078,8 @@ impl MetricsFlowIndices {
             },
             ingestion_channel_depth: idx!("ingestion_channel_depth"),
             backup_channel_depth: idx!("backup_channel_depth"),
+            logs_dropped_channel_full: idx!("logs_dropped_channel_full"),
+            log_channel_depth: idx!("log_channel_depth"),
             checkpoint: MetricsCheckpointFlowIndices {
                 count: idx!("checkpoint.count"),
                 failed_count: idx!("checkpoint.failed_count"),
@@ -1092,6 +1123,8 @@ impl Default for SiftStreamMetrics {
             grpc_status_counts: Default::default(),
             ingestion_channel_depth: U64Signal::default(),
             backup_channel_depth: U64Signal::default(),
+            logs_dropped_channel_full: U64Counter::default(),
+            log_channel_depth: U64Signal::default(),
             checkpoint: CheckpointMetrics::default(),
             backups: BackupMetrics::default(),
         }
@@ -1151,6 +1184,8 @@ mod tests {
             ],
             ingestion_channel_depth: 30,
             backup_channel_depth: 31,
+            logs_dropped_channel_full: 32,
+            log_channel_depth: 33,
             checkpoint: CheckpointMetricsSnapshot {
                 checkpoint_count: 32,
                 failed_checkpoint_count: 33,
@@ -1222,6 +1257,8 @@ mod tests {
         assert_val!("grpc_status_counts.unauthenticated", Type::Uint64(29));
         assert_val!("ingestion_channel_depth", Type::Uint64(30));
         assert_val!("backup_channel_depth", Type::Uint64(31));
+        assert_val!("logs_dropped_channel_full", Type::Uint64(32));
+        assert_val!("log_channel_depth", Type::Uint64(33));
         assert_val!("checkpoint.count", Type::Uint64(32));
         assert_val!("checkpoint.cur_elapsed_secs", Type::Double(36.0));
         assert_val!("checkpoint.cur_message_rate", Type::Double(38.0));

--- a/rust/crates/sift_stream/src/stream/builder.rs
+++ b/rust/crates/sift_stream/src/stream/builder.rs
@@ -12,6 +12,7 @@ mod config_loader;
 use crate::{
     FlowDescriptor,
     backup::{disk::DiskBackupPolicy, sanitize_name},
+    logging::{LogEvent, LogLevel},
     metrics::SiftStreamMetrics,
     stream::{
         mode::ingestion_config::IngestionConfigEncoder,
@@ -32,6 +33,9 @@ use sift_rs::{
 };
 use std::{sync::Arc, time::Duration};
 use uuid::Uuid;
+
+/// Capacity of the bounded log event channel created per stream.
+const LOG_CHANNEL_CAPACITY: usize = 512;
 
 /// The default checkpoint interval (1 minute) to use if left unspecified.
 pub const DEFAULT_CHECKPOINT_INTERVAL: Duration = Duration::from_secs(60);
@@ -137,6 +141,10 @@ impl SiftStreamBuilder {
             asset_metadata: None,
             run: None,
             run_id: None,
+            log_level_filter: LogLevel::default(),
+            #[cfg(feature = "tracing")]
+            scoped_dispatch_base: None,
+            disable_scoped_dispatch: false,
         }
     }
 }
@@ -158,6 +166,15 @@ pub struct StreamConfigBuilder {
     pub(crate) asset_metadata: Option<Vec<MetadataValue>>,
     pub(crate) run: Option<RunForm>,
     pub(crate) run_id: Option<String>,
+    /// Minimum log level forwarded to Sift via the telemetry layer. Defaults to `Info`.
+    pub(crate) log_level_filter: LogLevel,
+    /// A pre-built dispatch to use as the forwarding target for the scoped dispatch.
+    /// If `None`, the current global dispatch is captured at build time.
+    #[cfg(feature = "tracing")]
+    pub(crate) scoped_dispatch_base: Option<tracing::Dispatch>,
+    /// When `true`, the scoped dispatch is not created for this stream.
+    /// Set by the internal metrics sub-stream builder to prevent recursive event capture.
+    pub(crate) disable_scoped_dispatch: bool,
 }
 
 impl StreamConfigBuilder {
@@ -184,6 +201,39 @@ impl StreamConfigBuilder {
     /// metadata unchanged.
     pub fn add_asset_metadata(mut self, metadata: Vec<MetadataValue>) -> Self {
         self.asset_metadata = Some(metadata);
+        self
+    }
+
+    /// Sets the minimum log level forwarded to Sift via the internal telemetry layer.
+    ///
+    /// Events below this level are still emitted to the normal tracing subscriber (e.g. the
+    /// user's console logger) but will not be captured for streaming to Sift.
+    /// Defaults to [`LogLevel::Info`](crate::logging::LogLevel::Info).
+    pub fn log_level_filter(mut self, level: LogLevel) -> Self {
+        self.log_level_filter = level;
+        self
+    }
+
+    /// Provide a custom dispatch as the base for the scoped dispatch composition.
+    ///
+    /// The builder will layer `SiftTelemetryLayer` on top of this dispatch when constructing
+    /// the scoped subscriber used by background tasks. If not called, the current global
+    /// dispatch is captured at build time and used as the forwarding target.
+    ///
+    /// Use this to include additional layers (e.g. your own telemetry) alongside
+    /// sift_stream's internal telemetry layer.
+    #[cfg(feature = "tracing")]
+    pub fn with_scoped_dispatch_base(mut self, dispatch: tracing::Dispatch) -> Self {
+        self.scoped_dispatch_base = Some(dispatch);
+        self
+    }
+
+    /// Disable scoped dispatch entirely for this stream.
+    ///
+    /// Used internally when constructing the metrics sub-stream to prevent
+    /// `SiftTelemetryLayer` from capturing the metrics infrastructure's own events.
+    pub(crate) fn disable_scoped_dispatch(mut self) -> Self {
+        self.disable_scoped_dispatch = true;
         self
     }
 
@@ -311,6 +361,9 @@ impl LiveOnlyBuilder {
             control_channel_capacity: self.control_channel_capacity,
             metrics_streaming_interval: self.metrics_streaming_interval,
             retry_policy: self.retry_policy,
+            #[cfg(feature = "tracing")]
+            scoped_dispatch: setup.scoped_dispatch,
+            log_rx: setup.log_rx,
         };
 
         SiftStream::new_live_only(
@@ -458,6 +511,9 @@ impl LiveWithBackupsBuilder {
             ingestion_data_channel_capacity: self.ingestion_data_channel_capacity,
             backup_data_channel_capacity: self.backup_data_channel_capacity,
             metrics_streaming_interval: self.metrics_streaming_interval,
+            #[cfg(feature = "tracing")]
+            scoped_dispatch: setup.scoped_dispatch,
+            log_rx: setup.log_rx,
         };
 
         SiftStream::new_live_with_backups(
@@ -567,6 +623,13 @@ struct CommonSetup {
     metrics: Arc<SiftStreamMetrics>,
     session_name: String,
     sift_stream_id: Uuid,
+    /// Scoped dispatch to install on spawned background task futures.
+    /// `None` when the `tracing` feature is disabled or `disable_scoped_dispatch` was set.
+    #[cfg(feature = "tracing")]
+    scoped_dispatch: Option<tracing::Dispatch>,
+    /// Receiver for log events captured by the scoped dispatch.
+    /// `None` when the `tracing` feature is disabled or `disable_scoped_dispatch` was set.
+    log_rx: Option<async_channel::Receiver<LogEvent>>,
 }
 
 /// Performs setup steps common to all mode builders:
@@ -652,6 +715,32 @@ async fn setup_common(base: StreamConfigBuilder) -> Result<CommonSetup> {
     let session_name = format!("stream.{}.{}", asset_name, ingestion_config.client_key);
     let sift_stream_id = Uuid::new_v4();
 
+    // Build the scoped dispatch and log channel (tracing feature only).
+    #[cfg(feature = "tracing")]
+    let (scoped_dispatch, log_rx) = {
+        use tracing_subscriber::layer::SubscriberExt;
+        if base.disable_scoped_dispatch {
+            (None, None)
+        } else {
+            let (log_tx, log_rx) = async_channel::bounded::<LogEvent>(LOG_CHANNEL_CAPACITY);
+            let base_dispatch = base
+                .scoped_dispatch_base
+                .unwrap_or_else(|| tracing::dispatcher::get_default(|d| d.clone()));
+            let subscriber = tracing_subscriber::registry()
+                .with(crate::telemetry::SiftTelemetryLayer::new(
+                    log_tx,
+                    base.log_level_filter,
+                    metrics.clone(),
+                ))
+                .with(crate::telemetry::DispatchForwardingLayer(base_dispatch));
+            let dispatch = tracing::Dispatch::new(subscriber);
+            (Some(dispatch), Some(log_rx))
+        }
+    };
+
+    #[cfg(not(feature = "tracing"))]
+    let log_rx: Option<async_channel::Receiver<LogEvent>> = None;
+
     Ok(CommonSetup {
         setup_channel,
         ingestion_channel,
@@ -662,6 +751,9 @@ async fn setup_common(base: StreamConfigBuilder) -> Result<CommonSetup> {
         metrics,
         session_name,
         sift_stream_id,
+        #[cfg(feature = "tracing")]
+        scoped_dispatch,
+        log_rx,
     })
 }
 

--- a/rust/crates/sift_stream/src/stream/mode/file_backup.rs
+++ b/rust/crates/sift_stream/src/stream/mode/file_backup.rs
@@ -326,6 +326,7 @@ impl FileBackup {
                     session_name.clone(),
                     interval,
                     metrics_clone,
+                    None,
                 )
                 .await?;
 

--- a/rust/crates/sift_stream/src/stream/tasks/builder.rs
+++ b/rust/crates/sift_stream/src/stream/tasks/builder.rs
@@ -1,6 +1,7 @@
 use crate::{
     RetryPolicy,
     backup::disk::{AsyncBackupsManager, BackupIngestTask},
+    logging::LogEvent,
     metrics::SiftStreamMetrics,
     stream::tasks::{
         ControlMessage, DataMessage, RecoveryConfig,
@@ -26,6 +27,11 @@ pub(crate) struct LiveOnlyTaskConfig {
     pub(crate) control_channel_capacity: usize,
     pub(crate) retry_policy: RetryPolicy,
     pub(crate) metrics_streaming_interval: Option<Duration>,
+    /// Scoped dispatch to wrap spawned futures. `None` disables scoped dispatch.
+    #[cfg(feature = "tracing")]
+    pub(crate) scoped_dispatch: Option<tracing::Dispatch>,
+    /// Log event receiver forwarded to the metrics streaming task.
+    pub(crate) log_rx: Option<async_channel::Receiver<LogEvent>>,
 }
 
 /// Task handles and channel senders returned for LiveStreamingOnly mode.
@@ -52,6 +58,11 @@ pub(crate) struct LiveWithBackupsTaskConfig {
     pub(crate) retry_policy: RetryPolicy,
     pub(crate) recovery_config: RecoveryConfig,
     pub(crate) metrics_streaming_interval: Option<Duration>,
+    /// Scoped dispatch to wrap spawned futures. `None` disables scoped dispatch.
+    #[cfg(feature = "tracing")]
+    pub(crate) scoped_dispatch: Option<tracing::Dispatch>,
+    /// Log event receiver forwarded to the metrics streaming task.
+    pub(crate) log_rx: Option<async_channel::Receiver<LogEvent>>,
 }
 
 /// Task handles and channel senders returned for LiveStreamingWithBackups mode.
@@ -63,6 +74,21 @@ pub(crate) struct LiveWithBackupsTasks {
     pub(crate) backup_manager: JoinHandle<Result<()>>,
     pub(crate) reingestion: JoinHandle<Result<()>>,
     pub(crate) metrics_streaming: Option<JoinHandle<Result<()>>>,
+}
+
+/// Wrap a future in a scoped dispatch when the `tracing` feature is enabled and a dispatch is
+/// present; otherwise fall back to a plain `tokio::spawn`.
+#[cfg(feature = "tracing")]
+fn spawn_with_dispatch<F>(future: F, dispatch: &Option<tracing::Dispatch>) -> JoinHandle<F::Output>
+where
+    F: std::future::Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    use tracing::instrument::WithSubscriber;
+    match dispatch {
+        Some(d) => tokio::spawn(future.with_subscriber(d.clone())),
+        None => tokio::spawn(future),
+    }
 }
 
 pub(crate) struct TaskBuilder;
@@ -88,6 +114,17 @@ impl TaskBuilder {
         let control_rx = control_tx.subscribe();
         let ingestion_task =
             IngestionTask::new(control_tx.clone(), control_rx, ingestion_rx, task_config);
+
+        #[cfg(feature = "tracing")]
+        let ingestion = spawn_with_dispatch(
+            async move {
+                let mut task = ingestion_task;
+                task.run().await
+            },
+            &config.scoped_dispatch,
+        );
+
+        #[cfg(not(feature = "tracing"))]
         let ingestion = tokio::spawn(async move {
             let mut task = ingestion_task;
             task.run().await
@@ -100,9 +137,17 @@ impl TaskBuilder {
                 config.session_name.clone(),
                 interval,
                 config.metrics,
+                config.log_rx,
             )
             .await?;
-            Some(tokio::spawn(task.run()))
+
+            #[cfg(feature = "tracing")]
+            let handle = spawn_with_dispatch(task.run(), &config.scoped_dispatch);
+
+            #[cfg(not(feature = "tracing"))]
+            let handle = tokio::spawn(task.run());
+
+            Some(handle)
         } else {
             None
         };
@@ -143,14 +188,22 @@ impl TaskBuilder {
         .await?;
 
         let sift_stream_id = config.sift_stream_id;
-        let backup_manager = tokio::spawn(async move {
-            #[cfg(feature = "tracing")]
-            tracing::info!(
-                sift_stream_id = %sift_stream_id,
-                "backup manager task started"
-            );
-            backup_manager_task.run().await
-        });
+
+        #[cfg(feature = "tracing")]
+        let backup_manager = spawn_with_dispatch(
+            async move {
+                #[cfg(feature = "tracing")]
+                tracing::info!(
+                    sift_stream_id = %sift_stream_id,
+                    "backup manager task started"
+                );
+                backup_manager_task.run().await
+            },
+            &config.scoped_dispatch,
+        );
+
+        #[cfg(not(feature = "tracing"))]
+        let backup_manager = tokio::spawn(async move { backup_manager_task.run().await });
 
         let ingestion_control_tx = control_tx.clone();
         let ingestion_control_rx = ingestion_control_tx.subscribe();
@@ -169,14 +222,22 @@ impl TaskBuilder {
             ingestion_rx.clone(),
             task_config,
         );
-        let ingestion = tokio::spawn(async move {
-            #[cfg(feature = "tracing")]
-            tracing::info!(
-                sift_stream_id = %sift_stream_id,
-                "ingestion task started"
-            );
-            ingestion_task.run().await
-        });
+
+        #[cfg(feature = "tracing")]
+        let ingestion = spawn_with_dispatch(
+            async move {
+                #[cfg(feature = "tracing")]
+                tracing::info!(
+                    sift_stream_id = %sift_stream_id,
+                    "ingestion task started"
+                );
+                ingestion_task.run().await
+            },
+            &config.scoped_dispatch,
+        );
+
+        #[cfg(not(feature = "tracing"))]
+        let ingestion = tokio::spawn(async move { ingestion_task.run().await });
 
         let reingestion_control_tx = control_tx.clone();
         let reingest_retry_policy = RetryPolicy {
@@ -193,14 +254,22 @@ impl TaskBuilder {
             config.recovery_config.backup_policy.retain_backups,
             config.metrics.clone(),
         );
-        let reingestion = tokio::spawn(async move {
-            #[cfg(feature = "tracing")]
-            tracing::info!(
-                sift_stream_id = %sift_stream_id,
-                "backup re-ingestion task started"
-            );
-            reingestion_task.run().await
-        });
+
+        #[cfg(feature = "tracing")]
+        let reingestion = spawn_with_dispatch(
+            async move {
+                #[cfg(feature = "tracing")]
+                tracing::info!(
+                    sift_stream_id = %sift_stream_id,
+                    "backup re-ingestion task started"
+                );
+                reingestion_task.run().await
+            },
+            &config.scoped_dispatch,
+        );
+
+        #[cfg(not(feature = "tracing"))]
+        let reingestion = tokio::spawn(async move { reingestion_task.run().await });
 
         let metrics_streaming = if let Some(interval) = config.metrics_streaming_interval {
             let metrics_task = MetricsStreamingTask::new(
@@ -209,16 +278,27 @@ impl TaskBuilder {
                 config.session_name.clone(),
                 interval,
                 config.metrics.clone(),
+                config.log_rx,
             )
             .await?;
-            Some(tokio::spawn(async move {
-                #[cfg(feature = "tracing")]
-                tracing::info!(
-                    sift_stream_id = %sift_stream_id,
-                    "metrics streaming task started"
-                );
-                metrics_task.run().await
-            }))
+
+            #[cfg(feature = "tracing")]
+            let handle = spawn_with_dispatch(
+                async move {
+                    #[cfg(feature = "tracing")]
+                    tracing::info!(
+                        sift_stream_id = %sift_stream_id,
+                        "metrics streaming task started"
+                    );
+                    metrics_task.run().await
+                },
+                &config.scoped_dispatch,
+            );
+
+            #[cfg(not(feature = "tracing"))]
+            let handle = tokio::spawn(async move { metrics_task.run().await });
+
+            Some(handle)
         } else {
             None
         };

--- a/rust/crates/sift_stream/src/stream/tasks/metrics.rs
+++ b/rust/crates/sift_stream/src/stream/tasks/metrics.rs
@@ -33,10 +33,11 @@ struct LogFlowIndices {
 }
 
 impl LogFlowIndices {
-    fn new(descriptor: &FlowDescriptor<String>) -> Result<Self> {
+    fn new(descriptor: &FlowDescriptor<String>, channel_prefix: &str) -> Result<Self> {
         let m = descriptor.mapping();
-        let get = |key: &str| -> Result<ChannelIndex> {
-            m.get(key).copied().ok_or_else(|| {
+        let get = |suffix: &str| -> Result<ChannelIndex> {
+            let key = format!("{channel_prefix}.{suffix}");
+            m.get(&key).copied().ok_or_else(|| {
                 Error::new_msg(
                     ErrorKind::NotFoundError,
                     format!("log channel '{key}' not found in flow descriptor"),
@@ -44,30 +45,32 @@ impl LogFlowIndices {
             })
         };
         Ok(Self {
-            level: get("level")?,
-            target: get("target")?,
-            message: get("message")?,
+            level: get("tracing_event.level")?,
+            target: get("tracing_event.target")?,
+            message: get("tracing_event.message")?,
         })
     }
 }
 
-/// Returns the channel configs for the log event flow.
-fn log_channel_configs() -> Vec<ChannelConfig> {
+/// Returns the channel configs for the log event flow, namespaced under `channel_prefix`.
+///
+/// Channel names follow the same `{prefix}.{field}` convention used by the metrics flow.
+fn log_channel_configs(channel_prefix: &str) -> Vec<ChannelConfig> {
     vec![
         ChannelConfig {
-            name: "level".into(),
+            name: format!("{channel_prefix}.tracing_event.level"),
             description: "Log level (ERROR, WARN, INFO, DEBUG, TRACE)".into(),
             data_type: ChannelDataType::String.into(),
             ..Default::default()
         },
         ChannelConfig {
-            name: "target".into(),
+            name: format!("{channel_prefix}.tracing_event.target"),
             description: "Source module target of the log event".into(),
             data_type: ChannelDataType::String.into(),
             ..Default::default()
         },
         ChannelConfig {
-            name: "message".into(),
+            name: format!("{channel_prefix}.tracing_event.message"),
             description: "Log message, including any structured key-value fields".into(),
             data_type: ChannelDataType::String.into(),
             ..Default::default()
@@ -136,7 +139,7 @@ impl MetricsStreamingTask {
             c.name.hash(&mut hasher);
         });
         if log_rx.is_some() {
-            log_channel_configs().iter().for_each(|c| {
+            log_channel_configs(&session_name).iter().for_each(|c| {
                 c.name.hash(&mut hasher);
             });
         }
@@ -155,7 +158,7 @@ impl MetricsStreamingTask {
         if log_rx.is_some() {
             flows.push(FlowConfig {
                 name: LOG_FLOW_NAME.to_string(),
-                channels: log_channel_configs(),
+                channels: log_channel_configs(&session_name),
             });
         }
 
@@ -196,7 +199,7 @@ impl MetricsStreamingTask {
         let (log_flow_descriptor, log_flow_indices, log_rx) = match log_rx {
             Some(rx) => {
                 let desc = stream.get_flow_descriptor(LOG_FLOW_NAME)?;
-                let indices = LogFlowIndices::new(&desc)?;
+                let indices = LogFlowIndices::new(&desc, &session_name)?;
                 (Some(desc), Some(indices), Some(rx))
             }
             None => (None, None, None),
@@ -331,12 +334,14 @@ mod tests {
         ingest::v1::ingest_with_config_data_channel_value::Type, ingestion_configs::v2::FlowConfig,
     };
 
+    const TEST_PREFIX: &str = "stream.test_asset.test_key";
+
     fn make_log_descriptor() -> FlowDescriptor<String> {
         FlowDescriptor::try_from((
             "test-ingestion-config-id",
             FlowConfig {
                 name: LOG_FLOW_NAME.to_string(),
-                channels: log_channel_configs(),
+                channels: log_channel_configs(TEST_PREFIX),
             },
         ))
         .unwrap()
@@ -354,16 +359,23 @@ mod tests {
         }
     }
 
-    // ── log_channel_configs ───────────────────────────────────────────────────
-
     #[test]
     fn log_channel_configs_returns_three_string_channels() {
-        let configs = log_channel_configs();
+        let configs = log_channel_configs(TEST_PREFIX);
         assert_eq!(configs.len(), 3);
         let names: Vec<&str> = configs.iter().map(|c| c.name.as_str()).collect();
-        assert!(names.contains(&"level"), "missing 'level' channel");
-        assert!(names.contains(&"target"), "missing 'target' channel");
-        assert!(names.contains(&"message"), "missing 'message' channel");
+        assert!(
+            names.contains(&"stream.test_asset.test_key.tracing_event.level"),
+            "missing prefixed 'level' channel; got: {names:?}"
+        );
+        assert!(
+            names.contains(&"stream.test_asset.test_key.tracing_event.target"),
+            "missing prefixed 'target' channel; got: {names:?}"
+        );
+        assert!(
+            names.contains(&"stream.test_asset.test_key.tracing_event.message"),
+            "missing prefixed 'message' channel; got: {names:?}"
+        );
         for c in &configs {
             assert_eq!(
                 c.data_type,
@@ -374,29 +386,27 @@ mod tests {
         }
     }
 
-    // ── LogFlowIndices ────────────────────────────────────────────────────────
-
     #[test]
     fn log_flow_indices_new_succeeds_with_complete_descriptor() {
         let descriptor = make_log_descriptor();
-        assert!(LogFlowIndices::new(&descriptor).is_ok());
+        assert!(LogFlowIndices::new(&descriptor, TEST_PREFIX).is_ok());
     }
 
     #[test]
     fn log_flow_indices_new_fails_when_channel_missing() {
-        // Descriptor with only "level" and "target" — "message" is absent.
+        // Descriptor with only the prefixed "level" and "target" — "message" is absent.
         let partial_descriptor = FlowDescriptor::try_from((
             "test-ingestion-config-id",
             FlowConfig {
                 name: LOG_FLOW_NAME.to_string(),
                 channels: vec![
                     ChannelConfig {
-                        name: "level".into(),
+                        name: format!("{TEST_PREFIX}.tracing_event.level"),
                         data_type: ChannelDataType::String as i32,
                         ..Default::default()
                     },
                     ChannelConfig {
-                        name: "target".into(),
+                        name: format!("{TEST_PREFIX}.tracing_event.target"),
                         data_type: ChannelDataType::String as i32,
                         ..Default::default()
                     },
@@ -404,15 +414,13 @@ mod tests {
             },
         ))
         .unwrap();
-        assert!(LogFlowIndices::new(&partial_descriptor).is_err());
+        assert!(LogFlowIndices::new(&partial_descriptor, TEST_PREFIX).is_err());
     }
-
-    // ── encode_log_event ──────────────────────────────────────────────────────
 
     #[test]
     fn encode_log_event_no_fields_leaves_message_unchanged() {
         let descriptor = make_log_descriptor();
-        let indices = LogFlowIndices::new(&descriptor).unwrap();
+        let indices = LogFlowIndices::new(&descriptor, TEST_PREFIX).unwrap();
         let event = make_event("something happened", vec![]);
         let request = encode_log_event(&event, &indices, &descriptor).request(TimeValue::default());
 
@@ -425,7 +433,7 @@ mod tests {
     #[test]
     fn encode_log_event_appends_fields_as_key_value_pairs() {
         let descriptor = make_log_descriptor();
-        let indices = LogFlowIndices::new(&descriptor).unwrap();
+        let indices = LogFlowIndices::new(&descriptor, TEST_PREFIX).unwrap();
         let event = make_event(
             "base message",
             vec![
@@ -444,7 +452,7 @@ mod tests {
     #[test]
     fn encode_log_event_sets_level_and_target_channels() {
         let descriptor = make_log_descriptor();
-        let indices = LogFlowIndices::new(&descriptor).unwrap();
+        let indices = LogFlowIndices::new(&descriptor, TEST_PREFIX).unwrap();
         let event = make_event("msg", vec![]);
         let request = encode_log_event(&event, &indices, &descriptor).request(TimeValue::default());
 

--- a/rust/crates/sift_stream/src/stream/tasks/metrics.rs
+++ b/rust/crates/sift_stream/src/stream/tasks/metrics.rs
@@ -1,11 +1,15 @@
 use crate::{
-    FlowBuilder, FlowConfig, FlowDescriptor, IngestionConfigForm, LiveStreamingWithBackups,
-    SiftStream, SiftStreamBuilder,
+    FlowBuilder, FlowConfig, FlowDescriptor, IngestionConfigForm, LiveStreamingOnly, SiftStream,
+    SiftStreamBuilder,
+    logging::{DeduplicatorOutput, LogDeduplicator, LogEvent},
     metrics::{MetricsFlowIndices, SiftStreamMetrics, SiftStreamMetricsSnapshot},
-    stream::{mode::ingestion_config::IngestionConfigEncoder, tasks::ControlMessage},
+    stream::{
+        flow::ChannelIndex, mode::ingestion_config::IngestionConfigEncoder, tasks::ControlMessage,
+    },
 };
 use sift_connect::SiftChannel;
 use sift_error::prelude::*;
+use sift_rs::{common::r#type::v1::ChannelDataType, ingestion_configs::v2::ChannelConfig};
 use std::{sync::Arc, time::Duration};
 use tokio::{select, sync::broadcast};
 
@@ -18,13 +22,96 @@ const METRICS_STREAMING_INGESTION_CONFIG_CLIENT_KEY: &str = "sift-stream-metrics
 /// The flow name used for sift_stream metrics flow config.
 const METRICS_STREAMING_FLOW_NAME: &str = "sift-stream-metrics-flow";
 
+/// The flow name used for sift_stream log events.
+const LOG_FLOW_NAME: &str = "sift-stream-logs";
+
+/// Pre-resolved [`ChannelIndex`] values for the log event flow channels.
+struct LogFlowIndices {
+    level: ChannelIndex,
+    target: ChannelIndex,
+    message: ChannelIndex,
+}
+
+impl LogFlowIndices {
+    fn new(descriptor: &FlowDescriptor<String>) -> Result<Self> {
+        let m = descriptor.mapping();
+        let get = |key: &str| -> Result<ChannelIndex> {
+            m.get(key).copied().ok_or_else(|| {
+                Error::new_msg(
+                    ErrorKind::NotFoundError,
+                    format!("log channel '{key}' not found in flow descriptor"),
+                )
+            })
+        };
+        Ok(Self {
+            level: get("level")?,
+            target: get("target")?,
+            message: get("message")?,
+        })
+    }
+}
+
+/// Returns the channel configs for the log event flow.
+fn log_channel_configs() -> Vec<ChannelConfig> {
+    vec![
+        ChannelConfig {
+            name: "level".into(),
+            description: "Log level (ERROR, WARN, INFO, DEBUG, TRACE)".into(),
+            data_type: ChannelDataType::String.into(),
+            ..Default::default()
+        },
+        ChannelConfig {
+            name: "target".into(),
+            description: "Source module target of the log event".into(),
+            data_type: ChannelDataType::String.into(),
+            ..Default::default()
+        },
+        ChannelConfig {
+            name: "message".into(),
+            description: "Log message, including any structured key-value fields".into(),
+            data_type: ChannelDataType::String.into(),
+            ..Default::default()
+        },
+    ]
+}
+
+/// Build a [`FlowBuilder`] for a single log event.
+///
+/// Structured key-value fields are appended to the message as `key=value` pairs.
+fn encode_log_event<'a>(
+    event: &LogEvent,
+    indices: &LogFlowIndices,
+    descriptor: &'a FlowDescriptor<String>,
+) -> FlowBuilder<'a, String> {
+    let mut builder = FlowBuilder::new(descriptor);
+    let _ = builder.set(indices.level, event.level.as_str());
+    let _ = builder.set(indices.target, event.target);
+
+    let message = if event.fields.is_empty() {
+        event.message.clone()
+    } else {
+        let fields_str = event
+            .fields
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        format!("{} {fields_str}", event.message)
+    };
+    let _ = builder.set(indices.message, message);
+    builder
+}
+
 pub(crate) struct MetricsStreamingTask {
-    stream: SiftStream<IngestionConfigEncoder, LiveStreamingWithBackups>,
+    stream: SiftStream<IngestionConfigEncoder, LiveStreamingOnly>,
     control_rx: broadcast::Receiver<ControlMessage>,
     interval: Duration,
     metrics: Arc<SiftStreamMetrics>,
-    flow_descriptor: FlowDescriptor<String>,
+    metrics_flow_descriptor: FlowDescriptor<String>,
     flow_indices: MetricsFlowIndices,
+    log_rx: Option<async_channel::Receiver<LogEvent>>,
+    log_flow_descriptor: Option<FlowDescriptor<String>>,
+    log_flow_indices: Option<LogFlowIndices>,
 }
 
 impl MetricsStreamingTask {
@@ -34,19 +121,25 @@ impl MetricsStreamingTask {
         session_name: String,
         interval: Duration,
         metrics: Arc<SiftStreamMetrics>,
+        log_rx: Option<async_channel::Receiver<LogEvent>>,
     ) -> Result<Self> {
         use std::hash::{Hash, Hasher};
 
-        let channels = SiftStreamMetricsSnapshot::channel_configs(&session_name);
+        let metrics_channels = SiftStreamMetricsSnapshot::channel_configs(&session_name);
 
         // Hash the channel names to create a unique client key for the ingestion config.
         //
-        // Given the same "session_name", which influences the channel names, and the same metrics configuration,
-        // the ingestion config client key should be the same and re-used.
+        // When the log flow is present, its channel names are included so that an ingestion
+        // config with log channels and one without produce distinct client keys.
         let mut hasher = std::hash::DefaultHasher::new();
-        channels.iter().for_each(|channel| {
-            channel.name.hash(&mut hasher);
+        metrics_channels.iter().for_each(|c| {
+            c.name.hash(&mut hasher);
         });
+        if log_rx.is_some() {
+            log_channel_configs().iter().for_each(|c| {
+                c.name.hash(&mut hasher);
+            });
+        }
         let hash_key = hasher.finish();
 
         let client_key = format!(
@@ -54,70 +147,111 @@ impl MetricsStreamingTask {
             METRICS_STREAMING_INGESTION_CONFIG_CLIENT_KEY, hash_key
         );
 
+        let mut flows = vec![FlowConfig {
+            name: METRICS_STREAMING_FLOW_NAME.to_string(),
+            channels: metrics_channels,
+        }];
+
+        if log_rx.is_some() {
+            flows.push(FlowConfig {
+                name: LOG_FLOW_NAME.to_string(),
+                channels: log_channel_configs(),
+            });
+        }
+
         let ingestion_config = IngestionConfigForm {
             asset_name: METRICS_STREAMING_INGESTION_CONFIG_ASSET_NAME.to_string(),
             client_key,
-            flows: vec![FlowConfig {
-                name: METRICS_STREAMING_FLOW_NAME.to_string(),
-                channels: SiftStreamMetricsSnapshot::channel_configs(&session_name),
-            }],
+            flows,
         };
 
-        // Build a new [`SiftStream`] that is responsible for streaming metrics to Sift.
+        // Build a new [`SiftStream`] that is responsible for streaming metrics and logs to Sift.
         //
-        // Most builder parameters are carried over from the main stream being monitored, however,
-        // the differences are noted below:
+        // Differences from the main stream:
+        // - `LiveStreamingOnly` mode: no disk backups or checkpointing, reducing task count and
+        //   I/O paths since observability data is non-critical.
+        // - Channel capacities are substantially lower.
+        // - Metrics streaming interval is `None` to prevent a recursive sub-stream.
+        // - `disable_scoped_dispatch()` prevents `SiftTelemetryLayer` from capturing events
+        //   from this sub-stream's own tasks and causing a recursive capture loop.
+        // - The setup channel is used for all gRPC channels since they are less critical.
         //
-        // - Channel capacities are substantially lower since this stream deals with less throughput.
-        // - Metrics streaming interval is set to `None` to disable streaming.
-        // - The `setup-channel` is used for all gRPC channels in this stream since they are less
-        //   critical and thus can be multiplexed over a single connection.
-        //
-        // NOTE: The build future is boxed/pinned due to async recursion -- generally a sift-stream
-        // instance will be spawning a second sift-stream instance for streaming it's own metrics though
-        // the limit of recursion here is 2 since the metrics-streaming sift-stream doesn't itself
-        // spawn another sift-stream instance. Since this is only done during initialization, it is fine.
+        // NOTE: The build future is boxed/pinned due to async recursion.
         let stream_fut = Box::pin(
             SiftStreamBuilder::from_channel(setup_channel.clone())
                 .ingestion_config(ingestion_config)
-                .live_with_backups()
+                .disable_scoped_dispatch()
+                .live_only()
                 .metrics_streaming_interval(None)
                 .control_channel_capacity(100)
                 .ingestion_data_channel_capacity(1000)
-                .backup_data_channel_capacity(1000)
                 .build(),
         );
 
         let stream = stream_fut.await?;
 
-        let flow_descriptor = stream.get_flow_descriptor(METRICS_STREAMING_FLOW_NAME)?;
-        let flow_indices = MetricsFlowIndices::new(&flow_descriptor, &session_name)?;
+        let metrics_flow_descriptor = stream.get_flow_descriptor(METRICS_STREAMING_FLOW_NAME)?;
+        let flow_indices = MetricsFlowIndices::new(&metrics_flow_descriptor, &session_name)?;
+
+        let (log_flow_descriptor, log_flow_indices, log_rx) = match log_rx {
+            Some(rx) => {
+                let desc = stream.get_flow_descriptor(LOG_FLOW_NAME)?;
+                let indices = LogFlowIndices::new(&desc)?;
+                (Some(desc), Some(indices), Some(rx))
+            }
+            None => (None, None, None),
+        };
 
         Ok(Self {
             stream,
             control_rx,
             interval,
             metrics,
-            flow_descriptor,
+            metrics_flow_descriptor,
             flow_indices,
+            log_rx,
+            log_flow_descriptor,
+            log_flow_indices,
         })
     }
 
     pub(crate) async fn run(mut self) -> Result<()> {
         let mut interval = tokio::time::interval(self.interval);
+        let mut dedup = LogDeduplicator::default();
 
         loop {
             select! {
                 _ = interval.tick() => {
+                    // Update log channel depth metric before taking the snapshot.
+                    if let Some(rx) = &self.log_rx {
+                        self.metrics.log_channel_depth.set(rx.len() as u64);
+                    }
                     let snapshot = self.metrics.snapshot();
-                    let mut builder = FlowBuilder::new(&self.flow_descriptor);
-                    snapshot.populate_flow(&self.flow_indices, &mut builder).map_err(|e| {
-                        Error::new_msg(ErrorKind::StreamError, e.to_string())
-                    })?;
-                    self.stream.send(builder).await.map_err(|e| {
-                        Error::new_msg(ErrorKind::StreamError, e.to_string())
-                    })?;
+                    let mut builder = FlowBuilder::new(&self.metrics_flow_descriptor);
+                    let _ = snapshot.populate_flow(&self.flow_indices, &mut builder);
+                    let _ = self.stream.try_send(builder);
                 }
+
+                log_event = async {
+                    match &self.log_rx {
+                        Some(rx) => rx.recv().await,
+                        None => std::future::pending().await,
+                    }
+                }, if self.log_rx.is_some() => {
+                    if let Ok(event) = log_event {
+                        match dedup.process(event) {
+                            DeduplicatorOutput::Suppress => {}
+                            DeduplicatorOutput::Emit(e) => {
+                                self.send_log_event(e);
+                            }
+                            DeduplicatorOutput::EmitSummaryThenEmit(summary, e) => {
+                                self.send_log_event(summary);
+                                self.send_log_event(e);
+                            }
+                        }
+                    }
+                }
+
                 ctrl_msg = self.control_rx.recv() => {
                     match ctrl_msg {
                         Ok(ControlMessage::Shutdown) => {
@@ -137,6 +271,38 @@ impl MetricsStreamingTask {
             }
         }
 
+        // Flush pending dedup state and drain remaining log events before shutdown.
+        if self.log_flow_descriptor.is_some() {
+            if let Some(summary) = dedup.flush() {
+                self.send_log_event(summary);
+            }
+            // Collect remaining events first to avoid holding a borrow on self.log_rx
+            // while calling send_log_event (which needs &mut self).
+            let remaining: Vec<LogEvent> = match &self.log_rx {
+                Some(rx) => {
+                    let mut events = Vec::new();
+                    while let Ok(event) = rx.try_recv() {
+                        events.push(event);
+                    }
+                    events
+                }
+                None => Vec::new(),
+            };
+            for event in remaining {
+                match dedup.process(event) {
+                    DeduplicatorOutput::Suppress => {}
+                    DeduplicatorOutput::Emit(e) => self.send_log_event(e),
+                    DeduplicatorOutput::EmitSummaryThenEmit(s, e) => {
+                        self.send_log_event(s);
+                        self.send_log_event(e);
+                    }
+                }
+            }
+            if let Some(summary) = dedup.flush() {
+                self.send_log_event(summary);
+            }
+        }
+
         #[cfg(feature = "tracing")]
         tracing::info!("metrics streaming task shutting down");
 
@@ -144,5 +310,153 @@ impl MetricsStreamingTask {
             .finish()
             .await
             .map_err(|e| Error::new(ErrorKind::StreamError, e))
+    }
+
+    /// Encode and non-blockingly send a single log event to the stream.
+    /// Errors (e.g. channel full) are silently discarded — log streaming is best-effort.
+    fn send_log_event(&mut self, event: LogEvent) {
+        if let (Some(desc), Some(indices)) = (&self.log_flow_descriptor, &self.log_flow_indices) {
+            let builder = encode_log_event(&event, indices, desc);
+            let _ = self.stream.try_send(builder);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{TimeValue, logging::LogLevel};
+    use sift_rs::{
+        common::r#type::v1::ChannelDataType,
+        ingest::v1::ingest_with_config_data_channel_value::Type, ingestion_configs::v2::FlowConfig,
+    };
+
+    fn make_log_descriptor() -> FlowDescriptor<String> {
+        FlowDescriptor::try_from((
+            "test-ingestion-config-id",
+            FlowConfig {
+                name: LOG_FLOW_NAME.to_string(),
+                channels: log_channel_configs(),
+            },
+        ))
+        .unwrap()
+    }
+
+    fn make_event(message: &str, fields: Vec<(String, String)>) -> LogEvent {
+        LogEvent {
+            level: LogLevel::Warn,
+            target: "sift_stream::tasks::ingestion",
+            file: "ingestion.rs",
+            line: 42,
+            message: message.to_owned(),
+            fields,
+            timestamp: std::time::SystemTime::now(),
+        }
+    }
+
+    // ── log_channel_configs ───────────────────────────────────────────────────
+
+    #[test]
+    fn log_channel_configs_returns_three_string_channels() {
+        let configs = log_channel_configs();
+        assert_eq!(configs.len(), 3);
+        let names: Vec<&str> = configs.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains(&"level"), "missing 'level' channel");
+        assert!(names.contains(&"target"), "missing 'target' channel");
+        assert!(names.contains(&"message"), "missing 'message' channel");
+        for c in &configs {
+            assert_eq!(
+                c.data_type,
+                ChannelDataType::String as i32,
+                "channel '{}' must be String type",
+                c.name
+            );
+        }
+    }
+
+    // ── LogFlowIndices ────────────────────────────────────────────────────────
+
+    #[test]
+    fn log_flow_indices_new_succeeds_with_complete_descriptor() {
+        let descriptor = make_log_descriptor();
+        assert!(LogFlowIndices::new(&descriptor).is_ok());
+    }
+
+    #[test]
+    fn log_flow_indices_new_fails_when_channel_missing() {
+        // Descriptor with only "level" and "target" — "message" is absent.
+        let partial_descriptor = FlowDescriptor::try_from((
+            "test-ingestion-config-id",
+            FlowConfig {
+                name: LOG_FLOW_NAME.to_string(),
+                channels: vec![
+                    ChannelConfig {
+                        name: "level".into(),
+                        data_type: ChannelDataType::String as i32,
+                        ..Default::default()
+                    },
+                    ChannelConfig {
+                        name: "target".into(),
+                        data_type: ChannelDataType::String as i32,
+                        ..Default::default()
+                    },
+                ],
+            },
+        ))
+        .unwrap();
+        assert!(LogFlowIndices::new(&partial_descriptor).is_err());
+    }
+
+    // ── encode_log_event ──────────────────────────────────────────────────────
+
+    #[test]
+    fn encode_log_event_no_fields_leaves_message_unchanged() {
+        let descriptor = make_log_descriptor();
+        let indices = LogFlowIndices::new(&descriptor).unwrap();
+        let event = make_event("something happened", vec![]);
+        let request = encode_log_event(&event, &indices, &descriptor).request(TimeValue::default());
+
+        assert_eq!(
+            request.channel_values[indices.message.as_usize()].r#type,
+            Some(Type::String("something happened".to_owned()))
+        );
+    }
+
+    #[test]
+    fn encode_log_event_appends_fields_as_key_value_pairs() {
+        let descriptor = make_log_descriptor();
+        let indices = LogFlowIndices::new(&descriptor).unwrap();
+        let event = make_event(
+            "base message",
+            vec![
+                ("key1".to_owned(), "val1".to_owned()),
+                ("key2".to_owned(), "val2".to_owned()),
+            ],
+        );
+        let request = encode_log_event(&event, &indices, &descriptor).request(TimeValue::default());
+
+        assert_eq!(
+            request.channel_values[indices.message.as_usize()].r#type,
+            Some(Type::String("base message key1=val1 key2=val2".to_owned()))
+        );
+    }
+
+    #[test]
+    fn encode_log_event_sets_level_and_target_channels() {
+        let descriptor = make_log_descriptor();
+        let indices = LogFlowIndices::new(&descriptor).unwrap();
+        let event = make_event("msg", vec![]);
+        let request = encode_log_event(&event, &indices, &descriptor).request(TimeValue::default());
+
+        assert_eq!(
+            request.channel_values[indices.level.as_usize()].r#type,
+            Some(Type::String("WARN".to_owned())),
+            "level channel should contain the string representation"
+        );
+        assert_eq!(
+            request.channel_values[indices.target.as_usize()].r#type,
+            Some(Type::String("sift_stream::tasks::ingestion".to_owned())),
+            "target channel should contain the module target"
+        );
     }
 }

--- a/rust/crates/sift_stream/src/telemetry.rs
+++ b/rust/crates/sift_stream/src/telemetry.rs
@@ -1,0 +1,339 @@
+use crate::{
+    logging::{LogEvent, LogLevel},
+    metrics::SiftStreamMetrics,
+};
+use std::sync::Arc;
+
+/// Extracts the event message and structured key-value fields from a tracing event.
+#[derive(Default)]
+pub(crate) struct TelemetryVisitor {
+    pub message: String,
+    pub fields: Vec<(String, String)>,
+}
+
+impl tracing::field::Visit for TelemetryVisitor {
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "message" {
+            self.message = value.to_owned();
+        } else {
+            self.fields
+                .push((field.name().to_owned(), value.to_owned()));
+        }
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        let s = format!("{value:?}");
+        if field.name() == "message" {
+            self.message = s;
+        } else {
+            self.fields.push((field.name().to_owned(), s));
+        }
+    }
+}
+
+/// A `tracing_subscriber` layer that captures events originating from `sift_stream::*` and
+/// forwards them to a bounded channel for later forwarding to Sift.
+///
+/// Installed as part of a scoped dispatch on each background task future so that events
+/// are captured without touching the global subscriber.
+pub(crate) struct SiftTelemetryLayer {
+    tx: async_channel::Sender<LogEvent>,
+    level_filter: LogLevel,
+    metrics: Arc<SiftStreamMetrics>,
+}
+
+impl SiftTelemetryLayer {
+    pub(crate) fn new(
+        tx: async_channel::Sender<LogEvent>,
+        level_filter: LogLevel,
+        metrics: Arc<SiftStreamMetrics>,
+    ) -> Self {
+        Self {
+            tx,
+            level_filter,
+            metrics,
+        }
+    }
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::layer::Layer<S> for SiftTelemetryLayer {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let metadata = event.metadata();
+
+        // Only capture events originating from this crate.
+        if !metadata.target().starts_with("sift_stream") {
+            return;
+        }
+
+        // Level filter: plain comparison, no lock.
+        let level = LogLevel::from(metadata.level());
+        if level > self.level_filter {
+            return;
+        }
+
+        let mut visitor = TelemetryVisitor::default();
+        event.record(&mut visitor);
+
+        let log_event = LogEvent {
+            level,
+            target: metadata.target(),
+            file: metadata.file().unwrap_or(""),
+            line: metadata.line().unwrap_or(0),
+            message: visitor.message,
+            fields: visitor.fields,
+            timestamp: std::time::SystemTime::now(),
+        };
+
+        if self.tx.try_send(log_event).is_err() {
+            self.metrics.logs_dropped_channel_full.increment();
+        }
+    }
+}
+
+/// Forwards `sift_stream::*` events from the scoped dispatch to a captured
+/// `tracing::Dispatch`, typically the global subscriber at stream construction time.
+///
+/// This ensures that sift_stream's own tracing events from background tasks still reach
+/// the user's subscriber (e.g. a console logger) even when those tasks run under a scoped
+/// dispatch.
+///
+/// Only events with a `sift_stream` target prefix are forwarded. Third-party library events
+/// (h2, hyper, tonic, etc.) emitted from within the tasks are intentionally not forwarded:
+/// those were already not reaching user subscribers in the pre-scoped world (tokio spawned
+/// tasks do not propagate thread-local subscribers), so this preserves existing behavior and
+/// avoids unintended side effects such as flooding test subscribers with low-level TRACE spam.
+///
+/// **Limitation**: span lifecycle is not forwarded. This is acceptable for sift_stream's
+/// background tasks which do not create spans.
+pub(crate) struct DispatchForwardingLayer(pub tracing::Dispatch);
+
+impl<S: tracing::Subscriber> tracing_subscriber::layer::Layer<S> for DispatchForwardingLayer {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        // Only forward events originating from this crate to the base subscriber.
+        if event.metadata().target().starts_with("sift_stream") && self.0.enabled(event.metadata())
+        {
+            self.0.event(event);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::SiftStreamMetrics;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicU32, Ordering},
+    };
+    use tracing_subscriber::layer::SubscriberExt;
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn make_layer(
+        capacity: usize,
+        level: LogLevel,
+    ) -> (
+        SiftTelemetryLayer,
+        async_channel::Receiver<LogEvent>,
+        Arc<SiftStreamMetrics>,
+    ) {
+        let (tx, rx) = async_channel::bounded(capacity);
+        let metrics = Arc::new(SiftStreamMetrics::new());
+        let layer = SiftTelemetryLayer::new(tx, level, metrics.clone());
+        (layer, rx, metrics)
+    }
+
+    fn with_layer<F: FnOnce()>(layer: SiftTelemetryLayer, f: F) {
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::dispatcher::with_default(&tracing::Dispatch::new(subscriber), f);
+    }
+
+    /// Minimal subscriber that counts received events; used as the base for
+    /// `DispatchForwardingLayer` tests.
+    struct EventCounter(Arc<AtomicU32>);
+
+    impl tracing::Subscriber for EventCounter {
+        fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
+            true
+        }
+        fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+            tracing::span::Id::from_u64(1)
+        }
+        fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+        fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+        fn event(&self, _: &tracing::Event<'_>) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+        fn enter(&self, _: &tracing::span::Id) {}
+        fn exit(&self, _: &tracing::span::Id) {}
+    }
+
+    // ── SiftTelemetryLayer ────────────────────────────────────────────────────
+
+    #[test]
+    fn layer_captures_sift_stream_event() {
+        let (layer, rx, _) = make_layer(8, LogLevel::Info);
+        with_layer(layer, || {
+            tracing::event!(
+                target: "sift_stream::tasks::ingestion",
+                tracing::Level::INFO,
+                "hello from sift"
+            );
+        });
+        assert_eq!(rx.len(), 1);
+        let ev = rx.try_recv().unwrap();
+        assert_eq!(ev.message, "hello from sift");
+        assert_eq!(ev.level, LogLevel::Info);
+        assert_eq!(ev.target, "sift_stream::tasks::ingestion");
+    }
+
+    #[test]
+    fn layer_ignores_non_sift_stream_target() {
+        let (layer, rx, _) = make_layer(8, LogLevel::Info);
+        with_layer(layer, || {
+            tracing::event!(target: "h2::proto::connection", tracing::Level::INFO, "h2 noise");
+            tracing::event!(target: "tonic::transport", tracing::Level::WARN, "tonic noise");
+            tracing::event!(target: "hyper::client", tracing::Level::ERROR, "hyper noise");
+        });
+        assert_eq!(rx.len(), 0, "non-sift_stream events must not be captured");
+    }
+
+    #[test]
+    fn layer_filters_events_below_level_threshold() {
+        // With an INFO filter, DEBUG and TRACE are too verbose and must be dropped.
+        let (layer, rx, _) = make_layer(8, LogLevel::Info);
+        with_layer(layer, || {
+            tracing::event!(
+                target: "sift_stream::tasks",
+                tracing::Level::DEBUG,
+                "debug noise"
+            );
+            tracing::event!(
+                target: "sift_stream::tasks",
+                tracing::Level::TRACE,
+                "trace noise"
+            );
+        });
+        assert_eq!(
+            rx.len(),
+            0,
+            "DEBUG/TRACE must be dropped with an INFO filter"
+        );
+    }
+
+    #[test]
+    fn layer_passes_events_at_and_above_level_threshold() {
+        let (layer, rx, _) = make_layer(8, LogLevel::Info);
+        with_layer(layer, || {
+            tracing::event!(target: "sift_stream::tasks", tracing::Level::INFO, "info");
+            tracing::event!(target: "sift_stream::tasks", tracing::Level::WARN, "warn");
+            tracing::event!(target: "sift_stream::tasks", tracing::Level::ERROR, "error");
+        });
+        assert_eq!(
+            rx.len(),
+            3,
+            "INFO, WARN, ERROR must all pass an INFO filter"
+        );
+    }
+
+    #[test]
+    fn layer_captures_structured_fields() {
+        let (layer, rx, _) = make_layer(8, LogLevel::Info);
+        with_layer(layer, || {
+            tracing::event!(
+                target: "sift_stream::tasks",
+                tracing::Level::INFO,
+                user = "alice",
+                request_id = "req-42",
+                "user login"
+            );
+        });
+        let ev = rx.try_recv().unwrap();
+        assert_eq!(ev.message, "user login");
+        assert!(
+            ev.fields.iter().any(|(k, v)| k == "user" && v == "alice"),
+            "user field not captured: {:?}",
+            ev.fields
+        );
+        assert!(
+            ev.fields
+                .iter()
+                .any(|(k, v)| k == "request_id" && v == "req-42"),
+            "request_id field not captured: {:?}",
+            ev.fields
+        );
+    }
+
+    #[test]
+    fn layer_increments_dropped_metric_on_full_channel() {
+        // Capacity 1: the first event fills the channel; the second must be dropped.
+        let (layer, rx, metrics) = make_layer(1, LogLevel::Info);
+        with_layer(layer, || {
+            tracing::event!(target: "sift_stream::tasks", tracing::Level::INFO, "first");
+            tracing::event!(target: "sift_stream::tasks", tracing::Level::INFO, "overflow");
+        });
+        assert_eq!(rx.len(), 1, "only the first event should be in the channel");
+        assert_eq!(
+            metrics.logs_dropped_channel_full.get(),
+            1,
+            "exactly one drop should be counted"
+        );
+    }
+
+    // ── DispatchForwardingLayer ───────────────────────────────────────────────
+
+    #[test]
+    fn forwarding_layer_forwards_sift_stream_events_to_base() {
+        let count = Arc::new(AtomicU32::new(0));
+        let base = tracing::Dispatch::new(EventCounter(count.clone()));
+        let layer = DispatchForwardingLayer(base);
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::dispatcher::with_default(&tracing::Dispatch::new(subscriber), || {
+            tracing::event!(
+                target: "sift_stream::tasks::ingestion",
+                tracing::Level::INFO,
+                "sift event"
+            );
+            tracing::event!(
+                target: "sift_stream::stream::builder",
+                tracing::Level::WARN,
+                "another sift event"
+            );
+        });
+        assert_eq!(
+            count.load(Ordering::Relaxed),
+            2,
+            "both sift_stream events must reach the base dispatch"
+        );
+    }
+
+    #[test]
+    fn forwarding_layer_does_not_forward_non_sift_stream_events() {
+        let count = Arc::new(AtomicU32::new(0));
+        let base = tracing::Dispatch::new(EventCounter(count.clone()));
+        let layer = DispatchForwardingLayer(base);
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::dispatcher::with_default(&tracing::Dispatch::new(subscriber), || {
+            tracing::event!(
+                target: "h2::proto::connection",
+                tracing::Level::TRACE,
+                "h2 spam"
+            );
+            tracing::event!(target: "tonic::transport", tracing::Level::DEBUG, "tonic noise");
+            tracing::event!(target: "hyper::client", tracing::Level::INFO, "hyper log");
+        });
+        assert_eq!(
+            count.load(Ordering::Relaxed),
+            0,
+            "third-party library events must not reach the base dispatch"
+        );
+    }
+}

--- a/rust/crates/sift_stream/src/telemetry.rs
+++ b/rust/crates/sift_stream/src/telemetry.rs
@@ -102,10 +102,8 @@ impl<S: tracing::Subscriber> tracing_subscriber::layer::Layer<S> for SiftTelemet
 /// dispatch.
 ///
 /// Only events with a `sift_stream` target prefix are forwarded. Third-party library events
-/// (h2, hyper, tonic, etc.) emitted from within the tasks are intentionally not forwarded:
-/// those were already not reaching user subscribers in the pre-scoped world (tokio spawned
-/// tasks do not propagate thread-local subscribers), so this preserves existing behavior and
-/// avoids unintended side effects such as flooding test subscribers with low-level TRACE spam.
+/// (h2, hyper, tonic, etc.) emitted from within the tasks are intentionally not forwarded to
+/// avoid unintended side effects such as flooding subscribers with low-level TRACE spam.
 ///
 /// **Limitation**: span lifecycle is not forwarded. This is acceptable for sift_stream's
 /// background tasks which do not create spans.
@@ -134,8 +132,6 @@ mod tests {
         atomic::{AtomicU32, Ordering},
     };
     use tracing_subscriber::layer::SubscriberExt;
-
-    // ── Helpers ───────────────────────────────────────────────────────────────
 
     fn make_layer(
         capacity: usize,
@@ -175,8 +171,6 @@ mod tests {
         fn enter(&self, _: &tracing::span::Id) {}
         fn exit(&self, _: &tracing::span::Id) {}
     }
-
-    // ── SiftTelemetryLayer ────────────────────────────────────────────────────
 
     #[test]
     fn layer_captures_sift_stream_event() {
@@ -287,8 +281,6 @@ mod tests {
             "exactly one drop should be counted"
         );
     }
-
-    // ── DispatchForwardingLayer ───────────────────────────────────────────────
 
     #[test]
     fn forwarding_layer_forwards_sift_stream_events_to_base() {

--- a/rust/crates/sift_stream/tests/common/mod.rs
+++ b/rust/crates/sift_stream/tests/common/mod.rs
@@ -7,7 +7,11 @@ use sift_rs::assets::v1::{
     GetAssetRequest, GetAssetResponse, ListAssetsRequest, ListAssetsResponse, UpdateAssetRequest,
     UpdateAssetResponse,
 };
-use sift_rs::ingest::v1::ingest_service_server::{IngestService, IngestServiceServer};
+use sift_rs::ingest::v1::{
+    IngestArbitraryProtobufDataStreamRequest, IngestArbitraryProtobufDataStreamResponse,
+    IngestWithConfigDataStreamRequest, IngestWithConfigDataStreamResponse,
+    ingest_service_server::{IngestService, IngestServiceServer},
+};
 use sift_rs::ingestion_configs::v2::ingestion_config_service_server::{
     IngestionConfigService, IngestionConfigServiceServer,
 };
@@ -27,9 +31,11 @@ use sift_rs::runs::v2::{
     ListRunsResponse, Run, StopRunRequest, StopRunResponse, UpdateRunRequest, UpdateRunResponse,
 };
 use sift_stream::{ChannelConfig, ChannelDataType, FlowConfig};
+use std::collections::HashMap;
 use std::io::Error as IoError;
 use std::sync::{Arc, Mutex};
 use tokio::task::JoinHandle;
+use tokio_stream::StreamExt;
 use tonic::transport::{Endpoint, Server, Uri};
 use tonic::{Request, Response, Status};
 use tower::{ServiceBuilder, service_fn};

--- a/rust/crates/sift_stream/tests/test_ingestion_config_streaming_ingestion.rs
+++ b/rust/crates/sift_stream/tests/test_ingestion_config_streaming_ingestion.rs
@@ -1,68 +1,89 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
 use sift_rs::{
     common::r#type::v1::ChannelDataType,
     ingest::v1::{
         IngestArbitraryProtobufDataStreamRequest, IngestArbitraryProtobufDataStreamResponse,
-        IngestWithConfigDataChannelValue, IngestWithConfigDataStreamRequest,
-        IngestWithConfigDataStreamResponse,
-        ingest_with_config_data_channel_value::Type as RawChannelValue,
+        IngestWithConfigDataStreamRequest, IngestWithConfigDataStreamResponse,
+        ingest_service_server::IngestService,
     },
     ingestion_configs::v2::{ChannelConfig, FlowConfig},
 };
 use sift_stream::{ChannelValue, Flow, IngestionConfigForm, SiftStreamBuilder, TimeValue};
-use std::sync::{
-    Arc,
-    atomic::{AtomicU32, Ordering},
-};
 use tokio_stream::StreamExt;
 use tracing_test::traced_test;
 
 mod common;
-use common::prelude::*;
 
-struct IngestServiceMock {
-    num_message_received: Arc<AtomicU32>,
+/// Flow name used by the sift_stream log streaming task.
+const LOG_FLOW: &str = "sift-stream-logs";
+
+/// Per-flow message counter shared between a test and `FlowCountingIngestService`.
+///
+/// Call [`FlowMessageCounts::get`] after the stream finishes to assert how many messages
+/// arrived for a given flow name (e.g. `"flow-0"`, `"sift-stream-logs"`).
+#[derive(Clone, Default)]
+pub struct FlowMessageCounts(Arc<Mutex<HashMap<String, u32>>>);
+
+impl FlowMessageCounts {
+    pub fn record(&self, flow: &str) {
+        *self.0.lock().unwrap().entry(flow.to_owned()).or_insert(0) += 1;
+    }
+
+    /// Returns the number of messages received for `flow`, or 0 if none were received.
+    pub fn get(&self, flow: &str) -> u32 {
+        self.0.lock().unwrap().get(flow).copied().unwrap_or(0)
+    }
 }
 
-#[async_trait]
-impl IngestService for IngestServiceMock {
+/// An `IngestService` implementation that counts received messages grouped by flow name.
+///
+/// Construct with [`FlowCountingIngestService::new`], which returns both the service and a
+/// [`FlowMessageCounts`] handle the test can hold onto for assertions.
+pub struct FlowCountingIngestService {
+    counts: FlowMessageCounts,
+}
+
+impl FlowCountingIngestService {
+    pub fn new() -> (Self, FlowMessageCounts) {
+        let counts = FlowMessageCounts::default();
+        (
+            Self {
+                counts: counts.clone(),
+            },
+            counts,
+        )
+    }
+}
+
+#[tonic::async_trait]
+impl IngestService for FlowCountingIngestService {
     async fn ingest_with_config_data_stream(
         &self,
-        request: Request<Streaming<IngestWithConfigDataStreamRequest>>,
-    ) -> Result<Response<IngestWithConfigDataStreamResponse>, Status> {
-        let mut data_stream = request.into_inner();
-
-        loop {
-            match data_stream.try_next().await {
-                Ok(Some(_msg)) => {
-                    self.num_message_received.fetch_add(1, Ordering::Relaxed);
-                }
-                // Client has ended the stream and is requesting a checkpoint
-                Ok(None) => {
-                    break;
-                }
-                Err(err) => return Err(err),
-            }
+        request: tonic::Request<tonic::Streaming<IngestWithConfigDataStreamRequest>>,
+    ) -> Result<tonic::Response<IngestWithConfigDataStreamResponse>, tonic::Status> {
+        let mut stream = request.into_inner();
+        while let Ok(Some(msg)) = stream.try_next().await {
+            self.counts.record(&msg.flow);
         }
-
-        Ok(Response::new(IngestWithConfigDataStreamResponse {}))
+        Ok(tonic::Response::new(IngestWithConfigDataStreamResponse {}))
     }
+
     async fn ingest_arbitrary_protobuf_data_stream(
         &self,
-        _request: Request<Streaming<IngestArbitraryProtobufDataStreamRequest>>,
-    ) -> Result<Response<IngestArbitraryProtobufDataStreamResponse>, Status> {
-        unimplemented!("not relevant to this test")
+        _request: tonic::Request<tonic::Streaming<IngestArbitraryProtobufDataStreamRequest>>,
+    ) -> Result<tonic::Response<IngestArbitraryProtobufDataStreamResponse>, tonic::Status> {
+        unimplemented!("not used in flow-counting tests")
     }
 }
 
 #[tokio::test]
 async fn test_sending_raw_ingest_request() {
-    let messages_received = Arc::new(AtomicU32::default());
-
-    let ingest_service = IngestServiceMock {
-        num_message_received: messages_received.clone(),
-    };
-
-    let (client, server) = common::start_test_ingest_server(ingest_service).await;
+    let (service, counts) = FlowCountingIngestService::new();
+    let (client, server) = common::start_test_ingest_server(service).await;
 
     let flows = vec![FlowConfig {
         name: "flow-0".to_string(),
@@ -84,14 +105,16 @@ async fn test_sending_raw_ingest_request() {
         .await
         .expect("failed to build sift stream");
 
-    let num_messages = 100;
+    let num_messages = 100u32;
 
     let requests = (0..num_messages).map(|i| IngestWithConfigDataStreamRequest {
         ingestion_config_id: "ingestion-config-0".into(),
         flow: "flow-0".into(),
         timestamp: Some(pbjson_types::Timestamp::default()),
-        channel_values: vec![IngestWithConfigDataChannelValue {
-            r#type: Some(RawChannelValue::Double(i as f64)),
+        channel_values: vec![sift_rs::ingest::v1::IngestWithConfigDataChannelValue {
+            r#type: Some(
+                sift_rs::ingest::v1::ingest_with_config_data_channel_value::Type::Double(i as f64),
+            ),
         }],
         ..Default::default()
     });
@@ -104,8 +127,12 @@ async fn test_sending_raw_ingest_request() {
 
     assert_eq!(
         num_messages,
-        messages_received.load(Ordering::Relaxed),
-        "messages sent and received don't match",
+        counts.get("flow-0"),
+        "messages sent and received on flow-0 don't match",
+    );
+    assert!(
+        counts.get(LOG_FLOW) > 0,
+        "expected log events to be streamed to the log flow"
     );
     assert!(
         server.await.is_ok(),
@@ -115,13 +142,8 @@ async fn test_sending_raw_ingest_request() {
 
 #[tokio::test]
 async fn test_sending_flow() {
-    let messages_received = Arc::new(AtomicU32::default());
-
-    let ingest_service = IngestServiceMock {
-        num_message_received: messages_received.clone(),
-    };
-
-    let (client, server) = common::start_test_ingest_server(ingest_service).await;
+    let (service, counts) = FlowCountingIngestService::new();
+    let (client, server) = common::start_test_ingest_server(service).await;
 
     let flows = vec![FlowConfig {
         name: "flow-0".to_string(),
@@ -143,7 +165,7 @@ async fn test_sending_flow() {
         .await
         .expect("failed to build sift stream");
 
-    let num_messages = 100;
+    let num_messages = 100u32;
 
     let messages = (0..num_messages).map(|i| {
         Flow::new(
@@ -163,8 +185,12 @@ async fn test_sending_flow() {
 
     assert_eq!(
         num_messages,
-        messages_received.load(Ordering::Relaxed),
-        "messages sent and received don't match",
+        counts.get("flow-0"),
+        "messages sent and received on flow-0 don't match",
+    );
+    assert!(
+        counts.get(LOG_FLOW) > 0,
+        "expected log events to be streamed to the log flow"
     );
     assert!(
         server.await.is_ok(),
@@ -175,13 +201,8 @@ async fn test_sending_flow() {
 #[tokio::test]
 #[traced_test]
 async fn test_sending_flow_not_in_flow_cache() {
-    let messages_received = Arc::new(AtomicU32::default());
-
-    let ingest_service = IngestServiceMock {
-        num_message_received: messages_received.clone(),
-    };
-
-    let (client, server) = common::start_test_ingest_server(ingest_service).await;
+    let (service, counts) = FlowCountingIngestService::new();
+    let (client, server) = common::start_test_ingest_server(service).await;
 
     let expected_flows = vec![FlowConfig {
         name: "flow-0".to_string(),
@@ -203,7 +224,7 @@ async fn test_sending_flow_not_in_flow_cache() {
         .await
         .expect("failed to build sift stream");
 
-    let num_messages = 100;
+    let num_messages = 100u32;
 
     // First send some messages that have a channel not in the expected flow.
     let messages = (0..num_messages / 2).map(|i| {
@@ -246,10 +267,16 @@ async fn test_sending_flow_not_in_flow_cache() {
 
     assert!(sift_stream.finish().await.is_ok(), "finish call failed");
 
+    // Messages sent to unregistered channels/flows are not forwarded to Sift; only the
+    // messages that actually matched registered flows count toward the total.
+    let user_messages_received = counts.get("flow-0") + counts.get("unregistered_flow");
     assert_eq!(
-        num_messages,
-        messages_received.load(Ordering::Relaxed),
-        "messages sent and received don't match",
+        num_messages, user_messages_received,
+        "total user messages received don't match"
+    );
+    assert!(
+        counts.get(LOG_FLOW) > 0,
+        "expected log events to be streamed to the log flow"
     );
     assert!(
         server.await.is_ok(),


### PR DESCRIPTION
Adds tracing event capturing via "scoped dispatching" so that `SiftStream` internally can collect it's own tracing events and include them in metrics forwarded to Sift for debugging.