### PR TITLE
docs: link hosted Rust and Python documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ This repository contains client libraries and protocol buffers to interact with 
 to compile the protocol buffers yourself there are instructions on how to go about it in the [Manual Protobuf Compilation](#manual-protobuf-compilation) section.
 
 **Language-specific documentation:**
-- [Python](/python/)
-- [Rust](/rust/)
+- [Python](https://sift-stack.github.io/sift/python/latest/)
+- [Rust](https://docs.rs/sift_stream/latest/sift_stream/)
 - [Go](/go/)
 - [C++](/cpp/)
 


### PR DESCRIPTION
## Summary
- Updates the Language-specific documentation section in the README to point to hosted docs:
  - Python: https://sift-stack.github.io/sift/python/latest/
  - Rust: https://docs.rs/sift_stream/latest/sift_stream/
- Go and C++ links are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)