### PR TITLE
python(fix): remove client side detection for missing parquet time column 

### DIFF
--- a/python/lib/sift_client/resources/data_imports.py
+++ b/python/lib/sift_client/resources/data_imports.py
@@ -10,7 +10,6 @@ from sift_client._internal.util.hdf5 import detect_hdf5_config
 from sift_client._internal.util.tdms import detect_tdms_config
 from sift_client.resources._base import ResourceBase
 from sift_client.sift_types.asset import Asset
-from sift_client.sift_types.channel import ChannelDataType
 from sift_client.sift_types.data_import import (
     EXTENSION_TO_DATA_TYPE_KEY,
     CsvImportConfig,
@@ -18,13 +17,10 @@ from sift_client.sift_types.data_import import (
     ImportConfig,
     ParquetFlatDatasetImportConfig,
     ParquetSingleChannelPerRowImportConfig,
-    ParquetTimeColumn,
 )
 from sift_client.sift_types.run import Run
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
-
     from sift_client.client import SiftClient
     from sift_client.sift_types.job import Job
 
@@ -312,24 +308,6 @@ def _parse_csv_detect_response(proto) -> CsvImportConfig:
     return csv_config
 
 
-def _infer_time_column(columns: Iterable[tuple[str, ChannelDataType, str]]) -> str | None:
-    """Find a likely time column from a sequence of (name, data_type, path) tuples.
-
-    The backend only detects arrow timestamp types. This falls back to the first
-    integer column whose name starts with "time".
-    """
-    _integer_types = {
-        ChannelDataType.INT_32,
-        ChannelDataType.INT_64,
-        ChannelDataType.UINT_32,
-        ChannelDataType.UINT_64,
-    }
-    for name, data_type, path in columns:
-        if data_type in _integer_types and name.lower().startswith("time"):
-            return path
-    return None
-
-
 def _parse_parquet_detect_response(
     proto, filename: str, footer_offset: int, footer_length: int
 ) -> ParquetFlatDatasetImportConfig | ParquetSingleChannelPerRowImportConfig:
@@ -343,28 +321,11 @@ def _parse_parquet_detect_response(
             parquet_config.data_columns = [
                 dc for dc in parquet_config.data_columns if dc.path != time_path
             ]
-        else:
-            inferred = _infer_time_column(
-                (dc.name, dc.data_type, dc.path) for dc in parquet_config.data_columns
-            )
-            if inferred is not None:
-                parquet_config.time_column = ParquetTimeColumn(path=inferred)
-                parquet_config.data_columns = [
-                    c for c in parquet_config.data_columns if c.path != inferred
-                ]
         return parquet_config
     elif proto.HasField("single_channel_per_row"):
-        parquet_scpr_config = ParquetSingleChannelPerRowImportConfig._from_proto(
+        return ParquetSingleChannelPerRowImportConfig._from_proto(
             proto, footer_offset=footer_offset, footer_length=footer_length
         )
-        if not parquet_scpr_config.time_column.path:
-            inferred = _infer_time_column(
-                (col.column_config.name, ChannelDataType(col.column_config.data_type), col.path)
-                for col in proto.single_channel_per_row.columns
-            )
-            if inferred is not None:
-                parquet_scpr_config.time_column = ParquetTimeColumn(path=inferred)
-        return parquet_scpr_config
     raise ValueError(f"Unsupported parquet layout in DetectConfig response for '{filename}'.")
 
 


### PR DESCRIPTION
### What was changed

Removed client-side parquet time column detection after the server returns the config from `detect_config`. int64/uint64 and int32/uint32 with the string parsing for "time" is not a great heuristic for determining whether a column is a proper time column due to missing context regarding indented format. It's best to leave it to the user to either call detect_config and fix it or raise an error

Existing tests and imports still work as intended. 