### PR TITLE
python(chore): disable integration tests with sift

### DIFF
--- a/.github/workflows/python_ci.yaml
+++ b/.github/workflows/python_ci.yaml
@@ -90,13 +90,14 @@ jobs:
         run: |
           pytest -m "not integration"
 
-      - name: Pytest Integration Tests
-        env:
-          SIFT_GRPC_URI: ${{ vars.SIFT_GRPC_URI }}
-          SIFT_REST_URI: ${{ vars.SIFT_REST_URI }}
-          SIFT_API_KEY: ${{ secrets.SIFT_API_KEY }}
-        run: |
-          pytest -m "integration"
+      # Disabling integration tests that interact with Sift until a better solution is implemented
+      # - name: Pytest Integration Tests
+      #   env:
+      #     SIFT_GRPC_URI: ${{ vars.SIFT_GRPC_URI }}
+      #     SIFT_REST_URI: ${{ vars.SIFT_REST_URI }}
+      #     SIFT_API_KEY: ${{ secrets.SIFT_API_KEY }}
+      #   run: |
+      #     pytest -m "integration"
 
       - name: Sync Stubs Mypy
         working-directory: python/lib


### PR DESCRIPTION
Disabling integration tests that interact directly with sift until a better solution is implemented