### PR TITLE
rust(chore): Rust crate 0.9.1 prep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 
 [workspace.package]
 authors = ["Sift Software Engineers <engineering@siftstack.com>"]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 categories = ["aerospace", "science::robotics"]
 homepage = "https://github.com/sift-stack/sift"
@@ -73,11 +73,11 @@ tracing-test = { version = "0.2", features = ["no-env-filter"] }
 uuid = { version = "1.22", features = ["v4"] }
 zip = "8.2"
 
-sift_connect = { version = "0.9.0", path = "rust/crates/sift_connect" }
-sift_rs = { version = "0.9.0", path = "rust/crates/sift_rs" }
-sift_error = { version = "0.9.0", path = "rust/crates/sift_error" }
-sift_stream = { version = "0.9.0", path = "rust/crates/sift_stream" }
-sift_pbfs = { version = "0.9.0", path = "rust/crates/sift_pbfs" }
+sift_connect = { version = "0.9.1", path = "rust/crates/sift_connect" }
+sift_rs = { version = "0.9.1", path = "rust/crates/sift_rs" }
+sift_error = { version = "0.9.1", path = "rust/crates/sift_error" }
+sift_stream = { version = "0.9.1", path = "rust/crates/sift_stream" }
+sift_pbfs = { version = "0.9.1", path = "rust/crates/sift_pbfs" }
 
 sift_stream_bindings = { version = "0.3.0", path = "rust/crates/sift_stream_bindings" }
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -3,6 +3,19 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v0.9.1] - May 15, 2026
+### Bug Fixes
+
+#### Race condition when creating ingestion configs (PR [#562](https://github.com/sift-stack/sift/pull/562))
+
+`SiftStream` now attempts to create the ingestion config first and treats an `AlreadyExists` response
+as a successful lookup rather than an error. Previously, the logic fetched first and created on
+`NotFound`, which left a window where two processes starting simultaneously could both receive
+`NotFound` and then have one fail with `AlreadyExists`. The new approach also adds concurrent
+flow creation so that new flows added to an existing ingestion config are created in parallel.
+
+---
+
 ## [v0.9.0] - April 22, 2026
 ### What's New
 


### PR DESCRIPTION
Bumps Rust crate versions to 0.9.1 in order to release a bug fix for a race condition in creating ingestion configs and flow configs during initialization.