### PR TITLE
rust(fix): config create on existing config errors nicely

### DIFF
--- a/rust/crates/sift_cli/src/cmd/config.rs
+++ b/rust/crates/sift_cli/src/cmd/config.rs
@@ -24,8 +24,21 @@ pub fn show() -> Result<ExitCode> {
 }
 
 pub fn create() -> Result<ExitCode> {
-    let (_, path) = create_config_file()?;
+    let path = get_config_file_path()?;
     let p = path.display().to_string();
+
+    if metadata(&path).is_ok() {
+        Output::new()
+            .line(format!("A config file already exists at '{}'.", p.yellow()))
+            .tip(format!(
+                "Use '{}' to view the contents.",
+                format!("{BIN_NAME} config show").green()
+            ))
+            .print();
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    create_config_file()?;
 
     Output::new()
         .line(format!(


### PR DESCRIPTION
## Summary
`sift-cli config create` errored with `File exists (os error 17)` when run against an already-bootstrapped config. Now it prints a friendly message pointing at `sift-cli config show` and exits 0.

## Validation
Old: 
<img width="388" height="73" alt="image" src="https://github.com/user-attachments/assets/8129b1c0-0c5a-420f-93ab-bc6382ff3146" />

New: 
<img width="523" height="47" alt="image" src="https://github.com/user-attachments/assets/1a1a5c78-2495-40ae-b694-9c6561e8e00a" />