### PR TITLE
rust(feat): add list_reports tool

### DIFF
--- a/rust/crates/sift_cli/assets/docs/src/agents/mcp.md
+++ b/rust/crates/sift_cli/assets/docs/src/agents/mcp.md
@@ -27,6 +27,7 @@ not run interactively.
 | `list_assets`    | List assets, with filtering and ordering.                                     |
 | `list_runs`      | List runs, with filtering and ordering.                                       |
 | `list_channels`  | List channels for an asset.                                                   |
+| `list_reports`   | List reports, with filtering and ordering.                                    |
 | `get_data`       | Download channel data for an asset/run to a Parquet file, with optional decimation. |
 | `sql`            | Run SQL over one or more Parquet files; chain after `get_data` for analysis.  |
 | `upload_dataset` | Stream a Parquet dataset into Sift.                                           |

--- a/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
+++ b/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
@@ -16,7 +16,7 @@ to combine them when working with Sift.
 
 1. **Sift MCP server** — started by `sift-cli mcp`. The preferred surface for
    agents. Exposes structured, authenticated tools:
-   - `list_assets`, `list_runs`, `list_channels`: discover what exists.
+   - `list_assets`, `list_runs`, `list_channels`, `list_reports`: discover what exists.
    - `get_data`: download channel data for an asset/run to a Parquet file.
    - `sql`: run SQL over one or more Parquet files (chain after `get_data`).
    - `upload_dataset`: stream a Parquet dataset into Sift.

--- a/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
@@ -28,7 +28,7 @@ to combine them when working with Sift.
 
 1. **Sift MCP server** — started by `sift-cli mcp`. The preferred surface for
    agents. Exposes structured, authenticated tools:
-   - `list_assets`, `list_runs`, `list_channels`: discover what exists.
+   - `list_assets`, `list_runs`, `list_channels`, `list_reports`: discover what exists.
    - `get_data`: download channel data for an asset/run to a Parquet file.
    - `sql`: run SQL over one or more Parquet files (chain after `get_data`).
    - `upload_dataset`: stream a Parquet dataset into Sift.

--- a/rust/crates/sift_mcp/src/server/mod.rs
+++ b/rust/crates/sift_mcp/src/server/mod.rs
@@ -11,7 +11,7 @@ use sift_rs::SiftChannel;
 
 use crate::service::{
     assets::AssetService, channels::ChannelService, data::DataService, ingest::IngestService,
-    runs::RunService,
+    reports::ReportService, runs::RunService,
 };
 
 #[derive(Clone)]
@@ -24,6 +24,7 @@ pub struct SiftMcpServer {
     pub data_service: DataService,
     pub ingest_service: IngestService,
     pub run_service: RunService,
+    pub report_service: ReportService,
 }
 
 #[tool_handler(
@@ -49,6 +50,7 @@ impl SiftMcpServer {
         let channel_service = ChannelService::new(channel.clone());
         let ingest_service = IngestService::new(channel.clone());
         let run_service = RunService::new(channel.clone());
+        let report_service = ReportService::new(channel.clone());
 
         Self {
             asset_service,
@@ -56,6 +58,7 @@ impl SiftMcpServer {
             data_service,
             ingest_service,
             run_service,
+            report_service,
             tool_router,
             prompt_router,
         }

--- a/rust/crates/sift_mcp/src/service/mod.rs
+++ b/rust/crates/sift_mcp/src/service/mod.rs
@@ -2,6 +2,7 @@ pub mod assets;
 pub mod channels;
 pub mod data;
 pub mod ingest;
+pub mod reports;
 pub mod runs;
 
 pub(crate) mod common;

--- a/rust/crates/sift_mcp/src/service/reports/mod.rs
+++ b/rust/crates/sift_mcp/src/service/reports/mod.rs
@@ -1,0 +1,67 @@
+use crate::service::common;
+use anyhow::{Context, Result};
+use sift_rs::{
+    SiftChannel,
+    reports::v1::{
+        ListReportsRequest, ListReportsResponse, Report, report_service_client::ReportServiceClient,
+    },
+};
+
+#[cfg(test)]
+mod test;
+
+#[derive(Clone)]
+pub struct ReportService {
+    channel: SiftChannel,
+}
+
+impl ReportService {
+    pub fn new(channel: SiftChannel) -> Self {
+        Self { channel }
+    }
+
+    pub async fn list_reports(
+        &self,
+        filter: String,
+        order_by: Option<String>,
+        limit: Option<u32>,
+        organization_id: Option<String>,
+    ) -> Result<Vec<Report>> {
+        let (page_size, record_limit) = common::paging(limit);
+
+        let mut client = ReportServiceClient::new(self.channel.clone());
+        let mut page_token = String::new();
+        let mut results = Vec::new();
+
+        loop {
+            let resp = client
+                .list_reports(ListReportsRequest {
+                    filter: filter.clone(),
+                    page_size,
+                    page_token,
+                    order_by: order_by.clone().unwrap_or_default(),
+                    organization_id: organization_id.clone().unwrap_or_default(),
+                })
+                .await
+                .context("failed to query reports")?;
+
+            let ListReportsResponse {
+                reports,
+                next_page_token,
+            } = resp.into_inner();
+            if reports.is_empty() {
+                break;
+            }
+            results.extend(reports);
+
+            if results.len() >= record_limit || next_page_token.is_empty() {
+                break;
+            }
+            page_token = next_page_token;
+        }
+
+        results.truncate(record_limit);
+
+        Ok(results)
+    }
+}

--- a/rust/crates/sift_mcp/src/service/reports/test.rs
+++ b/rust/crates/sift_mcp/src/service/reports/test.rs
@@ -1,0 +1,235 @@
+use sift_rs::reports::v1::{
+    ListReportsResponse, Report, report_service_server::ReportServiceServer,
+};
+use sift_test_util::{grpc::memory_sift_channel, mock::reports::v1::MockReportServiceImpl};
+use tokio::task::JoinHandle;
+use tonic::{Response, Status, transport::Server};
+
+use super::ReportService;
+use crate::service::common::PAGE_SIZE;
+
+async fn service_with_mock(mock: MockReportServiceImpl) -> (ReportService, JoinHandle<()>) {
+    let (client, server) = tokio::io::duplex(1024);
+    let channel = memory_sift_channel(client).await;
+
+    let handle = tokio::spawn(async move {
+        Server::builder()
+            .add_service(ReportServiceServer::new(mock))
+            .serve_with_incoming(tokio_stream::once(Ok::<_, std::io::Error>(server)))
+            .await
+            .unwrap();
+    });
+
+    (ReportService::new(channel), handle)
+}
+
+#[tokio::test]
+async fn list_reports_returns_single_page() {
+    let mut mock = MockReportServiceImpl::new();
+    mock.expect_list_reports()
+        .withf(|req| req.get_ref().filter == "name == \"nightly\"")
+        .returning(|_| {
+            Ok(Response::new(ListReportsResponse {
+                reports: vec![Report {
+                    report_id: "rep1".into(),
+                    name: "nightly".into(),
+                    ..Default::default()
+                }],
+                next_page_token: String::new(),
+            }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let reports = service
+        .list_reports("name == \"nightly\"".to_string(), None, None, None)
+        .await
+        .expect("list_reports failed");
+
+    assert_eq!(reports.len(), 1);
+    assert_eq!(reports[0].report_id, "rep1");
+}
+
+#[tokio::test]
+async fn list_reports_forwards_organization_id() {
+    let mut mock = MockReportServiceImpl::new();
+    mock.expect_list_reports()
+        .withf(|req| req.get_ref().organization_id == "org-123")
+        .returning(|_| {
+            Ok(Response::new(ListReportsResponse {
+                reports: vec![Report {
+                    report_id: "rep1".into(),
+                    ..Default::default()
+                }],
+                next_page_token: String::new(),
+            }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let reports = service
+        .list_reports(String::new(), None, None, Some("org-123".to_string()))
+        .await
+        .expect("list_reports failed");
+
+    assert_eq!(reports.len(), 1);
+}
+
+#[tokio::test]
+async fn list_reports_paginates_until_token_empty() {
+    let mut mock = MockReportServiceImpl::new();
+    mock.expect_list_reports().returning(|req| {
+        let req = req.into_inner();
+        assert_eq!(req.page_size, PAGE_SIZE);
+        let (reports, next) = match req.page_token.as_str() {
+            "" => (
+                vec![Report {
+                    report_id: "rep1".into(),
+                    ..Default::default()
+                }],
+                "page-2".to_string(),
+            ),
+            "page-2" => (
+                vec![Report {
+                    report_id: "rep2".into(),
+                    ..Default::default()
+                }],
+                String::new(),
+            ),
+            other => return Err(Status::invalid_argument(format!("bad token: {other}"))),
+        };
+        Ok(Response::new(ListReportsResponse {
+            reports,
+            next_page_token: next,
+        }))
+    });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let reports = service
+        .list_reports(String::new(), None, None, None)
+        .await
+        .expect("list_reports failed");
+
+    let ids: Vec<&str> = reports.iter().map(|r| r.report_id.as_str()).collect();
+    assert_eq!(ids, vec!["rep1", "rep2"]);
+}
+
+#[tokio::test]
+async fn list_reports_respects_limit() {
+    let mut mock = MockReportServiceImpl::new();
+    mock.expect_list_reports().times(1).returning(|req| {
+        let req = req.into_inner();
+        assert_eq!(req.page_size, 2);
+        Ok(Response::new(ListReportsResponse {
+            reports: vec![
+                Report {
+                    report_id: "rep1".into(),
+                    ..Default::default()
+                },
+                Report {
+                    report_id: "rep2".into(),
+                    ..Default::default()
+                },
+            ],
+            next_page_token: "page-2".into(),
+        }))
+    });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let reports = service
+        .list_reports(String::new(), None, Some(2), None)
+        .await
+        .expect("list_reports failed");
+
+    assert_eq!(reports.len(), 2);
+}
+
+#[tokio::test]
+async fn list_reports_truncates_to_limit_across_pages() {
+    let mut mock = MockReportServiceImpl::new();
+    mock.expect_list_reports().returning(|req| {
+        let req = req.into_inner();
+        assert_eq!(req.page_size, 3);
+        let (reports, next) = match req.page_token.as_str() {
+            "" => (
+                vec![
+                    Report {
+                        report_id: "rep1".into(),
+                        ..Default::default()
+                    },
+                    Report {
+                        report_id: "rep2".into(),
+                        ..Default::default()
+                    },
+                ],
+                "page-2".to_string(),
+            ),
+            "page-2" => (
+                vec![
+                    Report {
+                        report_id: "rep3".into(),
+                        ..Default::default()
+                    },
+                    Report {
+                        report_id: "rep4".into(),
+                        ..Default::default()
+                    },
+                ],
+                String::new(),
+            ),
+            other => return Err(Status::invalid_argument(format!("bad token: {other}"))),
+        };
+        Ok(Response::new(ListReportsResponse {
+            reports,
+            next_page_token: next,
+        }))
+    });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let reports = service
+        .list_reports(String::new(), None, Some(3), None)
+        .await
+        .expect("list_reports failed");
+
+    let ids: Vec<&str> = reports.iter().map(|r| r.report_id.as_str()).collect();
+    assert_eq!(ids, vec!["rep1", "rep2", "rep3"]);
+}
+
+#[tokio::test]
+async fn list_reports_breaks_on_empty_page() {
+    let mut mock = MockReportServiceImpl::new();
+    mock.expect_list_reports().times(1).returning(|_| {
+        Ok(Response::new(ListReportsResponse {
+            reports: vec![],
+            next_page_token: "ignored".into(),
+        }))
+    });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let reports = service
+        .list_reports(String::new(), None, None, None)
+        .await
+        .expect("list_reports failed");
+
+    assert!(reports.is_empty());
+}
+
+#[tokio::test]
+async fn list_reports_propagates_grpc_error() {
+    let mut mock = MockReportServiceImpl::new();
+    mock.expect_list_reports()
+        .returning(|_| Err(Status::not_found("no such report")));
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let err = service
+        .list_reports(String::new(), None, None, None)
+        .await
+        .expect_err("expected error");
+
+    assert!(err.to_string().contains("failed to query reports"));
+}

--- a/rust/crates/sift_mcp/src/tool/list/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/list/mod.rs
@@ -21,6 +21,14 @@ pub struct ListParams {
     limit: Option<u32>,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ReportListParams {
+    filter: String,
+    order_by: Option<String>,
+    limit: Option<u32>,
+    organization_id: Option<String>,
+}
+
 #[tool_router(router = list_router, vis = "pub(crate)")]
 impl SiftMcpServer {
     #[tool(
@@ -168,6 +176,58 @@ impl SiftMcpServer {
             .list_channels(filter, order_by, limit)
             .await
             .map(|channels| serde_json::json!({ "channels": channels }))
+            .map_err(from_anyhow)?;
+
+        Ok(CallToolResult::structured(out))
+    }
+
+    #[tool(
+        name = "list_reports",
+        description = "
+            List reports in Sift, optionally filtered by a CEL expression and ordered by one or more fields.
+
+            Output:
+              - `{ \"reports\": [Report, ...] }`. Each item is the full Sift `Report` shape including `report_id`,
+                `report_template_id`, `run_id`, `organization_id`, `name`, `description`, per-rule `summaries`,
+                tags, metadata, timestamps, and archive state.
+
+            Parameters:
+              - `filter`: CEL expression. Pass an empty string to list everything. Filterable fields:
+                `report_id`, `report_template_id`, `tag_name`, `name`, `run_id`, `is_archived`, `archived_date`,
+                `created_date`, `created_by_user_id`, `metadata`, `modified_date`, `modified_by_user_id`.
+                Reference metadata entries as `metadata.{key}` (e.g. `metadata.batch == \"nightly\"`).
+              - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `name`,
+                `created_date`, `modified_date`. Default sort is `created_date desc` (newest first).
+                Example: `\"created_date desc,modified_date\"`.
+              - `limit`: optional cap on returned items. Values in `1..=1000` cap the result set. Omitting it OR
+                passing a value above 1000 returns ALL matching reports (paginated server-side).
+              - `organization_id`: optional. Required only when the caller belongs to multiple organizations; it
+                scopes the listing to that org. Omit it for single-organization users.
+
+            Errors:
+              - `INVALID_PARAMS` if `filter` is not a valid CEL expression or `order_by` references an unknown field.
+              - `INTERNAL_ERROR` for upstream gRPC failures.
+
+            Guidance:
+              - When the report's run is known, narrow with `run_id == \"...\"` first — it's the most selective field.
+              - Use `is_archived == false` to exclude archived reports unless they're explicitly needed.
+              - Order by `created_date desc` when surfacing the most recent reports to a user.
+        ",
+        annotations(title = "list_router/list_reports", read_only_hint = true)
+    )]
+    pub async fn list_reports(&self, params: Parameters<ReportListParams>) -> error::McpResult {
+        let Parameters(ReportListParams {
+            filter,
+            order_by,
+            limit,
+            organization_id,
+        }) = params;
+
+        let out = self
+            .report_service
+            .list_reports(filter, order_by, limit, organization_id)
+            .await
+            .map(|reports| serde_json::json!({ "reports": reports }))
             .map_err(from_anyhow)?;
 
         Ok(CallToolResult::structured(out))

--- a/rust/crates/sift_mcp/src/tool/list/test.rs
+++ b/rust/crates/sift_mcp/src/tool/list/test.rs
@@ -3,19 +3,20 @@ use serde_json::Value;
 use sift_rs::{
     assets::v1::{Asset, ListAssetsResponse, asset_service_server::AssetServiceServer},
     channels::v3::{Channel, ListChannelsResponse, channel_service_server::ChannelServiceServer},
+    reports::v1::{ListReportsResponse, Report, report_service_server::ReportServiceServer},
     runs::v2::{ListRunsResponse, Run, run_service_server::RunServiceServer},
 };
 use sift_test_util::{
     grpc::memory_sift_channel,
     mock::{
         assets::v1::MockAssetServiceImpl, channels::v3::MockChannelServiceImpl,
-        runs::v2::MockRunServiceImpl,
+        reports::v1::MockReportServiceImpl, runs::v2::MockRunServiceImpl,
     },
 };
 use tokio::task::JoinHandle;
 use tonic::{Response, Status, transport::Server};
 
-use super::ListParams;
+use super::{ListParams, ReportListParams};
 use crate::{server::SiftMcpServer, service::common::PAGE_SIZE};
 
 async fn server_with_mocks(
@@ -605,4 +606,237 @@ async fn list_channels_propagates_grpc_error() {
 
     assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
     assert!(err.message.contains("bad filter"));
+}
+
+async fn server_with_report_mock(
+    report_mock: MockReportServiceImpl,
+) -> (SiftMcpServer, JoinHandle<()>) {
+    let (client, server) = tokio::io::duplex(1024);
+    let channel = memory_sift_channel(client).await;
+
+    let handle = tokio::spawn(async move {
+        Server::builder()
+            .add_service(ReportServiceServer::new(report_mock))
+            .serve_with_incoming(tokio_stream::once(Ok::<_, std::io::Error>(server)))
+            .await
+            .unwrap();
+    });
+
+    (SiftMcpServer::new(channel), handle)
+}
+
+fn report_params(filter: &str, limit: Option<u32>) -> Parameters<ReportListParams> {
+    Parameters(ReportListParams {
+        filter: filter.into(),
+        order_by: None,
+        limit,
+        organization_id: None,
+    })
+}
+
+#[tokio::test]
+async fn list_reports_returns_single_page() {
+    let mut report_mock = MockReportServiceImpl::new();
+    report_mock
+        .expect_list_reports()
+        .withf(|req| req.get_ref().filter == "name == \"nightly\"")
+        .returning(|_| {
+            Ok(Response::new(ListReportsResponse {
+                reports: vec![Report {
+                    report_id: "rep1".into(),
+                    name: "nightly".into(),
+                    ..Default::default()
+                }],
+                next_page_token: String::new(),
+            }))
+        });
+
+    let (server, _h) = server_with_report_mock(report_mock).await;
+
+    let resp = server
+        .list_reports(report_params("name == \"nightly\"", None))
+        .await
+        .expect("list_reports failed");
+
+    let reports = structured_field(resp, "reports");
+    assert_eq!(reports.as_array().unwrap().len(), 1);
+    assert_eq!(reports[0]["reportId"], "rep1");
+}
+
+#[tokio::test]
+async fn list_reports_forwards_organization_id() {
+    let mut report_mock = MockReportServiceImpl::new();
+    report_mock
+        .expect_list_reports()
+        .withf(|req| req.get_ref().organization_id == "org-123")
+        .returning(|_| {
+            Ok(Response::new(ListReportsResponse {
+                reports: vec![Report {
+                    report_id: "rep1".into(),
+                    ..Default::default()
+                }],
+                next_page_token: String::new(),
+            }))
+        });
+
+    let (server, _h) = server_with_report_mock(report_mock).await;
+
+    let resp = server
+        .list_reports(Parameters(ReportListParams {
+            filter: String::new(),
+            order_by: None,
+            limit: None,
+            organization_id: Some("org-123".into()),
+        }))
+        .await
+        .expect("list_reports failed");
+
+    let reports = structured_field(resp, "reports");
+    assert_eq!(reports.as_array().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn list_reports_paginates_until_token_empty() {
+    let mut report_mock = MockReportServiceImpl::new();
+    report_mock.expect_list_reports().returning(|req| {
+        let token = req.into_inner().page_token;
+        let (reports, next) = match token.as_str() {
+            "" => (
+                vec![Report {
+                    report_id: "rep1".into(),
+                    ..Default::default()
+                }],
+                "page-2".to_string(),
+            ),
+            "page-2" => (
+                vec![Report {
+                    report_id: "rep2".into(),
+                    ..Default::default()
+                }],
+                String::new(),
+            ),
+            other => return Err(Status::invalid_argument(format!("bad token: {other}"))),
+        };
+        Ok(Response::new(ListReportsResponse {
+            reports,
+            next_page_token: next,
+        }))
+    });
+
+    let (server, _h) = server_with_report_mock(report_mock).await;
+
+    let resp = server
+        .list_reports(report_params("", None))
+        .await
+        .expect("list_reports failed");
+
+    let reports = structured_field(resp, "reports");
+    let ids: Vec<&str> = reports
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r["reportId"].as_str().unwrap())
+        .collect();
+    assert_eq!(ids, vec!["rep1", "rep2"]);
+}
+
+#[tokio::test]
+async fn list_reports_truncates_to_limit_across_pages() {
+    let mut report_mock = MockReportServiceImpl::new();
+    report_mock.expect_list_reports().returning(|req| {
+        let req = req.into_inner();
+        assert_eq!(req.page_size, 3);
+        let (reports, next) = match req.page_token.as_str() {
+            "" => (
+                vec![
+                    Report {
+                        report_id: "rep1".into(),
+                        ..Default::default()
+                    },
+                    Report {
+                        report_id: "rep2".into(),
+                        ..Default::default()
+                    },
+                ],
+                "page-2".to_string(),
+            ),
+            "page-2" => (
+                vec![
+                    Report {
+                        report_id: "rep3".into(),
+                        ..Default::default()
+                    },
+                    Report {
+                        report_id: "rep4".into(),
+                        ..Default::default()
+                    },
+                ],
+                String::new(),
+            ),
+            other => return Err(Status::invalid_argument(format!("bad token: {other}"))),
+        };
+        Ok(Response::new(ListReportsResponse {
+            reports,
+            next_page_token: next,
+        }))
+    });
+
+    let (server, _h) = server_with_report_mock(report_mock).await;
+
+    let resp = server
+        .list_reports(report_params("", Some(3)))
+        .await
+        .expect("list_reports failed");
+
+    let reports = structured_field(resp, "reports");
+    let ids = reports
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r["reportId"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(ids, vec!["rep1", "rep2", "rep3"]);
+}
+
+#[tokio::test]
+async fn list_reports_breaks_on_empty_page() {
+    let mut report_mock = MockReportServiceImpl::new();
+    report_mock.expect_list_reports().times(1).returning(|_| {
+        Ok(Response::new(ListReportsResponse {
+            reports: vec![],
+            next_page_token: "ignored".into(),
+        }))
+    });
+
+    let (server, _h) = server_with_report_mock(report_mock).await;
+
+    let resp = server
+        .list_reports(report_params("", None))
+        .await
+        .expect("list_reports failed");
+
+    assert!(
+        structured_field(resp, "reports")
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn list_reports_propagates_grpc_error() {
+    let mut report_mock = MockReportServiceImpl::new();
+    report_mock
+        .expect_list_reports()
+        .returning(|_| Err(Status::not_found("no such report")));
+
+    let (server, _h) = server_with_report_mock(report_mock).await;
+
+    let err = server
+        .list_reports(report_params("", None))
+        .await
+        .expect_err("expected error");
+
+    assert_eq!(err.code, ErrorCode::RESOURCE_NOT_FOUND);
+    assert!(err.message.contains("no such report"));
 }

--- a/rust/crates/sift_test_util/src/mock/mod.rs
+++ b/rust/crates/sift_test_util/src/mock/mod.rs
@@ -1,6 +1,7 @@
 pub mod assets;
 pub mod channels;
 pub mod data;
+pub mod reports;
 pub mod runs;
 
 /// A test demonstrating a little bit of everything of how to leverage the mock API.

--- a/rust/crates/sift_test_util/src/mock/reports/mod.rs
+++ b/rust/crates/sift_test_util/src/mock/reports/mod.rs
@@ -1,0 +1,1 @@
+pub mod v1;

--- a/rust/crates/sift_test_util/src/mock/reports/v1.rs
+++ b/rust/crates/sift_test_util/src/mock/reports/v1.rs
@@ -1,0 +1,59 @@
+use async_trait::async_trait;
+use mockall::mock;
+use sift_rs::reports::v1::{
+    CancelReportRequest, CancelReportResponse, CreateReportRequest, CreateReportResponse,
+    GetReportRequest, GetReportResponse, ListReportsRequest, ListReportsResponse,
+    RerunReportRequest, RerunReportResponse, UpdateReportRequest, UpdateReportResponse,
+    report_service_server::ReportService,
+};
+use tonic::{Request, Response, Status};
+
+mock! {
+    pub ReportServiceImpl {}
+
+    #[async_trait]
+    impl ReportService for ReportServiceImpl {
+        async fn get_report(
+            &self,
+            request: Request<GetReportRequest>,
+        ) -> std::result::Result<
+            Response<GetReportResponse>,
+            Status,
+        >;
+        async fn create_report(
+            &self,
+            request: Request<CreateReportRequest>,
+        ) -> std::result::Result<
+            Response<CreateReportResponse>,
+            Status,
+        >;
+        async fn update_report(
+            &self,
+            request: Request<UpdateReportRequest>,
+        ) -> std::result::Result<
+            Response<UpdateReportResponse>,
+            Status,
+        >;
+        async fn list_reports(
+            &self,
+            request: Request<ListReportsRequest>,
+        ) -> std::result::Result<
+            Response<ListReportsResponse>,
+            Status,
+        >;
+        async fn rerun_report(
+            &self,
+            request: Request<RerunReportRequest>,
+        ) -> std::result::Result<
+            Response<RerunReportResponse>,
+            Status,
+        >;
+        async fn cancel_report(
+            &self,
+            request: Request<CancelReportRequest>,
+        ) -> std::result::Result<
+            Response<CancelReportResponse>,
+            Status,
+        >;
+    }
+}


### PR DESCRIPTION
## Changes

Adds a `list_reports` tool to the Sift MCP, mirroring `list_runs` / `list_assets` / `list_channels`. A new `ReportService` wraps the `ListReports` API with the shared pagination and limit logic. The tool takes `filter`, `order_by`, `limit`, and an optional `organization_id` (multi-org users only). The skill files and the MCP docs table are updated to match.

## Validation

- Unit tests (`cargo test -p sift_mcp`) at the service and tool layers: single page, pagination, limit and truncation, empty-page break, gRPC error mapping, and `organization_id` forwarding.
- Manual QA via the MCP: run `sift-cli mcp` with credentials, call `list_reports`, and confirm `filter` (e.g. `run_id == "..."`), `limit`, `order_by`, and `organization_id` behave, returning `{ "reports": [...] }`.
