### PR TITLE
rust(feat): ping sub-command

### DIFF
--- a/rust/crates/sift_cli/src/cli/mod.rs
+++ b/rust/crates/sift_cli/src/cli/mod.rs
@@ -52,6 +52,9 @@ pub enum Cmd {
     /// Import time series files into Sift
     #[command(subcommand)]
     Import(ImportCmd),
+
+    /// Ping the Sift API to check connectivity
+    Ping,
 }
 
 #[derive(Subcommand)]

--- a/rust/crates/sift_cli/src/cli/mod.rs
+++ b/rust/crates/sift_cli/src/cli/mod.rs
@@ -53,7 +53,7 @@ pub enum Cmd {
     #[command(subcommand)]
     Import(ImportCmd),
 
-    /// Ping the Sift API to check connectivity
+    /// Ping the Sift API to verify credentials and connectivity
     Ping,
 }
 

--- a/rust/crates/sift_cli/src/cmd/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/mod.rs
@@ -8,6 +8,7 @@ pub mod completions;
 pub mod config;
 pub mod export;
 pub mod import;
+pub mod ping;
 
 pub struct Context {
     pub grpc_uri: String,

--- a/rust/crates/sift_cli/src/cmd/ping.rs
+++ b/rust/crates/sift_cli/src/cmd/ping.rs
@@ -1,0 +1,24 @@
+use std::process::ExitCode;
+
+use anyhow::{Context as AnyhowContext, Result};
+use sift_rs::ping::v1::{PingRequest, ping_service_client::PingServiceClient};
+
+use crate::util::{api::create_grpc_channel, tty::Output};
+
+use super::Context;
+
+pub async fn run(ctx: Context) -> Result<ExitCode> {
+    let grpc_channel = create_grpc_channel(&ctx)?;
+    let mut ping_service = PingServiceClient::new(grpc_channel);
+
+    let response = ping_service
+        .ping(PingRequest::default())
+        .await
+        .context("failed to ping Sift")?
+        .into_inner()
+        .response;
+
+    Output::new().line(response).print();
+
+    Ok(ExitCode::SUCCESS)
+}

--- a/rust/crates/sift_cli/src/main.rs
+++ b/rust/crates/sift_cli/src/main.rs
@@ -90,6 +90,7 @@ fn run(clargs: cli::Args) -> Result<ExitCode> {
             cli::ExportCmd::Run(args) => run_future(cmd::export::run(ctx, args)),
             cli::ExportCmd::Asset(args) => run_future(cmd::export::asset(ctx, args)),
         },
+        Cmd::Ping => run_future(cmd::ping::run(ctx)),
         _ => Ok(ExitCode::SUCCESS),
     }
 }


### PR DESCRIPTION
## Summary
Adds a `ping` subcommand to `sift-cli` that calls `PingService.Ping` and prints the server response.

local: 
<img width="595" height="100" alt="image" src="https://github.com/user-attachments/assets/50196939-4050-4d4b-bde1-f4c81f488f49" />
dev: 
<img width="598" height="97" alt="image" src="https://github.com/user-attachments/assets/434b3740-72e3-4b8c-8698-340285eb36a0" />
invalid: 
<img width="845" height="137" alt="image" src="https://github.com/user-attachments/assets/275c8912-404d-44cd-86c7-8222fbe75688" />


## Validation
-  `cargo run -p sift_cli -- ping` prints the server response
-  `--profile <name>` is honored
- Invalid API key surfaces the server's `unauthenticated` error
