### PR TITLE
rust(bug): Fix ingestion config already exists race, fix lint findings

### DIFF
--- a/rust/crates/sift_cli/src/cmd/import/backup.rs
+++ b/rust/crates/sift_cli/src/cmd/import/backup.rs
@@ -208,14 +208,10 @@ async fn process_backup_file(
         "Streaming".green()
     ));
 
-    let message_stream = tokio_stream::iter(messages.into_iter()).map(move |msg| {
+    let message_stream = tokio_stream::iter(messages).map(move |msg| {
         let current = streamed_count_clone.fetch_add(1, Ordering::Relaxed) + 1;
 
-        let percentage = if total_messages > 0 {
-            (current * 100) / total_messages
-        } else {
-            0
-        };
+        let percentage = (current * 100).checked_div(total_messages).unwrap_or(0);
         spinner_clone.set_message(format!(
             "{spinner_prefix_clone} - {} ({percentage}% - {current}/{total_messages} messages)",
             "Streaming".green()

--- a/rust/crates/sift_cli/src/cmd/import/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/import/mod.rs
@@ -146,7 +146,7 @@ fn preview_import_config(asset: &str, run: &str, channel_configs: &[&ChannelConf
             for enum_conf in &conf.enum_types {
                 enum_confs.push((enum_conf.key, &enum_conf.name));
             }
-            enum_confs.sort_by(|(k_a, _), (k_b, _)| k_a.cmp(k_b));
+            enum_confs.sort_by_key(|(k_a, _)| *k_a);
 
             for (k, v) in enum_confs {
                 configs.line(format!("{INDENT_3}{k} => {v}"));
@@ -162,7 +162,7 @@ fn preview_import_config(asset: &str, run: &str, channel_configs: &[&ChannelConf
             for el in &conf.bit_field_elements {
                 bit_field_elements.push((el.index, el.bit_count, &el.name));
             }
-            bit_field_elements.sort_by(|(k_a, _, _), (k_b, _, _)| k_a.cmp(k_b));
+            bit_field_elements.sort_by_key(|(k_a, _, _)| *k_a);
 
             for (idx, length, name) in bit_field_elements {
                 configs

--- a/rust/crates/sift_cli/src/util/calculated_channel.rs
+++ b/rust/crates/sift_cli/src/util/calculated_channel.rs
@@ -44,7 +44,7 @@ pub async fn filter_calculated_channels(
             .context("failed to query calculated channels")?
             .into_inner();
 
-        query_result.extend(calculated_channels.into_iter());
+        query_result.extend(calculated_channels);
 
         if next_page_token.is_empty() {
             break;

--- a/rust/crates/sift_cli/src/util/channel.rs
+++ b/rust/crates/sift_cli/src/util/channel.rs
@@ -80,7 +80,7 @@ pub async fn filter_channels(grpc_channel: SiftChannel, filter: &str) -> Result<
             .context("failed to query channels")?
             .into_inner();
 
-        query_result.extend(channels.into_iter());
+        query_result.extend(channels);
 
         if next_page_token.is_empty() {
             break;

--- a/rust/crates/sift_pbfs/src/test.rs
+++ b/rust/crates/sift_pbfs/src/test.rs
@@ -58,6 +58,7 @@ fn test_writing_and_reading_from_disk_chunks() {
         .read(true)
         .write(true)
         .create(true)
+        .truncate(true)
         .open(&file_path)
         .expect("failed to create file");
 
@@ -86,7 +87,7 @@ fn test_writing_and_reading_from_disk_chunks() {
     let mut pbfs_chunks = vec![];
 
     for chunk in &chunks {
-        let pbfs_chunk = PbfsChunk::new(&chunk).expect("failed to create pbfs chunk");
+        let pbfs_chunk = PbfsChunk::new(chunk).expect("failed to create pbfs chunk");
 
         file.write_all(&pbfs_chunk)
             .expect("failed to write to file");
@@ -137,6 +138,7 @@ fn test_data_integrity() {
         .read(true)
         .write(true)
         .create(true)
+        .truncate(true)
         .open(&file_path)
         .expect("failed to create file");
 
@@ -165,7 +167,7 @@ fn test_data_integrity() {
     let mut pbfs_chunks = vec![];
 
     for chunk in &chunks {
-        let pbfs_chunk = PbfsChunk::new(&chunk).expect("failed to create pbfs chunk");
+        let pbfs_chunk = PbfsChunk::new(chunk).expect("failed to create pbfs chunk");
 
         file.write_all(&pbfs_chunk)
             .expect("failed to write to file");

--- a/rust/crates/sift_rs/src/wrappers/ingestion_configs.rs
+++ b/rust/crates/sift_rs/src/wrappers/ingestion_configs.rs
@@ -201,7 +201,13 @@ impl IngestionConfigServiceWrapper for IngestionConfigServiceImpl {
         })
         .await
         .map(|res| res.into_inner().ingestion_config)
-        .map_err(|e| Error::new(ErrorKind::CreateIngestionConfigError, e))?
+        .map_err(|e| {
+            if e.code() == tonic::Code::AlreadyExists {
+                Error::new(ErrorKind::AlreadyExistsError, e)
+            } else {
+                Error::new(ErrorKind::CreateIngestionConfigError, e)
+            }
+        })?
         .ok_or_else(|| {
             Error::new_empty_response(
                 "unexpected empty response from IngestionConfigService/CreateIngestionConfig",

--- a/rust/crates/sift_stream/examples/metrics/http_server.rs
+++ b/rust/crates/sift_stream/examples/metrics/http_server.rs
@@ -145,7 +145,7 @@ async fn run() -> Result<(), Box<dyn Error>> {
                         counter += 1;
 
                         // Print status every 10 messages
-                        if counter % 10 == 0 {
+                        if counter.is_multiple_of(10) {
                             println!("Sent {} messages.", counter);
                         }
                     }

--- a/rust/crates/sift_stream/src/backup/disk/async_manager.rs
+++ b/rust/crates/sift_stream/src/backup/disk/async_manager.rs
@@ -791,16 +791,15 @@ impl BackupIngestTask {
                 // TODO: Convert this to use async file operations.
                 let backups_decoder = decode_backup(&backup_file_path)?;
 
-                let iter_stream =
-                    tokio_stream::iter(backups_decoder.into_iter()).filter_map(|res| {
-                        if let Err(e) = &res {
-                            tracing::warn!(
-                                "encountered error from sift ingesting backup file: {:?}",
-                                e
-                            );
-                        }
-                        res.ok()
-                    });
+                let iter_stream = tokio_stream::iter(backups_decoder).filter_map(|res| {
+                    if let Err(e) = &res {
+                        tracing::warn!(
+                            "encountered error from sift ingesting backup file: {:?}",
+                            e
+                        );
+                    }
+                    res.ok()
+                });
 
                 let raw_response = client.ingest_with_config_data_stream(iter_stream).await;
                 let response = raw_response

--- a/rust/crates/sift_stream/src/stream/builder/config_loader.rs
+++ b/rust/crates/sift_stream/src/stream/builder/config_loader.rs
@@ -1,10 +1,10 @@
 use super::IngestionConfigForm;
-use crate::stream::flow::validate_flows;
+use crate::stream::flow::{add_new_flows, validate_flows};
 use sift_connect::SiftChannel;
 use sift_error::prelude::*;
 use sift_rs::{
     assets::v1::Asset,
-    ingestion_configs::v2::{FlowConfig, IngestionConfig as IngestionConfigPb},
+    ingestion_configs::v2::{FlowConfig, IngestionConfig},
     retry::{RetryConfig, RetryExt},
     wrappers::{
         assets::{AssetServiceWrapper, new_asset_service},
@@ -17,7 +17,7 @@ use sift_rs::{
 pub async fn load_ingestion_config(
     grpc_channel: SiftChannel,
     ingestion_config: IngestionConfigForm,
-) -> Result<(IngestionConfigPb, Vec<FlowConfig>, Asset)> {
+) -> Result<(IngestionConfig, Vec<FlowConfig>, Asset)> {
     #[cfg(feature = "tracing")]
     tracing::info_span!("load_ingestion_config");
 
@@ -31,209 +31,219 @@ pub async fn load_ingestion_config(
     let retrying_ingestion_config =
         ingestion_config_service_wrapper.retrying(RetryConfig::default());
 
-    let client_key_clone = client_key.clone();
-    match retrying_ingestion_config
-        .call(|mut w| {
-            let client_key = client_key_clone.clone();
-            async move { w.try_get_ingestion_config_by_client_key(&client_key).await }
-        })
-        .await
-    {
-        Err(err) if err.kind() == ErrorKind::NotFoundError => {
-            let asset_name_clone = asset_name.clone();
-            let client_key_clone = client_key.clone();
-            let flows_clone = flows.clone();
+    let ingestion_config_create_res = {
+        let asset_name = asset_name.clone();
+        let client_key = client_key.clone();
+        let flows = flows.clone();
+        retrying_ingestion_config
+            .call(|mut w| {
+                let asset_name = asset_name.clone();
+                let client_key = client_key.clone();
+                let flows = flows.clone();
+                async move {
+                    w.try_create_ingestion_config(&asset_name, &client_key, &flows)
+                        .await
+                }
+            })
+            .await
+    };
+
+    let (ingestion_config, new_config) = match ingestion_config_create_res {
+        Ok(ingestion_config) => (ingestion_config, true),
+        Err(e) if e.kind() == ErrorKind::AlreadyExistsError => {
+            let client_key = client_key.clone();
             let ingestion_config = retrying_ingestion_config
                 .call(|mut w| {
-                    let asset_name = asset_name_clone.clone();
-                    let client_key = client_key_clone.clone();
-                    let flows = flows_clone.clone();
-                    async move {
-                        w.try_create_ingestion_config(&asset_name, &client_key, &flows)
-                            .await
-                    }
+                    let client_key = client_key.clone();
+                    async move { w.try_get_ingestion_config_by_client_key(&client_key).await }
                 })
                 .await?;
 
-            let new_flows = {
-                if flows.is_empty() {
-                    Vec::new()
-                } else {
-                    let ingestion_config_id_clone = ingestion_config.ingestion_config_id.clone();
-                    retrying_ingestion_config
-                        .call(|mut w| {
-                            let ingestion_config_id = ingestion_config_id_clone.clone();
-                            async move { w.try_filter_flows(&ingestion_config_id, "").await }
-                        })
-                        .await?
-                }
-            };
-
-            let asset_service_wrapper = new_asset_service(grpc_channel.clone());
-            let retrying_asset = asset_service_wrapper.retrying(RetryConfig::default());
-            let asset_id_clone = ingestion_config.asset_id.clone();
-            let asset = retrying_asset
-                .call(|mut w| {
-                    let asset_id = asset_id_clone.clone();
-                    async move { w.try_get_asset_by_id(&asset_id).await }
-                })
-                .await
-                .context("failed to retrieve asset specified by ingestion config")?;
-
-            #[cfg(feature = "tracing")]
-            {
-                if !new_flows.is_empty() {
-                    let flow_names = new_flows
-                        .iter()
-                        .map(|f| f.name.as_str())
-                        .collect::<Vec<&str>>()
-                        .join(",");
-                    tracing::info!(
-                        ingestion_config_id = ingestion_config.ingestion_config_id,
-                        flow_names = flow_names,
-                        "created new ingestion config"
-                    );
-                }
-            }
-            Ok((ingestion_config, flows, asset))
-        }
-        Err(err) => Err(err),
-
-        Ok(ingestion_config) => {
             #[cfg(feature = "tracing")]
             tracing::info!(
                 ingestion_config_id = ingestion_config.ingestion_config_id,
                 "an existing ingestion config was found with the provided client-key"
             );
+            (ingestion_config, false)
+        }
+        Err(e) => return Err(e),
+    };
 
-            let asset_service_wrapper = new_asset_service(grpc_channel.clone());
-            let retrying_asset = asset_service_wrapper.retrying(RetryConfig::default());
-            let asset_id_clone2 = ingestion_config.asset_id.clone();
-            let asset = retrying_asset
-                .call(|mut w| {
-                    let asset_id = asset_id_clone2.clone();
-                    async move { w.try_get_asset_by_id(&asset_id).await }
-                })
-                .await
-                .context("failed to retrieve asset specified by ingestion config")?;
+    // Get the asset corresponding to the ingestion config.
+    let asset_service_wrapper = new_asset_service(grpc_channel.clone());
+    let retrying_asset = asset_service_wrapper.retrying(RetryConfig::default());
+    let asset = {
+        let asset_id = ingestion_config.asset_id.clone();
+        retrying_asset
+            .call(|mut w| {
+                let asset_id = asset_id.clone();
+                async move { w.try_get_asset_by_id(&asset_id).await }
+            })
+            .await
+            .context("failed to retrieve asset specified by ingestion config")?
+    };
 
-            if asset.name != asset_name {
-                return Err(Error::new_msg(
-                    ErrorKind::IncompatibleIngestionConfigChange,
-                    format!(
-                        "local ingestion config references asset '{asset_name}' but this existing config in Sift refers to asset '{}'",
-                        asset.name
-                    ),
-                ));
-            }
+    // Sanity check the Sift asset matches the expected asset-name.
+    if asset.name != asset_name {
+        return Err(Error::new_msg(
+            ErrorKind::IncompatibleIngestionConfigChange,
+            format!(
+                "local ingestion config references asset '{asset_name}' but this existing config in Sift refers to asset '{}'",
+                asset.name
+            ),
+        ));
+    }
 
+    // If the ingestion config was created new, the create call provided all the known ingestion
+    // config flows, so no further API calls are required.
+    if new_config {
+        #[cfg(feature = "tracing")]
+        {
             let flow_names = flows
                 .iter()
-                .map(|f| format!("'{}'", f.name))
-                .collect::<Vec<String>>()
+                .map(|f| f.name.as_str())
+                .collect::<Vec<&str>>()
                 .join(",");
+            tracing::info!(
+                ingestion_config_id = ingestion_config.ingestion_config_id,
+                flow_names = flow_names,
+                "created new ingestion config"
+            );
+        }
+        return Ok((ingestion_config, flows, asset));
+    }
 
-            let filter = flow_names
-                .is_empty()
-                .then(String::new)
-                .unwrap_or_else(|| format!("flow_name in [{flow_names}]"));
+    // Fetch existing flow configs that match the names of the provided flow configs
+    // so we can validate what we are trying to use vs. what Sift expects.
+    let flow_names = flows
+        .iter()
+        .map(|f| format!("'{}'", f.name))
+        .collect::<Vec<String>>()
+        .join(",");
 
-            let ingestion_config_id_clone = ingestion_config.ingestion_config_id.clone();
-            let filter_clone = filter.clone();
-            let existing_flows = retrying_ingestion_config
-                .call(|mut w| {
-                    let ingestion_config_id = ingestion_config_id_clone.clone();
-                    let filter = filter_clone.clone();
-                    async move { w.try_filter_flows(&ingestion_config_id, &filter).await }
-                })
-                .await?;
+    let filter = flow_names
+        .is_empty()
+        .then(String::new)
+        .unwrap_or_else(|| format!("flow_name in [{flow_names}]"));
 
-            // If no flows are provided, use the existing flows in Sift to populate the local flow cache.
-            if flows.is_empty() {
-                #[cfg(feature = "tracing")]
-                tracing::info!(
-                    ingestion_config_id = ingestion_config.ingestion_config_id,
-                    "no flows provided, using existing flows in Sift to populate the local flow cache"
-                );
-                return Ok((ingestion_config, existing_flows, asset));
-            }
+    let existing_flows = {
+        let ingestion_config_id = ingestion_config.ingestion_config_id.clone();
+        let filter = filter.clone();
+        retrying_ingestion_config
+            .call(|mut w| {
+                let ingestion_config_id = ingestion_config_id.clone();
+                let filter = filter.clone();
+                async move { w.try_filter_flows(&ingestion_config_id, &filter).await }
+            })
+            .await?
+    };
 
-            let mut flows_to_create: Vec<FlowConfig> = Vec::new();
+    // If no flows were provided, use the existing flows in Sift to populate the local flow cache.
+    if flows.is_empty() {
+        #[cfg(feature = "tracing")]
+        tracing::info!(
+            ingestion_config_id = ingestion_config.ingestion_config_id,
+            "no flows provided, using existing flows in Sift to populate the local flow cache"
+        );
+        return Ok((ingestion_config, existing_flows, asset));
+    }
 
-            for flow in &flows {
-                let mut flow_exists = false;
+    // Find the local flows that Sift does not yet know about so they can be created.
+    let mut flows_to_create: Vec<FlowConfig> = Vec::new();
+    for flow in &flows {
+        let mut flow_exists = false;
 
-                for existing_flow in existing_flows.iter().filter(|ef| ef == &flow) {
-                    flow_exists = flow
-                        .channels
-                        .iter()
-                        .zip(existing_flow.channels.iter())
-                        .all(|(lhs, rhs)| lhs == rhs);
+        for existing_flow in existing_flows.iter().filter(|ef| ef == &flow) {
+            flow_exists = flow
+                .channels
+                .iter()
+                .zip(existing_flow.channels.iter())
+                .all(|(lhs, rhs)| lhs == rhs);
 
-                    if flow_exists {
-                        break;
-                    }
-                }
-
-                if !flow_exists {
-                    flows_to_create.push(flow.clone());
-                }
-            }
-
-            if !flows_to_create.is_empty() {
-                let flows_to_create_clone = flows_to_create.clone();
-                let ingestion_config_id_clone = ingestion_config.ingestion_config_id.clone();
-                let _ = retrying_ingestion_config
-                    .call(|mut w| {
-                        let ingestion_config_id = ingestion_config_id_clone.clone();
-                        let flows = flows_to_create_clone.clone();
-                        async move {
-                            w.try_create_flows(&ingestion_config_id, flows.as_slice())
-                                .await
-                        }
-                    })
-                    .await;
-
-                #[cfg(feature = "tracing")]
-                {
-                    let new_flow_names = flows_to_create
-                        .iter()
-                        .map(|f| f.name.as_str())
-                        .collect::<Vec<&str>>()
-                        .join(",");
-                    tracing::info!(
-                        ingestion_config_id = ingestion_config.ingestion_config_id,
-                        new_flows = new_flow_names,
-                        "created new flows for ingestion config"
-                    );
-                }
-
-                // All the flows Sift sees with the specified names
-                let ingestion_config_id_clone2 = ingestion_config.ingestion_config_id.clone();
-                let filter_clone2 = filter.clone();
-                let sift_flows = retrying_ingestion_config
-                    .call(|mut w| {
-                        let ingestion_config_id = ingestion_config_id_clone2.clone();
-                        let filter = filter_clone2.clone();
-                        async move { w.try_filter_flows(&ingestion_config_id, &filter).await }
-                    })
-                    .await?;
-
-                validate_flows(&flows, &sift_flows)?;
-
-                // Validation succeeded... used the flows we got for confidence in correctness.
-                Ok((ingestion_config, sift_flows, asset))
-            } else {
-                Ok((ingestion_config, existing_flows, asset))
+            if flow_exists {
+                break;
             }
         }
+
+        // If the flow isn't known to Sift yet, it will need to be created.
+        if !flow_exists {
+            flows_to_create.push(flow.clone());
+        }
+    }
+
+    if !flows_to_create.is_empty() {
+        // Capture names before moving flows_to_create into add_new_flows.
+        #[cfg(feature = "tracing")]
+        let flow_names: Vec<String> = flows_to_create.iter().map(|f| f.name.clone()).collect();
+
+        let results = add_new_flows(
+            grpc_channel.clone(),
+            &ingestion_config.ingestion_config_id,
+            flows_to_create,
+        )
+        .await;
+
+        let mut flow_create_error = false;
+        for (idx, result) in results.into_iter().enumerate() {
+            match result {
+                Ok(Ok(())) => {}
+                // A concurrent SiftStream instance may have won the race to create this flow.
+                Ok(Err(e)) if e.kind() == ErrorKind::AlreadyExistsError => {}
+                Ok(Err(e)) => {
+                    #[cfg(feature = "tracing")]
+                    tracing::error!("failed to create flow {}: {e}", flow_names[idx]);
+                    flow_create_error = true;
+                }
+                Err(e) => {
+                    #[cfg(feature = "tracing")]
+                    tracing::error!("failed to create flow {}: {e}", flow_names[idx]);
+                    flow_create_error = true;
+                }
+            }
+        }
+
+        if flow_create_error {
+            return Err(Error::new_msg(
+                ErrorKind::CreateFlowError,
+                "Ingestion config flow creation failed. See logs for details.",
+            ));
+        }
+
+        #[cfg(feature = "tracing")]
+        tracing::info!(
+            ingestion_config_id = ingestion_config.ingestion_config_id,
+            new_flows = flow_names.join(","),
+            "created new flows for ingestion config"
+        );
+
+        // Fetch all flows Sift knows about with the specified names for validation.
+        let sift_flows = {
+            let ingestion_config_id = ingestion_config.ingestion_config_id.clone();
+            let filter = filter.clone();
+            retrying_ingestion_config
+                .call(|mut w| {
+                    let ingestion_config_id = ingestion_config_id.clone();
+                    let filter = filter.clone();
+                    async move { w.try_filter_flows(&ingestion_config_id, &filter).await }
+                })
+                .await?
+        };
+
+        validate_flows(&flows, &sift_flows)?;
+
+        Ok((ingestion_config, sift_flows, asset))
+    } else {
+        Ok((ingestion_config, existing_flows, asset))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::create_mock_grpc_channel_with_service;
+    use crate::test::{
+        FlowCreateError, MockIngestionConfigService,
+        create_mock_grpc_channel_with_ingestion_service, create_mock_grpc_channel_with_service,
+    };
     use sift_rs::common::r#type::v1::ChannelDataType;
     use sift_rs::ingestion_configs::v2::ChannelConfig;
     use uuid::Uuid;
@@ -381,5 +391,78 @@ mod tests {
         assert_eq!(ingestion_config.client_key, client_key);
         // Should return existing flows
         assert!(!returned_flows.is_empty());
+    }
+
+    // Covers the Err(e) => return Err(e) branch at the ingestion-config create match.
+    // An empty asset name triggers ArgumentValidationError from try_create_ingestion_config,
+    // which is not AlreadyExistsError and must propagate rather than be swallowed.
+    #[tokio::test]
+    async fn test_load_ingestion_config_propagates_non_already_exists_create_error() {
+        let (grpc_channel, _) = create_mock_grpc_channel_with_service().await;
+        let form = create_test_ingestion_config_form("", "some_client_key", vec![]);
+
+        let result = load_ingestion_config(grpc_channel, form).await;
+
+        assert!(result.is_err());
+        assert_ne!(result.unwrap_err().kind(), ErrorKind::AlreadyExistsError);
+    }
+
+    // Covers the flow_create_error path where add_new_flows returns a non-AlreadyExists
+    // error, which should surface as CreateFlowError.
+    #[tokio::test]
+    async fn test_load_ingestion_config_flow_creation_failure_returns_error() {
+        let service = MockIngestionConfigService::with_flow_create_error(FlowCreateError::Internal);
+        let (grpc_channel, _) = create_mock_grpc_channel_with_ingestion_service(service).await;
+
+        // brand_new_flow is not in the mock's existing flows, so it is queued for creation.
+        let flows = vec![FlowConfig {
+            name: "brand_new_flow".to_string(),
+            channels: vec![ChannelConfig {
+                name: "ch".to_string(),
+                data_type: ChannelDataType::Double.into(),
+                ..Default::default()
+            }],
+        }];
+        let form = create_test_ingestion_config_form(
+            "already_exists_asset",
+            "already_exists_client_key",
+            flows,
+        );
+
+        let result = load_ingestion_config(grpc_channel, form).await;
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), ErrorKind::CreateFlowError);
+    }
+
+    // Covers the AlreadyExistsError arm inside add_new_flows processing (the race
+    // condition where a concurrent SiftStream instance created the flow first).
+    // The function must succeed and return the flows created by the winning instance.
+    #[tokio::test]
+    async fn test_load_ingestion_config_race_condition_on_flow_creation_succeeds() {
+        let race_flow = FlowConfig {
+            name: "race_flow".to_string(),
+            channels: vec![ChannelConfig {
+                name: "ch".to_string(),
+                data_type: ChannelDataType::Double.into(),
+                ..Default::default()
+            }],
+        };
+        let service = MockIngestionConfigService::with_race_condition(vec![race_flow.clone()]);
+        let (grpc_channel, _) = create_mock_grpc_channel_with_ingestion_service(service).await;
+
+        let form = create_test_ingestion_config_form(
+            "already_exists_asset",
+            "already_exists_client_key",
+            vec![race_flow],
+        );
+
+        let (ingestion_config, returned_flows, asset) =
+            load_ingestion_config(grpc_channel, form).await.unwrap();
+
+        assert_eq!(ingestion_config.client_key, "already_exists_client_key");
+        assert_eq!(asset.name, "already_exists_asset");
+        assert_eq!(returned_flows.len(), 1);
+        assert_eq!(returned_flows[0].name, "race_flow");
     }
 }

--- a/rust/crates/sift_stream/src/stream/builder/config_loader.rs
+++ b/rust/crates/sift_stream/src/stream/builder/config_loader.rs
@@ -241,8 +241,8 @@ pub async fn load_ingestion_config(
 mod tests {
     use super::*;
     use crate::test::{
-        FlowCreateError, MockIngestionConfigService,
-        create_mock_grpc_channel_with_ingestion_service, create_mock_grpc_channel_with_service,
+        MockIngestionConfigService, create_mock_grpc_channel_with_ingestion_service,
+        create_mock_grpc_channel_with_service,
     };
     use sift_rs::common::r#type::v1::ChannelDataType;
     use sift_rs::ingestion_configs::v2::ChannelConfig;
@@ -411,7 +411,9 @@ mod tests {
     // error, which should surface as CreateFlowError.
     #[tokio::test]
     async fn test_load_ingestion_config_flow_creation_failure_returns_error() {
-        let service = MockIngestionConfigService::with_flow_create_error(FlowCreateError::Internal);
+        let service = MockIngestionConfigService::with_flow_create_error(
+            sift_error::Error::new_msg(sift_error::ErrorKind::IoError, "io error"),
+        );
         let (grpc_channel, _) = create_mock_grpc_channel_with_ingestion_service(service).await;
 
         // brand_new_flow is not in the mock's existing flows, so it is queued for creation.

--- a/rust/crates/sift_stream/src/stream/flow/mod.rs
+++ b/rust/crates/sift_stream/src/stream/flow/mod.rs
@@ -8,6 +8,11 @@ use sift_rs::ingest::v1::{
     IngestWithConfigDataStreamRequest, ingest_with_config_data_channel_value::Type,
 };
 use sift_rs::ingestion_configs::v2::FlowConfig;
+use sift_rs::wrappers::ingestion_configs::{
+    IngestionConfigServiceWrapper, new_ingestion_config_service,
+};
+use sift_rs::{RetryConfig, RetryExt, SiftChannel};
+use tokio::task::JoinError;
 
 use crate::{TimeValue, Value};
 
@@ -332,4 +337,50 @@ pub(crate) fn validate_flows(
         }
     }
     Ok(())
+}
+
+/// Concurrently creates flows for the given ingestion config.
+///
+/// Takes ownership of `flow_configs` so each can be moved directly into its spawned task
+/// without an intermediate clone. The per-retry clone inside each task is unavoidable.
+/// Errors are returned per-flow so callers can handle them individually, including treating
+/// [`ErrorKind::AlreadyExistsError`] as a success when a concurrent instance races to create
+/// the same flow.
+pub(crate) async fn add_new_flows(
+    grpc_channel: SiftChannel,
+    ingestion_config_id: &str,
+    flow_configs: Vec<FlowConfig>,
+) -> Vec<std::result::Result<Result<()>, JoinError>> {
+    #[cfg(feature = "tracing")]
+    tracing::info!(
+        ingestion_config_id =? ingestion_config_id,
+        new_flows = flow_configs
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect::<Vec<&str>>()
+            .join(","),
+        "adding new flows to ingestion config"
+    );
+
+    let mut calls = Vec::with_capacity(flow_configs.len());
+
+    for flow_config in flow_configs {
+        let channel = grpc_channel.clone();
+        let config_id = ingestion_config_id.to_string();
+
+        calls.push(tokio::spawn(async move {
+            let wrapper = new_ingestion_config_service(channel);
+            let retrying = wrapper.retrying(RetryConfig::default());
+            retrying
+                .call(|mut w| {
+                    let config_id = config_id.clone();
+                    let flow_config = flow_config.clone();
+                    async move { w.try_create_flows(&config_id, vec![flow_config]).await }
+                })
+                .await
+                .context("SiftStream::add_new_flows")
+        }));
+    }
+
+    futures::future::join_all(calls).await
 }

--- a/rust/crates/sift_stream/src/stream/flow/test.rs
+++ b/rust/crates/sift_stream/src/stream/flow/test.rs
@@ -1,7 +1,8 @@
-use super::validate_flows;
-use super::{FlowBuilder, FlowDescriptor, FlowDescriptorBuilder};
+use super::{FlowBuilder, FlowDescriptor, FlowDescriptorBuilder, add_new_flows, validate_flows};
 use crate::TimeValue;
 use crate::stream::channel::ChannelEnum;
+use crate::test::create_mock_grpc_channel_with_service;
+use sift_error::prelude::ErrorKind;
 use sift_rs::common::r#type::v1::ChannelDataType;
 use sift_rs::ingest::v1::ingest_with_config_data_channel_value::Type;
 use sift_rs::ingestion_configs::v2::{ChannelConfig, FlowConfig};
@@ -834,4 +835,88 @@ fn test_flow_builder_set_with_enum_key() {
     for value in &request.channel_values {
         assert!(value.r#type.is_some());
     }
+}
+
+#[tokio::test]
+async fn test_add_new_flows_creates_flows() {
+    let (grpc_channel, _) = create_mock_grpc_channel_with_service().await;
+
+    let flows = vec![
+        FlowConfig {
+            name: "flow_a".to_string(),
+            channels: vec![ChannelConfig {
+                name: "ch1".to_string(),
+                data_type: ChannelDataType::Double.into(),
+                ..Default::default()
+            }],
+        },
+        FlowConfig {
+            name: "flow_b".to_string(),
+            channels: vec![ChannelConfig {
+                name: "ch2".to_string(),
+                data_type: ChannelDataType::Int32.into(),
+                ..Default::default()
+            }],
+        },
+    ];
+
+    let results = add_new_flows(grpc_channel, "test_config_id", flows).await;
+
+    assert_eq!(results.len(), 2);
+    for result in results {
+        assert!(
+            matches!(result, Ok(Ok(()))),
+            "expected Ok(Ok(())) for each new flow"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_add_new_flows_returns_already_exists_for_callers_to_handle() {
+    let (grpc_channel, _) = create_mock_grpc_channel_with_service().await;
+
+    // The mock service pre-seeds "already_exists_flow"; creating it again returns AlreadyExists.
+    let flows = vec![FlowConfig {
+        name: "already_exists_flow".to_string(),
+        channels: vec![],
+    }];
+
+    let results = add_new_flows(grpc_channel, "test_config_id", flows).await;
+
+    assert_eq!(results.len(), 1);
+    let result = results.into_iter().next().unwrap();
+    assert!(
+        matches!(&result, Ok(Err(e)) if e.kind() == ErrorKind::AlreadyExistsError),
+        "expected AlreadyExists to be surfaced so callers can decide how to treat it"
+    );
+}
+
+#[tokio::test]
+async fn test_add_new_flows_empty_input() {
+    let (grpc_channel, _) = create_mock_grpc_channel_with_service().await;
+    let results = add_new_flows(grpc_channel, "test_config_id", vec![]).await;
+    assert!(results.is_empty());
+}
+
+#[tokio::test]
+async fn test_add_new_flows_mixed_new_and_existing() {
+    let (grpc_channel, _) = create_mock_grpc_channel_with_service().await;
+
+    let flows = vec![
+        FlowConfig {
+            name: "brand_new_flow".to_string(),
+            channels: vec![],
+        },
+        // Pre-seeded by the mock service.
+        FlowConfig {
+            name: "already_exists_flow".to_string(),
+            channels: vec![],
+        },
+    ];
+
+    let results = add_new_flows(grpc_channel, "test_config_id", flows).await;
+
+    assert_eq!(results.len(), 2);
+    assert!(matches!(results[0], Ok(Ok(()))));
+    assert!(matches!(&results[1], Ok(Err(e)) if e.kind() == ErrorKind::AlreadyExistsError));
 }

--- a/rust/crates/sift_stream/src/stream/mode/ingestion_config.rs
+++ b/rust/crates/sift_stream/src/stream/mode/ingestion_config.rs
@@ -1,5 +1,6 @@
 use crate::FlowBuilder;
 use crate::metrics::{SiftStreamMetrics, SiftStreamMetricsSnapshot};
+use crate::stream::flow::add_new_flows;
 use crate::stream::{Encodeable, Encoder, MetricsSnapshot};
 use crate::stream::{
     channel::ChannelValue,
@@ -14,10 +15,6 @@ use prost::Message;
 use sift_error::prelude::*;
 use sift_rs::SiftChannel;
 use sift_rs::ingestion_configs::v2::FlowConfig;
-use sift_rs::retry::{RetryConfig, RetryExt};
-use sift_rs::wrappers::ingestion_configs::{
-    IngestionConfigServiceWrapper, new_ingestion_config_service,
-};
 use sift_rs::{
     ingest::v1::IngestWithConfigDataStreamRequest, ingestion_configs::v2::IngestionConfig,
     runs::v2::Run,
@@ -61,54 +58,24 @@ impl IngestionConfigEncoder {
 
     /// Modify the existing ingestion config by adding new flows that weren't accounted for during
     /// initialization. This will register the flows with Sift.
+    ///
+    /// [`ErrorKind::AlreadyExistsError`] from any flow creation is treated as success: a
+    /// concurrent SiftStream instance may have won the race to create that flow.
     pub async fn add_new_flows(&mut self, flow_configs: &[FlowConfig]) -> Result<()> {
-        // Filter out flows that already exist.
-        let filtered = flow_configs
+        let filtered: Vec<&FlowConfig> = flow_configs
             .iter()
             .filter(|f| !self.flows_by_name.contains_key(&f.name))
-            .collect::<Vec<_>>();
+            .collect();
 
-        // If no new flows are provided, return early.
         if filtered.is_empty() {
             return Ok(());
         }
 
-        #[cfg(feature = "tracing")]
-        tracing::info!(
-            ingestion_config_id = self.ingestion_config_id(),
-            new_flows = filtered
-                .iter()
-                .map(|f| f.name.as_str())
-                .collect::<Vec<&str>>()
-                .join(","),
-            "adding new flows to ingestion config"
-        );
+        // Clone to produce owned copies for the spawned tasks; refs are kept for result processing.
+        let owned: Vec<FlowConfig> = filtered.iter().map(|&f| f.clone()).collect();
 
-        let mut calls = Vec::with_capacity(filtered.len());
-        let create_flows = filtered.into_iter().cloned().collect::<Vec<FlowConfig>>();
-        let ingestion_config_id = self.ingestion_config_id().to_string();
-
-        for flow_config in create_flows.iter() {
-            let channel = self.grpc_channel.clone();
-            let config_id = ingestion_config_id.clone();
-            let flow_config = flow_config.clone();
-
-            calls.push(tokio::spawn(async move {
-                let wrapper = new_ingestion_config_service(channel);
-                let retrying = wrapper.retrying(RetryConfig::default());
-                retrying
-                    .call(|mut w| {
-                        let config_id = config_id.clone();
-                        let flow_config = flow_config.clone();
-                        async move { w.try_create_flows(&config_id, vec![flow_config]).await }
-                    })
-                    .await
-                    .context("SiftStream::add_new_flows")
-            }));
-        }
-
-        // Wait for all the gRPC calls to complete.
-        let results = futures::future::join_all(calls).await;
+        let results =
+            add_new_flows(self.grpc_channel.clone(), self.ingestion_config_id(), owned).await;
 
         let mut add_config = |config: &FlowConfig| -> Result<()> {
             let flow_name = config.name.clone();
@@ -121,8 +88,7 @@ impl IngestionConfigEncoder {
             Ok(())
         };
 
-        // Iterate over the results and update the flow cache for the successfully created flows.
-        for (config, result) in create_flows.iter().zip(results.into_iter()) {
+        for (config, result) in filtered.into_iter().zip(results) {
             match result {
                 Ok(Ok(())) => {
                     add_config(config)?;
@@ -132,11 +98,11 @@ impl IngestionConfigEncoder {
                 }
                 Ok(Err(e)) => {
                     #[cfg(feature = "tracing")]
-                    tracing::error!("failed to create flow {}: {e}", config.name,);
+                    tracing::error!("failed to create flow {}: {e}", config.name);
                 }
                 Err(e) => {
                     #[cfg(feature = "tracing")]
-                    tracing::error!("failed to create flow {}: {e}", config.name,);
+                    tracing::error!("failed to create flow {}: {e}", config.name);
                 }
             }
         }

--- a/rust/crates/sift_stream/src/test.rs
+++ b/rust/crates/sift_stream/src/test.rs
@@ -2,6 +2,7 @@ use crate::SiftChannel;
 use hyper_util::rt::TokioIo;
 use pbjson_types::Timestamp;
 use sift_connect::grpc::interceptor::AuthInterceptor;
+use sift_error::{Error, ErrorKind};
 use sift_rs::assets::v1::asset_service_server::{AssetService, AssetServiceServer};
 use sift_rs::assets::v1::{
     ArchiveAssetRequest, ArchiveAssetResponse, Asset, DeleteAssetRequest, DeleteAssetResponse,
@@ -51,15 +52,10 @@ impl PingService for MockPingService {
     }
 }
 
-pub(crate) enum FlowCreateError {
-    AlreadyExists,
-    Internal,
-}
-
 pub(crate) struct MockIngestionConfigService {
     existing_flows: Arc<Mutex<Vec<FlowConfig>>>,
     existing_ingestion_configs: Arc<Mutex<Vec<IngestionConfig>>>,
-    flow_create_error: Option<FlowCreateError>,
+    flow_create_error: Option<Error>,
     list_flows_call_count: Arc<AtomicUsize>,
     // Non-empty signals race-condition mode: returned on calls after the first.
     deferred_flows: Vec<FlowConfig>,
@@ -91,7 +87,7 @@ impl Default for MockIngestionConfigService {
 }
 
 impl MockIngestionConfigService {
-    pub(crate) fn with_flow_create_error(err: FlowCreateError) -> Self {
+    pub(crate) fn with_flow_create_error(err: Error) -> Self {
         let existing_flow = FlowConfig {
             name: "already_exists_flow".to_string(),
             channels: vec![ChannelConfig {
@@ -127,7 +123,10 @@ impl MockIngestionConfigService {
         Self {
             existing_flows: Arc::new(Mutex::new(vec![])),
             existing_ingestion_configs: Arc::new(Mutex::new(vec![existing_ingestion_config])),
-            flow_create_error: Some(FlowCreateError::AlreadyExists),
+            flow_create_error: Some(Error::new_msg(
+                sift_error::ErrorKind::AlreadyExistsError,
+                "already exists",
+            )),
             list_flows_call_count: Arc::new(AtomicUsize::new(0)),
             deferred_flows,
         }
@@ -203,11 +202,11 @@ impl IngestionConfigService for MockIngestionConfigService {
         request: Request<CreateIngestionConfigFlowsRequest>,
     ) -> Result<Response<CreateIngestionConfigFlowsResponse>, Status> {
         if let Some(err) = &self.flow_create_error {
-            return Err(match err {
-                FlowCreateError::AlreadyExists => {
+            return Err(match err.kind() {
+                ErrorKind::AlreadyExistsError => {
                     Status::already_exists("another instance already created this flow")
                 }
-                FlowCreateError::Internal => Status::internal("internal error creating flow"),
+                _ => Status::internal("internal error creating flow"),
             });
         }
 

--- a/rust/crates/sift_stream/src/test.rs
+++ b/rust/crates/sift_stream/src/test.rs
@@ -51,9 +51,18 @@ impl PingService for MockPingService {
     }
 }
 
+pub(crate) enum FlowCreateError {
+    AlreadyExists,
+    Internal,
+}
+
 pub(crate) struct MockIngestionConfigService {
     existing_flows: Arc<Mutex<Vec<FlowConfig>>>,
     existing_ingestion_configs: Arc<Mutex<Vec<IngestionConfig>>>,
+    flow_create_error: Option<FlowCreateError>,
+    list_flows_call_count: Arc<AtomicUsize>,
+    // Non-empty signals race-condition mode: returned on calls after the first.
+    deferred_flows: Vec<FlowConfig>,
 }
 
 impl Default for MockIngestionConfigService {
@@ -74,6 +83,53 @@ impl Default for MockIngestionConfigService {
         Self {
             existing_flows: Arc::new(Mutex::new(vec![existing_flow])),
             existing_ingestion_configs: Arc::new(Mutex::new(vec![existing_ingestion_config])),
+            flow_create_error: None,
+            list_flows_call_count: Arc::new(AtomicUsize::new(0)),
+            deferred_flows: vec![],
+        }
+    }
+}
+
+impl MockIngestionConfigService {
+    pub(crate) fn with_flow_create_error(err: FlowCreateError) -> Self {
+        let existing_flow = FlowConfig {
+            name: "already_exists_flow".to_string(),
+            channels: vec![ChannelConfig {
+                name: "channel1".to_string(),
+                data_type: ChannelDataType::Double.into(),
+                ..Default::default()
+            }],
+        };
+        let existing_ingestion_config = IngestionConfig {
+            ingestion_config_id: Uuid::new_v4().to_string(),
+            asset_id: "already_exists_asset".to_string(),
+            client_key: "already_exists_client_key".to_string(),
+        };
+        Self {
+            existing_flows: Arc::new(Mutex::new(vec![existing_flow])),
+            existing_ingestion_configs: Arc::new(Mutex::new(vec![existing_ingestion_config])),
+            flow_create_error: Some(err),
+            list_flows_call_count: Arc::new(AtomicUsize::new(0)),
+            deferred_flows: vec![],
+        }
+    }
+
+    // Simulates the TOCTOU race where another SiftStream instance creates the flows
+    // between our initial list check and our create attempt. The first list_flows call
+    // returns empty; create_flows returns AlreadyExists; subsequent list_flows calls
+    // return `deferred_flows` so validation passes.
+    pub(crate) fn with_race_condition(deferred_flows: Vec<FlowConfig>) -> Self {
+        let existing_ingestion_config = IngestionConfig {
+            ingestion_config_id: Uuid::new_v4().to_string(),
+            asset_id: "already_exists_asset".to_string(),
+            client_key: "already_exists_client_key".to_string(),
+        };
+        Self {
+            existing_flows: Arc::new(Mutex::new(vec![])),
+            existing_ingestion_configs: Arc::new(Mutex::new(vec![existing_ingestion_config])),
+            flow_create_error: Some(FlowCreateError::AlreadyExists),
+            list_flows_call_count: Arc::new(AtomicUsize::new(0)),
+            deferred_flows,
         }
     }
 }
@@ -146,6 +202,15 @@ impl IngestionConfigService for MockIngestionConfigService {
         &self,
         request: Request<CreateIngestionConfigFlowsRequest>,
     ) -> Result<Response<CreateIngestionConfigFlowsResponse>, Status> {
+        if let Some(err) = &self.flow_create_error {
+            return Err(match err {
+                FlowCreateError::AlreadyExists => {
+                    Status::already_exists("another instance already created this flow")
+                }
+                FlowCreateError::Internal => Status::internal("internal error creating flow"),
+            });
+        }
+
         let create_flows = request.into_inner();
 
         let mut existing_flows = self.existing_flows.lock().unwrap();
@@ -163,10 +228,21 @@ impl IngestionConfigService for MockIngestionConfigService {
         &self,
         request: Request<ListIngestionConfigFlowsRequest>,
     ) -> Result<Response<ListIngestionConfigFlowsResponse>, Status> {
+        let count = self.list_flows_call_count.fetch_add(1, Ordering::Relaxed);
+
+        // Race-condition mode: after the first call (which returns nothing, making
+        // the caller believe the flows don't exist), return the deferred flows so
+        // that the post-creation validation pass succeeds.
+        if count > 0 && !self.deferred_flows.is_empty() {
+            return Ok(Response::new(ListIngestionConfigFlowsResponse {
+                flows: self.deferred_flows.clone(),
+                next_page_token: "".to_string(),
+            }));
+        }
+
         let list_flows: ListIngestionConfigFlowsRequest = request.into_inner();
         let existing_flows = self.existing_flows.lock().unwrap();
 
-        // If the filter contains "already_exists_flow" or is empty, return the existing flow.
         let mut flows = Vec::new();
         for flow in existing_flows.iter() {
             if list_flows.filter.is_empty() || list_flows.filter.contains(&flow.name) {
@@ -372,6 +448,54 @@ impl IngestService for MockIngestService {
     {
         Err(Status::unimplemented("Not implemented for test"))
     }
+}
+
+pub(crate) async fn create_mock_grpc_channel_with_ingestion_service(
+    ingestion_service: MockIngestionConfigService,
+) -> (SiftChannel, MockIngestService) {
+    let mock_ingest_service = MockIngestService::new();
+    let mock_ingest_service_clone = mock_ingest_service.clone();
+
+    let (client, server) = tokio::io::duplex(1024);
+
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(IngestServiceServer::new(mock_ingest_service_clone))
+            .add_service(PingServiceServer::new(MockPingService))
+            .add_service(IngestionConfigServiceServer::new(ingestion_service))
+            .add_service(AssetServiceServer::new(MockAssetService))
+            .add_service(RunServiceServer::new(MockRunService))
+            .serve_with_incoming(tokio_stream::once(Ok::<_, std::io::Error>(server)))
+            .await
+            .unwrap();
+    });
+
+    let mut client = Some(client);
+    let channel = Endpoint::try_from("http://[::]:50051")
+        .unwrap()
+        .connect_with_connector(service_fn(move |_: Uri| {
+            let client = client.take();
+
+            async move {
+                if let Some(client) = client {
+                    Ok(TokioIo::new(client))
+                } else {
+                    Err(std::io::Error::other("Client already taken"))
+                }
+            }
+        }))
+        .await
+        .unwrap();
+
+    let sift_channel = ServiceBuilder::new()
+        .layer(tonic::service::interceptor::InterceptorLayer::new(
+            AuthInterceptor {
+                apikey: "test-api-key".to_string(),
+            },
+        ))
+        .service(channel);
+
+    (sift_channel, mock_ingest_service)
 }
 
 pub(crate) async fn create_mock_grpc_channel_with_service() -> (SiftChannel, MockIngestService) {

--- a/rust/crates/sift_stream/tests/common/mod.rs
+++ b/rust/crates/sift_stream/tests/common/mod.rs
@@ -7,11 +7,7 @@ use sift_rs::assets::v1::{
     GetAssetRequest, GetAssetResponse, ListAssetsRequest, ListAssetsResponse, UpdateAssetRequest,
     UpdateAssetResponse,
 };
-use sift_rs::ingest::v1::{
-    IngestArbitraryProtobufDataStreamRequest, IngestArbitraryProtobufDataStreamResponse,
-    IngestWithConfigDataStreamRequest, IngestWithConfigDataStreamResponse,
-    ingest_service_server::{IngestService, IngestServiceServer},
-};
+use sift_rs::ingest::v1::ingest_service_server::{IngestService, IngestServiceServer};
 use sift_rs::ingestion_configs::v2::ingestion_config_service_server::{
     IngestionConfigService, IngestionConfigServiceServer,
 };
@@ -31,11 +27,9 @@ use sift_rs::runs::v2::{
     ListRunsResponse, Run, StopRunRequest, StopRunResponse, UpdateRunRequest, UpdateRunResponse,
 };
 use sift_stream::{ChannelConfig, ChannelDataType, FlowConfig};
-use std::collections::HashMap;
 use std::io::Error as IoError;
 use std::sync::{Arc, Mutex};
 use tokio::task::JoinHandle;
-use tokio_stream::StreamExt;
 use tonic::transport::{Endpoint, Server, Uri};
 use tonic::{Request, Response, Status};
 use tower::{ServiceBuilder, service_fn};
@@ -191,12 +185,13 @@ pub(crate) struct MockAssetService;
 impl AssetService for MockAssetService {
     async fn get_asset(
         &self,
-        _: Request<GetAssetRequest>,
+        request: Request<GetAssetRequest>,
     ) -> Result<Response<GetAssetResponse>, Status> {
+        let asset_id = request.into_inner().asset_id;
         Ok(Response::new(GetAssetResponse {
             asset: Some(Asset {
-                asset_id: "asset-0".to_string(),
-                name: "test_asset".to_string(),
+                name: asset_id.clone(),
+                asset_id,
                 organization_id: "test".to_string(),
                 created_by_user_id: "test".to_string(),
                 modified_by_user_id: "test".to_string(),

--- a/rust/crates/sift_stream/tests/common/prelude.rs
+++ b/rust/crates/sift_stream/tests/common/prelude.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)]
 pub use async_trait::async_trait;
 pub use sift_rs::ingest::v1::ingest_service_server::IngestService;
 pub use tonic::{Request, Response, Status, Streaming};


### PR DESCRIPTION
Fixes a race condition when setting up `SiftStream` and trying to create new ingestion configs or ingestion config flows.

The issue stemmed from the fact that we first were checking if the configs already existed, creating essentially a time-of-check-time-of-use race condition. If two separate instances were attempting to create the same new config, both would see the config didn't exist, then attempt to create it -- only one would succeed in creation, while the other would fail with "Already Exists". The fix is to simply first attempt to create the new config -- if it already exists, the function can fall through to fetch the existing configuration.

A similar approach is also used for creating ingestion config flows. 

Finally, lint findings for the Rust crates are being fixed to ensure the crates are clean of lint findings.