### PR TITLE
rust(feat): Added cli args for parquet export

### DIFF
--- a/rust/crates/sift_cli/src/cli/export.rs
+++ b/rust/crates/sift_cli/src/cli/export.rs
@@ -5,6 +5,7 @@ use sift_rs::exports::v1::ExportOutputFormat;
 pub enum Format {
     Csv,
     Sun,
+    Parquet,
 }
 
 impl From<Format> for ExportOutputFormat {
@@ -12,6 +13,7 @@ impl From<Format> for ExportOutputFormat {
         match val {
             Format::Csv => ExportOutputFormat::Csv,
             Format::Sun => ExportOutputFormat::Sun,
+            Format::Parquet => ExportOutputFormat::Parquet,
         }
     }
 }


### PR DESCRIPTION
## Description

:ticket: ENG-10459 :ticket: 

Adding parquet export functionality. It just hits the endpoint to make a export data request.

## Verification

Tested manual exports for both Flat Dataset and SCPR.

Export Command
<img width="1132" height="159" alt="Screenshot 2026-05-18 at 1 29 02 PM" src="https://github.com/user-attachments/assets/e023d3fe-12ec-48e2-98b7-c80b25f99090" />

The above visualized via local tool
<img width="1481" height="465" alt="Screenshot 2026-05-18 at 1 31 18 PM" src="https://github.com/user-attachments/assets/b96631f6-b3f5-4d79-8ee7-60a0bb6ac3b6" />

