### PR TITLE
Python(fix): pytest exit instead of raise on connection fail

### DIFF
--- a/python/lib/sift_client/_tests/pytest_plugin/test_online.py
+++ b/python/lib/sift_client/_tests/pytest_plugin/test_online.py
@@ -1,10 +1,10 @@
 """Tests for online mode (the default).
 
 Online mode requires connectivity to Sift. The plugin pings via
-``client_has_connection`` at session start and aborts with
-``pytest.UsageError`` on failure. Missing ``SIFT_API_KEY`` /
-``SIFT_GRPC_URI`` / ``SIFT_REST_URI`` env vars are reported as a usage error
-so the failure is actionable.
+``client_has_connection`` at session start and aborts via ``pytest.exit`` on
+failure, so the message prints once before any test runs. Missing
+``SIFT_API_KEY`` / ``SIFT_GRPC_URI`` / ``SIFT_REST_URI`` env vars are reported
+as a usage error so the failure is actionable.
 """
 
 from __future__ import annotations
@@ -23,7 +23,7 @@ class TestOnlineMode:
         pytester: pytest.Pytester,
         clear_sift_env: None,
     ) -> None:
-        """Online mode with an unreachable ping aborts the session via UsageError."""
+        """Online mode with an unreachable ping aborts the session before any test runs."""
         pytester.makeconftest(
             """
             import pytest
@@ -46,12 +46,19 @@ class TestOnlineMode:
             @pytest.mark.sift_include
             def test_should_not_run():
                 assert True
+
+            @pytest.mark.sift_include
+            def test_should_not_run_either():
+                assert True
             """
         )
         result = pytester.runpytest_subprocess()
         assert result.ret != 0
         combined = "\n".join(result.outlines + result.errlines)
-        assert "Sift ping failed" in combined, combined
+        # ``pytest.exit`` stops on the first gated test's setup: the message
+        # appears once (not once per test) and nothing runs.
+        assert combined.count("Sift ping failed") == 1, combined
+        result.assert_outcomes()
 
     def test_missing_env_vars_named_in_error(
         self,

--- a/python/lib/sift_client/pytest_plugin.py
+++ b/python/lib/sift_client/pytest_plugin.py
@@ -1184,7 +1184,7 @@ def report_context(
       session end.
     * default (online): verify connectivity via ``client_has_connection``
       before constructing the context. A failed ping aborts the session
-      with ``pytest.UsageError`` and points at ``--sift-offline`` and
+      with ``pytest.exit`` and points at ``--sift-offline`` and
       ``--sift-disabled`` as escape hatches.
 
     The log-file destination is controlled by
@@ -1204,11 +1204,12 @@ def report_context(
         except Exception as exc:
             grpc_config = getattr(getattr(sift_client, "grpc_client", None), "_config", None)
             grpc_url = getattr(grpc_config, "uri", "<unknown>")
-            raise pytest.UsageError(
+            pytest.exit(
                 f"Sift ping failed against {grpc_url}: {exc}. "
                 "Pass --sift-offline to run without contacting Sift, or "
-                "--sift-disabled to skip Sift entirely."
-            ) from exc
+                "--sift-disabled to skip Sift entirely.",
+                returncode=4,
+            )
     yield from _report_context_impl(sift_client, request, pytestconfig=pytestconfig)
 
 
@@ -1413,8 +1414,8 @@ def client_has_connection(pytestconfig: pytest.Config, request: pytest.FixtureRe
     """Verify the ``SiftClient`` can reach Sift via ``/ping``.
 
     Consulted at session start by ``report_context`` in online mode. A failed
-    ping raises through ``report_context`` and aborts the session with
-    ``pytest.UsageError``. Override this fixture in your conftest to use a
+    ping aborts the session via ``pytest.exit``. Override this fixture in your
+    conftest to use a
     different reachability signal (e.g. a cached auth token) for environments
     where pinging is the wrong check. Returns ``False`` in ``--sift-disabled``
     mode without constructing a client.


### PR DESCRIPTION
## Summary

On a failed connectivity ping in online mode, the pytest plugin now aborts the session with `pytest.exit` instead of raising `pytest.UsageError`.

Previously the ping ran during the first gated test's setup, so a session-scoped fixture failure was cached and re-raised once per test. A connection failure produced one error block per collected test, with the gRPC error truncated in the summary lines.

`pytest.exit` stops the session on the spot and prints the message once, before any test body runs, with the full error untruncated. The message text and exit code (4) are unchanged.

## Notes

The check stays in the `report_context` fixture rather than moving to a collection hook, so the user-overridable `sift_client` and `client_has_connection` fixtures still resolve as documented.
