### PR TITLE
python(fix): expose page_size on resource list_ methods

### DIFF
--- a/python/lib/sift_client/_internal/low_level_wrappers/calculated_channels.py
+++ b/python/lib/sift_client/_internal/low_level_wrappers/calculated_channels.py
@@ -259,6 +259,7 @@ class CalculatedChannelsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         query_filter: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = DEFAULT_PAGE_SIZE,
     ) -> list[CalculatedChannel]:
         """List all versions of a calculated channel."""
         return await self._handle_pagination(
@@ -271,4 +272,5 @@ class CalculatedChannelsLowLevelClient(LowLevelClientBase, WithGrpcClient):
             },
             order_by=order_by,
             max_results=limit,
+            page_size=page_size,
         )

--- a/python/lib/sift_client/resources/assets.py
+++ b/python/lib/sift_client/resources/assets.py
@@ -89,6 +89,7 @@ class AssetsAPIAsync(ResourceBase):
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[Asset]:
         """List assets with optional filtering.
 
@@ -111,6 +112,8 @@ class AssetsAPIAsync(ResourceBase):
             filter_query: Explicit CEL query to filter assets.
             order_by: Field and direction to order results by.
             limit: Maximum number of assets to return. If None, returns all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of Asset objects that match the filter criteria.
@@ -142,6 +145,7 @@ class AssetsAPIAsync(ResourceBase):
             query_filter=filter_query or None,
             order_by=order_by,
             max_results=limit,
+            **({"page_size": page_size} if page_size is not None else {}),
         )
         return self._apply_client_to_instances(assets)
 

--- a/python/lib/sift_client/resources/calculated_channels.py
+++ b/python/lib/sift_client/resources/calculated_channels.py
@@ -101,6 +101,7 @@ class CalculatedChannelsAPIAsync(ResourceBase):
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[CalculatedChannel]:
         """List calculated channels with optional filtering. This will return the latest version. To find all versions, use `list_versions`.
 
@@ -127,6 +128,8 @@ class CalculatedChannelsAPIAsync(ResourceBase):
             filter_query: Explicit CEL query to filter calculated channels.
             order_by: How to order the retrieved calculated channels.
             limit: How many calculated channels to retrieve. If None, retrieves all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of CalculatedChannels that matches the filter.
@@ -169,6 +172,7 @@ class CalculatedChannelsAPIAsync(ResourceBase):
             query_filter=query_filter or None,
             order_by=order_by,
             max_results=limit,
+            **({"page_size": page_size} if page_size is not None else {}),
         )
         return self._apply_client_to_instances(calculated_channels)
 
@@ -304,6 +308,7 @@ class CalculatedChannelsAPIAsync(ResourceBase):
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[CalculatedChannel]:
         """List versions of a calculated channel.
 
@@ -327,6 +332,8 @@ class CalculatedChannelsAPIAsync(ResourceBase):
             filter_query: Explicit CEL query to filter versions.
             order_by: How to order the retrieved versions.
             limit: Maximum number of versions to return. If None, returns all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of CalculatedChannel versions that match the filter criteria.
@@ -360,6 +367,7 @@ class CalculatedChannelsAPIAsync(ResourceBase):
             query_filter=query_filter or None,
             order_by=order_by,
             limit=limit,
+            **({"page_size": page_size} if page_size is not None else {}),
         )
 
         return self._apply_client_to_instances(versions)

--- a/python/lib/sift_client/resources/calculated_channels.py
+++ b/python/lib/sift_client/resources/calculated_channels.py
@@ -172,7 +172,7 @@ class CalculatedChannelsAPIAsync(ResourceBase):
             query_filter=query_filter or None,
             order_by=order_by,
             max_results=limit,
-            **({"page_size": page_size} if page_size is not None else {}),
+            **({"page_size": page_size} if page_size is not None else {}),  # type: ignore[arg-type]
         )
         return self._apply_client_to_instances(calculated_channels)
 
@@ -367,7 +367,7 @@ class CalculatedChannelsAPIAsync(ResourceBase):
             query_filter=query_filter or None,
             order_by=order_by,
             limit=limit,
-            **({"page_size": page_size} if page_size is not None else {}),
+            **({"page_size": page_size} if page_size is not None else {}),  # type: ignore[arg-type]
         )
 
         return self._apply_client_to_instances(versions)

--- a/python/lib/sift_client/resources/channels.py
+++ b/python/lib/sift_client/resources/channels.py
@@ -103,6 +103,7 @@ class ChannelsAPIAsync(ResourceBase):
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[Channel]:
         """List channels with optional filtering.
 
@@ -124,6 +125,8 @@ class ChannelsAPIAsync(ResourceBase):
             filter_query: Explicit CEL query to filter channels.
             order_by: Field and direction to order results by.
             limit: Maximum number of channels to return. If None, returns all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of Channels that matches the filter criteria.
@@ -167,6 +170,7 @@ class ChannelsAPIAsync(ResourceBase):
             query_filter=query_filter or None,
             order_by=order_by,
             max_results=limit,
+            **({"page_size": page_size} if page_size is not None else {}),
         )
         return self._apply_client_to_instances(channels)
 

--- a/python/lib/sift_client/resources/file_attachments.py
+++ b/python/lib/sift_client/resources/file_attachments.py
@@ -104,6 +104,7 @@ class FileAttachmentsAPIAsync(ResourceBase):
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[FileAttachment]:
         """List file attachments with optional filtering.
 
@@ -120,6 +121,8 @@ class FileAttachmentsAPIAsync(ResourceBase):
             filter_query: Explicit CEL query to filter file attachments.
             order_by: Field and direction to order results by. Note: Not supported by the backend, but it is here for API consistency.
             limit: Maximum number of file attachments to return. If None, returns all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of FileAttachment objects that match the filter criteria.
@@ -160,6 +163,7 @@ class FileAttachmentsAPIAsync(ResourceBase):
         file_attachments = await self._low_level_client.list_all_remote_files(
             query_filter=query_filter or None,
             max_results=limit,
+            **({"page_size": page_size} if page_size is not None else {}),
         )
         return self._apply_client_to_instances(file_attachments)
 

--- a/python/lib/sift_client/resources/file_attachments.py
+++ b/python/lib/sift_client/resources/file_attachments.py
@@ -163,7 +163,7 @@ class FileAttachmentsAPIAsync(ResourceBase):
         file_attachments = await self._low_level_client.list_all_remote_files(
             query_filter=query_filter or None,
             max_results=limit,
-            **({"page_size": page_size} if page_size is not None else {}),
+            **({"page_size": page_size} if page_size is not None else {}),  # type: ignore[arg-type]
         )
         return self._apply_client_to_instances(file_attachments)
 

--- a/python/lib/sift_client/resources/jobs.py
+++ b/python/lib/sift_client/resources/jobs.py
@@ -76,6 +76,7 @@ class JobsAPIAsync(ResourceBase):
         # Ordering and pagination
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[Job]:
         """List jobs with optional filtering.
 
@@ -97,6 +98,8 @@ class JobsAPIAsync(ResourceBase):
             filter_query: Explicit CEL query to filter jobs. If provided, other filter arguments are ignored.
             order_by: Field and direction to order results by.
             limit: Maximum number of jobs to return. If None, returns all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of Job objects that match the filter criteria.
@@ -134,6 +137,7 @@ class JobsAPIAsync(ResourceBase):
             organization_id=organization_id,
             order_by=order_by,
             max_results=limit,
+            **({"page_size": page_size} if page_size is not None else {}),
         )
         return self._apply_client_to_instances(jobs)
 

--- a/python/lib/sift_client/resources/reports.py
+++ b/python/lib/sift_client/resources/reports.py
@@ -66,6 +66,7 @@ class ReportsAPIAsync(ResourceBase):
         modified_by: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
         include_archived: bool = False,
         filter_query: str | None = None,
         created_after: datetime | None = None,
@@ -91,6 +92,8 @@ class ReportsAPIAsync(ResourceBase):
             modified_by: The user ID of the last modifier of the reports.
             order_by: How to order the retrieved reports.
             limit: How many reports to retrieve. If None, retrieves all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
             include_archived: Whether to include archived reports.
             filter_query: Explicit CEL query to filter reports.
             created_after: Filter reports created after this datetime.
@@ -142,6 +145,7 @@ class ReportsAPIAsync(ResourceBase):
             organization_id=organization_id,
             order_by=order_by,
             max_results=limit,
+            **({"page_size": page_size} if page_size is not None else {}),
         )
         return self._apply_client_to_instances(reports)
 

--- a/python/lib/sift_client/resources/rules.py
+++ b/python/lib/sift_client/resources/rules.py
@@ -84,6 +84,7 @@ class RulesAPIAsync(ResourceBase):
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[Rule]:
         """List rules with optional filtering.
 
@@ -108,6 +109,8 @@ class RulesAPIAsync(ResourceBase):
             filter_query: Explicit CEL query to filter rules.
             order_by: Field and direction to order results by.
             limit: Maximum number of rules to return. If None, returns all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, defaults to `limit`.
 
         Returns:
             A list of Rules that matches the filter.
@@ -146,7 +149,7 @@ class RulesAPIAsync(ResourceBase):
             filter_query=query_filter,
             order_by=order_by,
             max_results=limit,
-            page_size=limit,
+            page_size=page_size if page_size is not None else limit,
         )
         return self._apply_client_to_instances(rules)
 
@@ -338,6 +341,7 @@ class RulesAPIAsync(ResourceBase):
         rule_version_ids: list[str] | None = None,
         filter_query: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[RuleVersion]:
         """List versions of a rule with optional filtering.
 
@@ -348,6 +352,8 @@ class RulesAPIAsync(ResourceBase):
             rule_version_ids: Limit to these rule version IDs.
             filter_query: Raw CEL filter (fields: rule_version_id, user_notes, change_message).
             limit: Maximum number of versions to return. If None, returns all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, defaults to `limit`.
 
         Returns:
             A list of RuleVersion objects matching the filters, ordered by newest versions first.
@@ -372,7 +378,7 @@ class RulesAPIAsync(ResourceBase):
             rule_id=rule_id,
             filter_query=query_filter,
             max_results=limit,
-            page_size=limit,
+            page_size=page_size if page_size is not None else limit,
         )
 
     async def get_rule_version(self, rule_version: RuleVersion | str) -> Rule:

--- a/python/lib/sift_client/resources/runs.py
+++ b/python/lib/sift_client/resources/runs.py
@@ -94,6 +94,7 @@ class RunsAPIAsync(ResourceBase):
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[Run]:
         """List runs with optional filtering.
 
@@ -126,6 +127,8 @@ class RunsAPIAsync(ResourceBase):
             filter_query: Explicit CEL query to filter runs.
             order_by: Field and direction to order results by.
             limit: Maximum number of runs to return. If None, returns all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of Run objects that match the filter criteria.
@@ -185,6 +188,7 @@ class RunsAPIAsync(ResourceBase):
             query_filter=query_filter or None,
             order_by=order_by,
             max_results=limit,
+            **({"page_size": page_size} if page_size is not None else {}),
         )
         return self._apply_client_to_instances(runs)
 

--- a/python/lib/sift_client/resources/sync_stubs/__init__.pyi
+++ b/python/lib/sift_client/resources/sync_stubs/__init__.pyi
@@ -136,6 +136,7 @@ class AssetsAPI:
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[Asset]:
         """List assets with optional filtering.
 
@@ -158,6 +159,8 @@ class AssetsAPI:
             filter_query: Explicit CEL query to filter assets.
             order_by: Field and direction to order results by.
             limit: Maximum number of assets to return. If None, returns all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of Asset objects that match the filter criteria.
@@ -285,6 +288,7 @@ class CalculatedChannelsAPI:
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[CalculatedChannel]:
         """List calculated channels with optional filtering. This will return the latest version. To find all versions, use `list_versions`.
 
@@ -311,6 +315,8 @@ class CalculatedChannelsAPI:
             filter_query: Explicit CEL query to filter calculated channels.
             order_by: How to order the retrieved calculated channels.
             limit: How many calculated channels to retrieve. If None, retrieves all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of CalculatedChannels that matches the filter.
@@ -339,6 +345,7 @@ class CalculatedChannelsAPI:
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[CalculatedChannel]:
         """List versions of a calculated channel.
 
@@ -362,6 +369,8 @@ class CalculatedChannelsAPI:
             filter_query: Explicit CEL query to filter versions.
             order_by: How to order the retrieved versions.
             limit: Maximum number of versions to return. If None, returns all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of CalculatedChannel versions that match the filter criteria.
@@ -509,6 +518,7 @@ class ChannelsAPI:
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[Channel]:
         """List channels with optional filtering.
 
@@ -530,6 +540,8 @@ class ChannelsAPI:
             filter_query: Explicit CEL query to filter channels.
             order_by: Field and direction to order results by.
             limit: Maximum number of channels to return. If None, returns all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of Channels that matches the filter criteria.
@@ -865,6 +877,7 @@ class FileAttachmentsAPI:
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[FileAttachment]:
         """List file attachments with optional filtering.
 
@@ -881,6 +894,8 @@ class FileAttachmentsAPI:
             filter_query: Explicit CEL query to filter file attachments.
             order_by: Field and direction to order results by. Note: Not supported by the backend, but it is here for API consistency.
             limit: Maximum number of file attachments to return. If None, returns all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of FileAttachment objects that match the filter criteria.
@@ -981,6 +996,7 @@ class JobsAPI:
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[Job]:
         """List jobs with optional filtering.
 
@@ -1002,6 +1018,8 @@ class JobsAPI:
             filter_query: Explicit CEL query to filter jobs. If provided, other filter arguments are ignored.
             order_by: Field and direction to order results by.
             limit: Maximum number of jobs to return. If None, returns all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of Job objects that match the filter criteria.
@@ -1266,6 +1284,7 @@ class ReportsAPI:
         modified_by: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
         include_archived: bool = False,
         filter_query: str | None = None,
         created_after: datetime | None = None,
@@ -1291,6 +1310,8 @@ class ReportsAPI:
             modified_by: The user ID of the last modifier of the reports.
             order_by: How to order the retrieved reports.
             limit: How many reports to retrieve. If None, retrieves all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
             include_archived: Whether to include archived reports.
             filter_query: Explicit CEL query to filter reports.
             created_after: Filter reports created after this datetime.
@@ -1502,6 +1523,7 @@ class RulesAPI:
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[Rule]:
         """List rules with optional filtering.
 
@@ -1526,6 +1548,8 @@ class RulesAPI:
             filter_query: Explicit CEL query to filter rules.
             order_by: Field and direction to order results by.
             limit: Maximum number of rules to return. If None, returns all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, defaults to `limit`.
 
         Returns:
             A list of Rules that matches the filter.
@@ -1541,6 +1565,7 @@ class RulesAPI:
         rule_version_ids: list[str] | None = None,
         filter_query: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[RuleVersion]:
         """List versions of a rule with optional filtering.
 
@@ -1551,6 +1576,8 @@ class RulesAPI:
             rule_version_ids: Limit to these rule version IDs.
             filter_query: Raw CEL filter (fields: rule_version_id, user_notes, change_message).
             limit: Maximum number of versions to return. If None, returns all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, defaults to `limit`.
 
         Returns:
             A list of RuleVersion objects matching the filters, ordered by newest versions first.
@@ -1690,6 +1717,7 @@ class RunsAPI:
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[Run]:
         """List runs with optional filtering.
 
@@ -1722,6 +1750,8 @@ class RunsAPI:
             filter_query: Explicit CEL query to filter runs.
             order_by: Field and direction to order results by.
             limit: Maximum number of runs to return. If None, returns all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of Run objects that match the filter criteria.
@@ -1816,6 +1846,7 @@ class TagsAPI:
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[Tag]:
         """List tags with optional filtering.
 
@@ -1828,6 +1859,8 @@ class TagsAPI:
             filter_query: Explicit CEL query to filter tags.
             order_by: How to order the retrieved tags.
             limit: How many tags to retrieve. If None, retrieves all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of Tags that matches the filter.
@@ -2040,6 +2073,7 @@ class TestResultsAPI:
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[TestReport]:
         """List test reports with optional filtering.
 
@@ -2066,6 +2100,8 @@ class TestResultsAPI:
             filter_query: Custom filter to apply to the test reports.
             order_by: How to order the retrieved test reports. If used, this will override the other filters.
             limit: How many test reports to retrieve. If None, retrieves all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of TestReports that matches the filter.
@@ -2087,6 +2123,7 @@ class TestResultsAPI:
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[TestMeasurement]:
         """List test measurements with optional filtering.
 
@@ -2103,6 +2140,8 @@ class TestResultsAPI:
             filter_query: Explicit CEL query to filter test measurements.
             order_by: How to order the retrieved test measurements.
             limit: How many test measurements to retrieve. If None, retrieves all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of TestMeasurements that matches the filter.
@@ -2124,6 +2163,7 @@ class TestResultsAPI:
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[TestStep]:
         """List test steps with optional filtering.
 
@@ -2140,6 +2180,8 @@ class TestResultsAPI:
             filter_query: Explicit CEL query to filter test steps.
             order_by: How to order the retrieved test steps.
             limit: How many test steps to retrieve. If None, retrieves all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of TestSteps that matches the filter.

--- a/python/lib/sift_client/resources/tags.py
+++ b/python/lib/sift_client/resources/tags.py
@@ -36,6 +36,7 @@ class TagsAPIAsync(ResourceBase):
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[Tag]:
         """List tags with optional filtering.
 
@@ -48,6 +49,8 @@ class TagsAPIAsync(ResourceBase):
             filter_query: Explicit CEL query to filter tags.
             order_by: How to order the retrieved tags.
             limit: How many tags to retrieve. If None, retrieves all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of Tags that matches the filter.
@@ -71,6 +74,7 @@ class TagsAPIAsync(ResourceBase):
             query_filter=query_filter,
             order_by=order_by,
             max_results=limit,
+            **({"page_size": page_size} if page_size is not None else {}),
         )
         return self._apply_client_to_instances(tags)
 

--- a/python/lib/sift_client/resources/test_results.py
+++ b/python/lib/sift_client/resources/test_results.py
@@ -125,6 +125,7 @@ class TestResultsAPIAsync(ResourceBase):
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[TestReport]:
         """List test reports with optional filtering.
 
@@ -151,6 +152,8 @@ class TestResultsAPIAsync(ResourceBase):
             filter_query: Custom filter to apply to the test reports.
             order_by: How to order the retrieved test reports. If used, this will override the other filters.
             limit: How many test reports to retrieve. If None, retrieves all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of TestReports that matches the filter.
@@ -204,6 +207,7 @@ class TestResultsAPIAsync(ResourceBase):
             query_filter=query_filter,
             order_by=order_by,
             max_results=limit,
+            **({"page_size": page_size} if page_size is not None else {}),
         )
         return self._apply_client_to_instances(test_reports)
 
@@ -321,6 +325,7 @@ class TestResultsAPIAsync(ResourceBase):
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[TestStep]:
         """List test steps with optional filtering.
 
@@ -337,6 +342,8 @@ class TestResultsAPIAsync(ResourceBase):
             filter_query: Explicit CEL query to filter test steps.
             order_by: How to order the retrieved test steps.
             limit: How many test steps to retrieve. If None, retrieves all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of TestSteps that matches the filter.
@@ -384,6 +391,7 @@ class TestResultsAPIAsync(ResourceBase):
             query_filter=query_filter,
             order_by=order_by,
             max_results=limit,
+            **({"page_size": page_size} if page_size is not None else {}),
         )
         return self._apply_client_to_instances(test_steps)
 
@@ -503,6 +511,7 @@ class TestResultsAPIAsync(ResourceBase):
         filter_query: str | None = None,
         order_by: str | None = None,
         limit: int | None = None,
+        page_size: int | None = None,
     ) -> list[TestMeasurement]:
         """List test measurements with optional filtering.
 
@@ -519,6 +528,8 @@ class TestResultsAPIAsync(ResourceBase):
             filter_query: Explicit CEL query to filter test measurements.
             order_by: How to order the retrieved test measurements.
             limit: How many test measurements to retrieve. If None, retrieves all matches.
+            page_size: Number of results to fetch per request. Lower this if you hit gRPC
+                message size limits on responses. If None, uses the server default.
 
         Returns:
             A list of TestMeasurements that matches the filter.
@@ -566,6 +577,7 @@ class TestResultsAPIAsync(ResourceBase):
             query_filter=query_filter,
             order_by=order_by,
             max_results=limit,
+            **({"page_size": page_size} if page_size is not None else {}),
         )
         return self._apply_client_to_instances(test_measurements)
 


### PR DESCRIPTION
## What was changed
- Adds an optional `page_size` kwarg to resource list methods, forwarded to the existing low-level pagination plumbing.
-  Backwards compatible as an optional arg defaulting to None or the set default value.

## Validation
- Manual: traced `RunsLowLevelClient.list_runs` and called `client.async_.runs.list_(page_size=2, limit=6)`. Saw three round trips at `page_size=2`. Default call still uses `page_size=1000`.
