### PR TITLE
python(chore): v0.14.1 prep

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v0.14.1] - April 30, 2026
+
+### Bugfixes
+- Lazy-import `h5py` and `nptdms` so the base install doesn't require them. ([#547](https://github.com/sift-stack/sift/pull/547))
+- Expose `page_size` on resource list methods so callers can shrink pages when responses hit gRPC message-size limits. ([#548](https://github.com/sift-stack/sift/pull/548))
+
 ## [v0.14.0] - April 28, 2026
 
 ### What's New

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sift_stack_py"
-version = "0.14.0"
+version = "0.14.1"
 description = "Python client library for the Sift API"
 requires-python = ">=3.8"
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
Bumps to v0.14.1 and adds a changelog entry for #547 (lazy-import h5py/nptdms) and #548 (expose page_size on list methods).
