### PR TITLE
rust(feat): hdf5 and tdms preview shows time stamp channels

### DIFF
--- a/rust/crates/sift_cli/src/cmd/import/hdf5/detect_hdf5_schema.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/detect_hdf5_schema.rs
@@ -130,9 +130,37 @@ pub fn detect_config(
         Ok((data, _)) if data.is_empty() => Err(no_match_error(
             &datasets, schema, time_index, time_field, time_name,
         )),
-        Ok(other) => Ok(other),
+        Ok((data, mut channel_configs)) => {
+            let time_rows = build_time_channel_rows(&data);
+            channel_configs.splice(0..0, time_rows);
+            Ok((data, channel_configs))
+        }
         Err(e) => Err(e),
     }
+}
+
+pub(super) fn build_time_channel_rows(data: &[Hdf5DataConfig]) -> Vec<ChannelConfig> {
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut rows: Vec<ChannelConfig> = Vec::new();
+    for cfg in data {
+        let dataset_name = group_path_to_channel_name(&cfg.time_dataset);
+        let name = match &cfg.time_field {
+            Some(field) if !field.is_empty() => format!("{dataset_name}.{field}"),
+            _ if cfg.time_dataset == cfg.value_dataset => {
+                format!("{dataset_name}.{}", cfg.time_index)
+            }
+            _ => dataset_name,
+        };
+        if seen.insert(name.clone()) {
+            rows.push(ChannelConfig {
+                name,
+                description: "[time]".into(),
+                data_type: ChannelDataType::Int64 as i32,
+                ..Default::default()
+            });
+        }
+    }
+    rows
 }
 
 fn no_match_error(

--- a/rust/crates/sift_cli/src/cmd/import/hdf5/detect_hdf5_schema.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/detect_hdf5_schema.rs
@@ -161,7 +161,7 @@ pub(super) fn weave_time_channel_rows(
             woven.push(ChannelConfig {
                 name,
                 description: "[time]".into(),
-                data_type: ChannelDataType::Int64 as i32,
+                data_type: ChannelDataType::Int64.into(),
                 ..Default::default()
             });
         }

--- a/rust/crates/sift_cli/src/cmd/import/hdf5/detect_hdf5_schema.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/detect_hdf5_schema.rs
@@ -131,11 +131,7 @@ pub fn detect_config(
             &datasets, schema, time_index, time_field, time_name,
         )),
         Ok((data, channel_configs)) => {
-            let woven = if matches!(schema, Hdf5Schema::TwoD) {
-                channel_configs
-            } else {
-                weave_time_channel_rows(&data, &channel_configs)
-            };
+            let woven = weave_time_channel_rows(&data, &channel_configs);
             Ok((data, woven))
         }
         Err(e) => Err(e),

--- a/rust/crates/sift_cli/src/cmd/import/hdf5/detect_hdf5_schema.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/detect_hdf5_schema.rs
@@ -131,9 +131,6 @@ pub fn detect_config(
             &datasets, schema, time_index, time_field, time_name,
         )),
         Ok((data, channel_configs)) => {
-            // 2D mode has no signal — the time column is whatever index the user passed
-            // via --time-index. We can't verify it, so we don't tag it in the preview.
-            // 1D auto-detects from dataset name; compound takes an explicit --time-field.
             let woven = if matches!(schema, Hdf5Schema::TwoD) {
                 channel_configs
             } else {

--- a/rust/crates/sift_cli/src/cmd/import/hdf5/detect_hdf5_schema.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/detect_hdf5_schema.rs
@@ -130,37 +130,51 @@ pub fn detect_config(
         Ok((data, _)) if data.is_empty() => Err(no_match_error(
             &datasets, schema, time_index, time_field, time_name,
         )),
-        Ok((data, mut channel_configs)) => {
-            let time_rows = build_time_channel_rows(&data);
-            channel_configs.splice(0..0, time_rows);
-            Ok((data, channel_configs))
+        Ok((data, channel_configs)) => {
+            // 2D mode has no signal — the time column is whatever index the user passed
+            // via --time-index. We can't verify it, so we don't tag it in the preview.
+            // 1D auto-detects from dataset name; compound takes an explicit --time-field.
+            let woven = if matches!(schema, Hdf5Schema::TwoD) {
+                channel_configs
+            } else {
+                weave_time_channel_rows(&data, &channel_configs)
+            };
+            Ok((data, woven))
         }
         Err(e) => Err(e),
     }
 }
 
-pub(super) fn build_time_channel_rows(data: &[Hdf5DataConfig]) -> Vec<ChannelConfig> {
+fn time_channel_name(cfg: &Hdf5DataConfig) -> String {
+    let dataset_name = group_path_to_channel_name(&cfg.time_dataset);
+    match &cfg.time_field {
+        Some(field) if !field.is_empty() => format!("{dataset_name}.{field}"),
+        _ if cfg.time_dataset == cfg.value_dataset => {
+            format!("{dataset_name}.{}", cfg.time_index)
+        }
+        _ => dataset_name,
+    }
+}
+
+pub(super) fn weave_time_channel_rows(
+    data: &[Hdf5DataConfig],
+    channels: &[ChannelConfig],
+) -> Vec<ChannelConfig> {
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let mut rows: Vec<ChannelConfig> = Vec::new();
-    for cfg in data {
-        let dataset_name = group_path_to_channel_name(&cfg.time_dataset);
-        let name = match &cfg.time_field {
-            Some(field) if !field.is_empty() => format!("{dataset_name}.{field}"),
-            _ if cfg.time_dataset == cfg.value_dataset => {
-                format!("{dataset_name}.{}", cfg.time_index)
-            }
-            _ => dataset_name,
-        };
+    let mut woven: Vec<ChannelConfig> = Vec::with_capacity(channels.len() + data.len());
+    for (cfg, channel) in data.iter().zip(channels.iter()) {
+        let name = time_channel_name(cfg);
         if seen.insert(name.clone()) {
-            rows.push(ChannelConfig {
+            woven.push(ChannelConfig {
                 name,
                 description: "[time]".into(),
                 data_type: ChannelDataType::Int64 as i32,
                 ..Default::default()
             });
         }
+        woven.push(channel.clone());
     }
-    rows
+    woven
 }
 
 fn no_match_error(

--- a/rust/crates/sift_cli/src/cmd/import/hdf5/detect_hdf5_schema.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/detect_hdf5_schema.rs
@@ -153,8 +153,8 @@ pub(super) fn weave_time_channel_rows(
     data: &[Hdf5DataConfig],
     channels: &[ChannelConfig],
 ) -> Vec<ChannelConfig> {
-    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let mut woven: Vec<ChannelConfig> = Vec::with_capacity(channels.len() + data.len());
+    let mut seen = std::collections::HashSet::new();
+    let mut woven = Vec::with_capacity(channels.len() + data.len());
     for (cfg, channel) in data.iter().zip(channels.iter()) {
         let name = time_channel_name(cfg);
         if seen.insert(name.clone()) {

--- a/rust/crates/sift_cli/src/cmd/import/hdf5/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/tests.rs
@@ -9,8 +9,8 @@ use crate::cli::hdf5::Hdf5Schema;
 use crate::cli::time::TimeFormat;
 use crate::cli::{CommonImportArgs, ImportHdf5Args};
 use crate::cmd::import::hdf5::detect_hdf5_schema::{
-    basename, build_time_channel_rows, enum_types_for, hdf5_to_sift_data_type,
-    is_time_dataset_name, parent_path,
+    basename, enum_types_for, hdf5_to_sift_data_type, is_time_dataset_name, parent_path,
+    weave_time_channel_rows,
 };
 use crate::cmd::import::hdf5::import::build_hdf5_config;
 use crate::cmd::import::utils::group_path_to_channel_name;
@@ -392,37 +392,46 @@ fn make_data_config(
     }
 }
 
+fn make_channel(name: &str) -> sift_rs::common::r#type::v1::ChannelConfig {
+    sift_rs::common::r#type::v1::ChannelConfig {
+        name: name.into(),
+        data_type: ChannelDataType::Double as i32,
+        ..Default::default()
+    }
+}
+
 #[test]
-fn build_time_channel_rows_one_d_dedups_shared_time_dataset() {
-    let configs = vec![
+fn weave_one_d_shared_time_appears_once_before_channels() {
+    let data = vec![
         make_data_config("/group_a/time", "/group_a/voltage", 0, None),
         make_data_config("/group_a/time", "/group_a/current", 0, None),
         make_data_config("/group_b/timestamp", "/group_b/value", 0, None),
     ];
-    let rows = build_time_channel_rows(&configs);
-    assert_eq!(rows.len(), 2);
-    assert_eq!(rows[0].name, "group_a.time");
-    assert_eq!(rows[0].description, "[time]");
-    assert_eq!(rows[0].data_type, ChannelDataType::Int64 as i32);
-    assert_eq!(rows[1].name, "group_b.timestamp");
-    assert_eq!(rows[1].description, "[time]");
-}
-
-#[test]
-fn build_time_channel_rows_two_d_includes_time_index() {
-    let configs = vec![
-        make_data_config("/sensor_0", "/sensor_0", 0, None),
-        make_data_config("/sensor_1", "/sensor_1", 0, None),
+    let channels = vec![
+        make_channel("group_a.voltage"),
+        make_channel("group_a.current"),
+        make_channel("group_b.value"),
     ];
-    let rows = build_time_channel_rows(&configs);
-    assert_eq!(rows.len(), 2);
-    assert_eq!(rows[0].name, "sensor_0.0");
-    assert_eq!(rows[1].name, "sensor_1.0");
+    let woven = weave_time_channel_rows(&data, &channels);
+    let layout: Vec<(&str, &str)> = woven
+        .iter()
+        .map(|c| (c.name.as_str(), c.description.as_str()))
+        .collect();
+    assert_eq!(
+        layout,
+        vec![
+            ("group_a.time", "[time]"),
+            ("group_a.voltage", ""),
+            ("group_a.current", ""),
+            ("group_b.timestamp", "[time]"),
+            ("group_b.value", ""),
+        ]
+    );
 }
 
 #[test]
-fn build_time_channel_rows_compound_renders_dataset_dot_field() {
-    let configs = vec![
+fn weave_compound_shows_dataset_dot_field_once_per_compound_dataset() {
+    let data = vec![
         make_data_config("/measurements/run1", "/measurements/run1", 0, Some("ts")),
         make_data_config("/measurements/run1", "/measurements/run1", 0, Some("ts")),
         make_data_config(
@@ -432,15 +441,27 @@ fn build_time_channel_rows_compound_renders_dataset_dot_field() {
             Some("timestamp"),
         ),
     ];
-    let rows = build_time_channel_rows(&configs);
-    assert_eq!(rows.len(), 2);
-    assert_eq!(rows[0].name, "measurements.run1.ts");
-    assert_eq!(rows[0].description, "[time]");
-    assert_eq!(rows[1].name, "measurements.run2.timestamp");
+    let channels = vec![
+        make_channel("measurements.run1.voltage"),
+        make_channel("measurements.run1.current"),
+        make_channel("measurements.run2.voltage"),
+    ];
+    let woven = weave_time_channel_rows(&data, &channels);
+    let names: Vec<&str> = woven.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec![
+            "measurements.run1.ts",
+            "measurements.run1.voltage",
+            "measurements.run1.current",
+            "measurements.run2.timestamp",
+            "measurements.run2.voltage",
+        ]
+    );
 }
 
 #[test]
-fn build_time_channel_rows_empty_when_no_data_configs() {
-    let rows = build_time_channel_rows(&[]);
-    assert!(rows.is_empty());
+fn weave_empty_returns_empty() {
+    let woven = weave_time_channel_rows(&[], &[]);
+    assert!(woven.is_empty());
 }

--- a/rust/crates/sift_cli/src/cmd/import/hdf5/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/tests.rs
@@ -2,9 +2,8 @@ use std::path::PathBuf;
 
 use chrono::DateTime;
 use hdf5::types::{EnumMember, EnumType, FloatSize, IntSize, TypeDescriptor};
-use sift_rs::common::r#type::v1::ChannelDataType;
+use sift_rs::common::r#type::v1::{ ChannelDataType, ChannelConfig };
 use sift_rs::data_imports::v2::TimeFormat as ProtoTimeFormat;
-
 use crate::cli::hdf5::Hdf5Schema;
 use crate::cli::time::TimeFormat;
 use crate::cli::{CommonImportArgs, ImportHdf5Args};
@@ -390,7 +389,7 @@ fn make_data_config(
     }
 }
 
-fn make_channel(name: &str) -> sift_rs::common::r#type::v1::ChannelConfig {
+fn make_channel(name: &str) -> ChannelConfig {
     sift_rs::common::r#type::v1::ChannelConfig {
         name: name.into(),
         data_type: ChannelDataType::Double as i32,

--- a/rust/crates/sift_cli/src/cmd/import/hdf5/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/tests.rs
@@ -1,9 +1,5 @@
 use std::path::PathBuf;
 
-use chrono::DateTime;
-use hdf5::types::{EnumMember, EnumType, FloatSize, IntSize, TypeDescriptor};
-use sift_rs::common::r#type::v1::{ ChannelDataType, ChannelConfig };
-use sift_rs::data_imports::v2::TimeFormat as ProtoTimeFormat;
 use crate::cli::hdf5::Hdf5Schema;
 use crate::cli::time::TimeFormat;
 use crate::cli::{CommonImportArgs, ImportHdf5Args};
@@ -13,6 +9,10 @@ use crate::cmd::import::hdf5::detect_hdf5_schema::{
 };
 use crate::cmd::import::hdf5::import::build_hdf5_config;
 use crate::cmd::import::utils::group_path_to_channel_name;
+use chrono::DateTime;
+use hdf5::types::{EnumMember, EnumType, FloatSize, IntSize, TypeDescriptor};
+use sift_rs::common::r#type::v1::{ChannelConfig, ChannelDataType};
+use sift_rs::data_imports::v2::TimeFormat as ProtoTimeFormat;
 
 fn make_args() -> ImportHdf5Args {
     ImportHdf5Args {

--- a/rust/crates/sift_cli/src/cmd/import/hdf5/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/tests.rs
@@ -9,7 +9,8 @@ use crate::cli::hdf5::Hdf5Schema;
 use crate::cli::time::TimeFormat;
 use crate::cli::{CommonImportArgs, ImportHdf5Args};
 use crate::cmd::import::hdf5::detect_hdf5_schema::{
-    basename, enum_types_for, hdf5_to_sift_data_type, is_time_dataset_name, parent_path,
+    basename, build_time_channel_rows, enum_types_for, hdf5_to_sift_data_type,
+    is_time_dataset_name, parent_path,
 };
 use crate::cmd::import::hdf5::import::build_hdf5_config;
 use crate::cmd::import::utils::group_path_to_channel_name;
@@ -372,4 +373,74 @@ fn group_path_to_channel_name_no_leading_slash() {
         group_path_to_channel_name("group1/current"),
         "group1.current"
     );
+}
+
+fn make_data_config(
+    time_dataset: &str,
+    value_dataset: &str,
+    time_index: u64,
+    time_field: Option<&str>,
+) -> sift_rs::data_imports::v2::Hdf5DataConfig {
+    sift_rs::data_imports::v2::Hdf5DataConfig {
+        time_dataset: time_dataset.into(),
+        time_index,
+        value_dataset: value_dataset.into(),
+        value_index: 0,
+        channel_config: None,
+        time_field: time_field.map(Into::into),
+        value_field: None,
+    }
+}
+
+#[test]
+fn build_time_channel_rows_one_d_dedups_shared_time_dataset() {
+    let configs = vec![
+        make_data_config("/group_a/time", "/group_a/voltage", 0, None),
+        make_data_config("/group_a/time", "/group_a/current", 0, None),
+        make_data_config("/group_b/timestamp", "/group_b/value", 0, None),
+    ];
+    let rows = build_time_channel_rows(&configs);
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].name, "group_a.time");
+    assert_eq!(rows[0].description, "[time]");
+    assert_eq!(rows[0].data_type, ChannelDataType::Int64 as i32);
+    assert_eq!(rows[1].name, "group_b.timestamp");
+    assert_eq!(rows[1].description, "[time]");
+}
+
+#[test]
+fn build_time_channel_rows_two_d_includes_time_index() {
+    let configs = vec![
+        make_data_config("/sensor_0", "/sensor_0", 0, None),
+        make_data_config("/sensor_1", "/sensor_1", 0, None),
+    ];
+    let rows = build_time_channel_rows(&configs);
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].name, "sensor_0.0");
+    assert_eq!(rows[1].name, "sensor_1.0");
+}
+
+#[test]
+fn build_time_channel_rows_compound_renders_dataset_dot_field() {
+    let configs = vec![
+        make_data_config("/measurements/run1", "/measurements/run1", 0, Some("ts")),
+        make_data_config("/measurements/run1", "/measurements/run1", 0, Some("ts")),
+        make_data_config(
+            "/measurements/run2",
+            "/measurements/run2",
+            0,
+            Some("timestamp"),
+        ),
+    ];
+    let rows = build_time_channel_rows(&configs);
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].name, "measurements.run1.ts");
+    assert_eq!(rows[0].description, "[time]");
+    assert_eq!(rows[1].name, "measurements.run2.timestamp");
+}
+
+#[test]
+fn build_time_channel_rows_empty_when_no_data_configs() {
+    let rows = build_time_channel_rows(&[]);
+    assert!(rows.is_empty());
 }

--- a/rust/crates/sift_cli/src/cmd/import/hdf5/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/tests.rs
@@ -385,10 +385,8 @@ fn make_data_config(
         time_dataset: time_dataset.into(),
         time_index,
         value_dataset: value_dataset.into(),
-        value_index: 0,
-        channel_config: None,
         time_field: time_field.map(Into::into),
-        value_field: None,
+        ..Default::default()
     }
 }
 

--- a/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
+++ b/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
@@ -213,15 +213,14 @@ fn detect_config(path: &Path, fallback_method: TdmsFallbackMethod) -> Result<Vec
         let time_channel_name = find_time_channel(&channels);
 
         if let Some(time_name) = time_channel_name.as_ref() && let Some((_, time_channel)) = channels.iter().find(|(n, _)| n == time_name) {
-                let time_dt = tdms_to_sift_data_type(time_channel.data_type)
-                    .unwrap_or(ChannelDataType::Int64);
-                channels_vec.push(ChannelConfig {
-                    name: format!("{group}.{time_name}"),
-                    description: "[time]".into(),
-                    data_type: time_dt.into(),
-                    ..Default::default()
-                });
-            }
+            let time_dt = tdms_to_sift_data_type(time_channel.data_type)
+                .unwrap_or(ChannelDataType::Int64);
+            channels_vec.push(ChannelConfig {
+                name: format!("{group}.{time_name}"),
+                description: "[time]".into(),
+                data_type: time_dt.into(),
+                ..Default::default()
+            });
         }
 
         for (channel_name, channel) in &channels {

--- a/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
+++ b/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
@@ -212,9 +212,11 @@ fn detect_config(path: &Path, fallback_method: TdmsFallbackMethod) -> Result<Vec
         let channels = file.channels(&group).into_iter().collect::<Vec<_>>();
         let time_channel_name = find_time_channel(&channels);
 
-        if let Some(time_name) = time_channel_name.as_ref() && let Some((_, time_channel)) = channels.iter().find(|(n, _)| n == time_name) {
-            let time_dt = tdms_to_sift_data_type(time_channel.data_type)
-                .unwrap_or(ChannelDataType::Int64);
+        if let Some(time_name) = time_channel_name.as_ref()
+            && let Some((_, time_channel)) = channels.iter().find(|(n, _)| n == time_name)
+        {
+            let time_dt =
+                tdms_to_sift_data_type(time_channel.data_type).unwrap_or(ChannelDataType::Int64);
             channels_vec.push(ChannelConfig {
                 name: format!("{group}.{time_name}"),
                 description: "[time]".into(),

--- a/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
+++ b/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
@@ -212,6 +212,19 @@ fn detect_config(path: &Path, fallback_method: TdmsFallbackMethod) -> Result<Vec
         let channels: Vec<(String, &Channel)> = file.channels(&group).into_iter().collect();
         let time_channel_name = find_time_channel(&channels);
 
+        if let Some(time_name) = time_channel_name.as_ref() {
+            if let Some((_, time_channel)) = channels.iter().find(|(n, _)| n == time_name) {
+                let time_dt = tdms_to_sift_data_type(time_channel.data_type)
+                    .unwrap_or(ChannelDataType::Int64);
+                channels_vec.push(ChannelConfig {
+                    name: format!("{group}.{time_name}"),
+                    description: "[time]".into(),
+                    data_type: time_dt as i32,
+                    ..Default::default()
+                });
+            }
+        }
+
         for (channel_name, channel) in &channels {
             if Some(channel_name) == time_channel_name.as_ref() {
                 continue;
@@ -221,7 +234,8 @@ fn detect_config(path: &Path, fallback_method: TdmsFallbackMethod) -> Result<Vec
                 continue;
             };
 
-            let has_timing = is_waveform_channel(channel) || time_channel_name.is_some();
+            let is_waveform = is_waveform_channel(channel);
+            let has_timing = is_waveform || time_channel_name.is_some();
             if !has_timing {
                 match fallback_method {
                     TdmsFallbackMethod::IgnoreError => continue,
@@ -235,10 +249,23 @@ fn detect_config(path: &Path, fallback_method: TdmsFallbackMethod) -> Result<Vec
                 }
             }
 
+            let description = {
+                let raw = get_string_property(channel, "description");
+                if is_waveform {
+                    if raw.is_empty() {
+                        "[waveform timing]".to_string()
+                    } else {
+                        format!("[waveform timing] {raw}")
+                    }
+                } else {
+                    raw
+                }
+            };
+
             channels_vec.push(ChannelConfig {
                 name: format!("{}.{}", group, channel_name),
                 units: get_string_property(channel, "unit_string"),
-                description: get_string_property(channel, "description"),
+                description,
                 data_type: data_type as i32,
                 ..Default::default()
             });

--- a/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
+++ b/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
@@ -209,7 +209,7 @@ fn detect_config(path: &Path, fallback_method: TdmsFallbackMethod) -> Result<Vec
     let mut channels_vec: Vec<ChannelConfig> = vec![];
 
     for group in file.groups() {
-        let channels: Vec<(String, &Channel)> = file.channels(&group).into_iter().collect();
+        let channels = file.channels(&group).into_iter().collect::<Vec<_>>();
         let time_channel_name = find_time_channel(&channels);
 
         if let Some(time_name) = time_channel_name.as_ref() && let Some((_, time_channel)) = channels.iter().find(|(n, _)| n == time_name) {

--- a/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
+++ b/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
@@ -212,14 +212,13 @@ fn detect_config(path: &Path, fallback_method: TdmsFallbackMethod) -> Result<Vec
         let channels: Vec<(String, &Channel)> = file.channels(&group).into_iter().collect();
         let time_channel_name = find_time_channel(&channels);
 
-        if let Some(time_name) = time_channel_name.as_ref() {
-            if let Some((_, time_channel)) = channels.iter().find(|(n, _)| n == time_name) {
+        if let Some(time_name) = time_channel_name.as_ref() && let Some((_, time_channel)) = channels.iter().find(|(n, _)| n == time_name) {
                 let time_dt = tdms_to_sift_data_type(time_channel.data_type)
                     .unwrap_or(ChannelDataType::Int64);
                 channels_vec.push(ChannelConfig {
                     name: format!("{group}.{time_name}"),
                     description: "[time]".into(),
-                    data_type: time_dt as i32,
+                    data_type: time_dt.into(),
                     ..Default::default()
                 });
             }

--- a/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
+++ b/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
@@ -234,8 +234,7 @@ fn detect_config(path: &Path, fallback_method: TdmsFallbackMethod) -> Result<Vec
                 continue;
             };
 
-            let is_waveform = is_waveform_channel(channel);
-            let has_timing = is_waveform || time_channel_name.is_some();
+            let has_timing = is_waveform_channel(channel) || time_channel_name.is_some();
             if !has_timing {
                 match fallback_method {
                     TdmsFallbackMethod::IgnoreError => continue,
@@ -249,23 +248,10 @@ fn detect_config(path: &Path, fallback_method: TdmsFallbackMethod) -> Result<Vec
                 }
             }
 
-            let description = {
-                let raw = get_string_property(channel, "description");
-                if is_waveform {
-                    if raw.is_empty() {
-                        "[waveform timing]".to_string()
-                    } else {
-                        format!("[waveform timing] {raw}")
-                    }
-                } else {
-                    raw
-                }
-            };
-
             channels_vec.push(ChannelConfig {
                 name: format!("{}.{}", group, channel_name),
                 units: get_string_property(channel, "unit_string"),
-                description,
+                description: get_string_property(channel, "description"),
                 data_type: data_type as i32,
                 ..Default::default()
             });


### PR DESCRIPTION
## Description

:ticket: ENG-11824 :ticket: 

For HDF5 and TDMS import previews we show the timestamp and properly surface that to the user.
HDF5 1D we show each groups timestamp
HDF5 2D we show the time index for each 2D array
HDF5 Compound we show the group timestamp
TDMS shows waveform/detected timestamp

HDF5 1D:
```
Asset: hdf5-time-check
Run: time-check
Channels: {
  CHANNEL_DATA_TYPE_INT_64    timestamp
    description [time]
  CHANNEL_DATA_TYPE_DOUBLE    cpu_usage
  CHANNEL_DATA_TYPE_INT_64    disk_io
  CHANNEL_DATA_TYPE_DOUBLE    memory_usage
  CHANNEL_DATA_TYPE_INT_64    group1.timestamp
    description [time]
  CHANNEL_DATA_TYPE_INT_64    group1.current
  CHANNEL_DATA_TYPE_DOUBLE    group1.pressure
  CHANNEL_DATA_TYPE_DOUBLE    group1.temperature
  CHANNEL_DATA_TYPE_DOUBLE    group1.voltage
  CHANNEL_DATA_TYPE_INT_64    group2.timestamp
    description [time]
  CHANNEL_DATA_TYPE_DOUBLE    group2.acceleration
  CHANNEL_DATA_TYPE_DOUBLE    group2.altitude
  CHANNEL_DATA_TYPE_INT_64    group2.thrust
  CHANNEL_DATA_TYPE_DOUBLE    group2.velocity
  CHANNEL_DATA_TYPE_INT_64    group2.group3.timestamp
    description [time]
  CHANNEL_DATA_TYPE_DOUBLE    group2.group3.battery_current
  CHANNEL_DATA_TYPE_DOUBLE    group2.group3.battery_temp
  CHANNEL_DATA_TYPE_DOUBLE    group2.group3.battery_voltage
  CHANNEL_DATA_TYPE_DOUBLE    group2.group3.group4.cell_voltage
}
```
HDF5 2D:
```
Asset: hdf5-time-check
Run: time-check
Channels: {
  CHANNEL_DATA_TYPE_INT_64    group1.current.0
    description [time]
  CHANNEL_DATA_TYPE_DOUBLE    group1.current.1
  CHANNEL_DATA_TYPE_INT_64    group1.pressure.0
    description [time]
  CHANNEL_DATA_TYPE_DOUBLE    group1.pressure.1
  CHANNEL_DATA_TYPE_INT_64    group1.temperature.0
    description [time]
  CHANNEL_DATA_TYPE_DOUBLE    group1.temperature.1
  CHANNEL_DATA_TYPE_INT_64    group1.voltage.0
    description [time]
  CHANNEL_DATA_TYPE_DOUBLE    group1.voltage.1
}
```
HDF5 Compound:
```
Asset: hdf5-time-check
Run: time-check
Channels: {
  CHANNEL_DATA_TYPE_INT_64    sensors.timestamp
    description [time]
  CHANNEL_DATA_TYPE_DOUBLE    sensors.temperature
  CHANNEL_DATA_TYPE_DOUBLE    sensors.pressure
  CHANNEL_DATA_TYPE_DOUBLE    sensors.voltage
  CHANNEL_DATA_TYPE_INT_64    sensors.current
}
```
TDMS:
```
Asset: asset
Run: run
Channels: {
  CHANNEL_DATA_TYPE_INT_64    group_a_time_channel.Time
    description [time]
  CHANNEL_DATA_TYPE_DOUBLE    group_a_time_channel.voltage
    units V
    description Sine wave 1 Hz
  CHANNEL_DATA_TYPE_DOUBLE    group_a_time_channel.current
    units A
    description Cosine wave 1 Hz
  CHANNEL_DATA_TYPE_DOUBLE    group_b_waveform.voltage
    units V
    description Sine wave 1 Hz (waveform)
  CHANNEL_DATA_TYPE_DOUBLE    group_b_waveform.current
    units A
    description Cosine wave 1 Hz (waveform)
  CHANNEL_DATA_TYPE_INT_64    group_c_named_timestamp.Timestamp
    description [time]
  CHANNEL_DATA_TYPE_UINT_64   group_c_named_timestamp.counter
    units ticks
    description Monotonic counter
}
```

## Verification

Manual testing end to end.

Added unit tests for auto detection.

