### PR TITLE
python(fix): lazy-import h5py and nptdms so base install doesn't require them

### DIFF
--- a/python/lib/sift_client/resources/data_imports.py
+++ b/python/lib/sift_client/resources/data_imports.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING
 from sift_client._internal.low_level_wrappers.data_imports import DataImportsLowLevelClient
 from sift_client._internal.util.executor import run_sync_function
 from sift_client._internal.util.file import extract_parquet_footer, upload_file
-from sift_client._internal.util.hdf5 import detect_hdf5_config
-from sift_client._internal.util.tdms import detect_tdms_config
 from sift_client.resources._base import ResourceBase
 from sift_client.sift_types.asset import Asset
 from sift_client.sift_types.data_import import (
@@ -240,8 +238,22 @@ class DataImportAPIAsync(ResourceBase):
         data_type_key = _resolve_data_type_key(path.suffix.lower(), data_type)
 
         if data_type_key == DataTypeKey.HDF5:
+            try:
+                from sift_client._internal.util.hdf5 import detect_hdf5_config
+            except ImportError as e:
+                raise RuntimeError(
+                    "h5py is required for HDF5 import. "
+                    "Install it via `pip install sift-stack-py[hdf5]`."
+                ) from e
             return await run_sync_function(lambda: detect_hdf5_config(path))
         if data_type_key == DataTypeKey.TDMS:
+            try:
+                from sift_client._internal.util.tdms import detect_tdms_config
+            except ImportError as e:
+                raise RuntimeError(
+                    "npTDMS is required for TDMS import. "
+                    "Install it via `pip install sift-stack-py[tdms]`."
+                ) from e
             return await run_sync_function(lambda: detect_tdms_config(path))
 
         is_parquet = data_type_key in (


### PR DESCRIPTION
## Summary
- v0.14.0 made `import sift_client` crash with `ModuleNotFoundError` when installed without the `[hdf5]` / `[tdms]` extras, because `data_imports` imported `h5py` and `nptdms` at the module level.
- Move those imports inside `detect_config`, with a friendly error pointing at the right extra.

## Test plan
- [x] `from sift_client import SiftClient` works without extras
- [x] `detect_config("foo.h5")` without `[hdf5]` raises a clear error
- [x] Existing `test_hdf5.py` + `test_tdms.py` (18 tests) pass