### PR TITLE
Python(fix): add channel timeout

### DIFF
--- a/python/lib/sift_client/_internal/grpc_transport/_retry.py
+++ b/python/lib/sift_client/_internal/grpc_transport/_retry.py
@@ -4,7 +4,13 @@ import json
 from typing import ClassVar, TypedDict
 
 from grpc import StatusCode
-from typing_extensions import Self
+from typing_extensions import NotRequired, Self
+
+
+def _format_grpc_duration(seconds: float) -> str:
+    """Format seconds as a protobuf Duration string, e.g. ``60s`` or ``0.5s``."""
+    trimmed = f"{seconds:.9f}".rstrip("0").rstrip(".")
+    return f"{trimmed}s"
 
 
 class RetryPolicy:
@@ -50,8 +56,24 @@ class RetryPolicy:
         return json.dumps(self.config)
 
     @classmethod
-    def default(cls) -> Self:
-        return cls(config=cls.DEFAULT_POLICY)
+    def default(cls, timeout_seconds: float | None = None) -> Self:
+        """Build the default policy, optionally with a per-call deadline.
+
+        When ``timeout_seconds`` is set, every method config carries a
+        ``timeout`` so the C-core fails a stalled call with ``DEADLINE_EXCEEDED``
+        instead of hanging. The deadline bounds the whole call, retries included,
+        and a per-call ``timeout=`` still overrides it.
+        """
+        if timeout_seconds is None:
+            return cls(config=cls.DEFAULT_POLICY)
+        duration = _format_grpc_duration(timeout_seconds)
+        config: RetryConfig = {
+            "methodConfig": [
+                {**method_config, "timeout": duration}
+                for method_config in cls.DEFAULT_POLICY["methodConfig"]
+            ]
+        }
+        return cls(config=config)
 
 
 class RetryConfig(TypedDict):
@@ -61,6 +83,10 @@ class RetryConfig(TypedDict):
 class MethodConfigDict(TypedDict):
     name: list[dict[str, str]]
     retryPolicy: RetryConfigDict
+    # Applies to all methods via the wildcard `name` matcher above. If a
+    # server-streaming RPC is ever added to this channel, scope this by method
+    # name so the deadline doesn't clip a long-lived stream.
+    timeout: NotRequired[str]
 
 
 class RetryConfigDict(TypedDict):

--- a/python/lib/sift_client/_internal/grpc_transport/transport.py
+++ b/python/lib/sift_client/_internal/grpc_transport/transport.py
@@ -31,6 +31,9 @@ from sift_client._internal.grpc_transport.keepalive import DEFAULT_KEEPALIVE_CON
 SiftChannel: TypeAlias = grpc.Channel
 SiftAsyncChannel: TypeAlias = grpc_aio.Channel
 
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 60.0
+"""Default per-call deadline applied to unary RPCs that don't set their own."""
+
 
 def get_ssl_credentials(cert_via_openssl: bool) -> grpc.ChannelCredentials:
     """
@@ -155,9 +158,10 @@ def _compute_channel_options(opts: SiftChannelConfig) -> list[tuple[str, Any]]:
     Initialize all [channel options](https://github.com/grpc/grpc/blob/v1.64.x/include/grpc/impl/channel_arg_names.h) here.
     """
 
+    request_timeout = opts.get("request_timeout", DEFAULT_REQUEST_TIMEOUT_SECONDS)
     options = [
         ("grpc.enable_retries", 1),
-        ("grpc.service_config", RetryPolicy.default().as_json()),
+        ("grpc.service_config", RetryPolicy.default(timeout_seconds=request_timeout).as_json()),
         # Primary cannot be overriden:
         #  https://github.com/grpc/grpc/blob/0498194240f55d7f4b12633ad01339fb690621bf/src/core/ext/filters/http/client/http_client_filter.cc#L97
         ("grpc.secondary_user_agent", _compute_user_agent()),
@@ -248,6 +252,8 @@ class SiftChannelConfig(TypedDict):
     Run `pip install sift-stack-py[openssl]` to install the dependencies required to use this option.
     This works around this issue with grpc loading SSL certificates: https://github.com/grpc/grpc/issues/29682.
     Default is False.
+    - `request_timeout`: Default deadline in seconds applied to unary RPCs that don't set their own.
+    Defaults to 60s. Set to `None` to disable the default deadline.
     """
 
     uri: str
@@ -255,3 +261,4 @@ class SiftChannelConfig(TypedDict):
     enable_keepalive: NotRequired[bool | KeepaliveConfig]
     use_ssl: NotRequired[bool]
     cert_via_openssl: NotRequired[bool]
+    request_timeout: NotRequired[float | None]

--- a/python/lib/sift_client/_internal/sync_wrapper.py
+++ b/python/lib/sift_client/_internal/sync_wrapper.py
@@ -65,9 +65,7 @@ def generate_sync_api(cls: type[ResourceBase], sync_name: str) -> type:
             loop_running = loop.is_running()
         if not loop_running:
             coro.close()
-            raise RuntimeError(
-                "Sift client is closed; cannot make synchronous API calls."
-            )
+            raise RuntimeError("Sift client is closed; cannot make synchronous API calls.")
 
         timeout = getattr(client, "sync_call_timeout", None)
         future = asyncio.run_coroutine_threadsafe(coro, loop)

--- a/python/lib/sift_client/_internal/sync_wrapper.py
+++ b/python/lib/sift_client/_internal/sync_wrapper.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import inspect
 import sys
 from functools import wraps
@@ -53,8 +54,31 @@ def generate_sync_api(cls: type[ResourceBase], sync_name: str) -> type:
         self._async_impl._is_sync = True
 
     def _run(self, coro):
-        loop = self._async_impl.client.get_asyncio_loop()
-        return asyncio.run_coroutine_threadsafe(coro, loop).result()
+        client = self._async_impl.client
+        loop = client.get_asyncio_loop()
+
+        # Fail fast if the loop has stopped (e.g. the client was closed during
+        # teardown). Scheduling onto a stopped loop would block forever because
+        # the coroutine can never run.
+        loop_running = getattr(client, "is_loop_running", None)
+        if loop_running is None:
+            loop_running = loop.is_running()
+        if not loop_running:
+            coro.close()
+            raise RuntimeError(
+                "Sift client is closed; cannot make synchronous API calls."
+            )
+
+        timeout = getattr(client, "sync_call_timeout", None)
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+        try:
+            return future.result(timeout=timeout)
+        except concurrent.futures.TimeoutError as exc:
+            future.cancel()
+            raise TimeoutError(
+                f"Sift synchronous API call exceeded its {timeout}s deadline; the server "
+                "did not respond in time and the request was cancelled."
+            ) from exc
 
     namespace = {
         "__module__": module,

--- a/python/lib/sift_client/_tests/_internal/grpc_transport/test_service_config_timeout.py
+++ b/python/lib/sift_client/_tests/_internal/grpc_transport/test_service_config_timeout.py
@@ -23,14 +23,14 @@ def test_default_policy_has_no_timeout():
 
 def test_timeout_is_formatted_as_duration():
     config = RetryPolicy.default(timeout_seconds=60.0).config
-    assert config["methodConfig"][0]["timeout"] == "60s"
+    assert config["methodConfig"][0].get("timeout") == "60s"
     # Retry policy is preserved alongside the timeout.
     assert "retryPolicy" in config["methodConfig"][0]
 
 
 def test_fractional_timeout_trims_trailing_zeros():
     config = RetryPolicy.default(timeout_seconds=0.5).config
-    assert config["methodConfig"][0]["timeout"] == "0.5s"
+    assert config["methodConfig"][0].get("timeout") == "0.5s"
 
 
 def test_channel_options_apply_default_timeout():

--- a/python/lib/sift_client/_tests/_internal/grpc_transport/test_service_config_timeout.py
+++ b/python/lib/sift_client/_tests/_internal/grpc_transport/test_service_config_timeout.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+
+from sift_client._internal.grpc_transport._retry import RetryPolicy
+from sift_client._internal.grpc_transport.transport import (
+    DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    _compute_channel_options,
+)
+
+
+def _service_config(options) -> dict:
+    for key, value in options:
+        if key == "grpc.service_config":
+            return json.loads(value)
+    raise AssertionError("grpc.service_config not present in channel options")
+
+
+def test_default_policy_has_no_timeout():
+    config = RetryPolicy.default().config
+    assert "timeout" not in config["methodConfig"][0]
+
+
+def test_timeout_is_formatted_as_duration():
+    config = RetryPolicy.default(timeout_seconds=60.0).config
+    assert config["methodConfig"][0]["timeout"] == "60s"
+    # Retry policy is preserved alongside the timeout.
+    assert "retryPolicy" in config["methodConfig"][0]
+
+
+def test_fractional_timeout_trims_trailing_zeros():
+    config = RetryPolicy.default(timeout_seconds=0.5).config
+    assert config["methodConfig"][0]["timeout"] == "0.5s"
+
+
+def test_channel_options_apply_default_timeout():
+    options = _compute_channel_options({"uri": "x", "apikey": "y"})
+    service_config = _service_config(options)
+    expected = f"{int(DEFAULT_REQUEST_TIMEOUT_SECONDS)}s"
+    assert service_config["methodConfig"][0]["timeout"] == expected
+
+
+def test_channel_options_respect_explicit_timeout():
+    options = _compute_channel_options({"uri": "x", "apikey": "y", "request_timeout": 5.0})
+    service_config = _service_config(options)
+    assert service_config["methodConfig"][0]["timeout"] == "5s"
+
+
+def test_channel_options_omit_timeout_when_disabled():
+    options = _compute_channel_options({"uri": "x", "apikey": "y", "request_timeout": None})
+    service_config = _service_config(options)
+    assert "timeout" not in service_config["methodConfig"][0]

--- a/python/lib/sift_client/_tests/_internal/test_sync_wrapper.py
+++ b/python/lib/sift_client/_tests/_internal/test_sync_wrapper.py
@@ -16,9 +16,11 @@ from sift_client.resources._base import ResourceBase
 class MockClient:
     """Mock client that simulates the SiftClient with an event loop."""
 
-    def __init__(self):
+    def __init__(self, sync_call_timeout: float | None = None):
         """Initialize the mock client."""
         self._default_loop = asyncio.new_event_loop()
+        self._loop_running = True
+        self.sync_call_timeout = sync_call_timeout
         atexit.register(self.close_sync)
 
         def _run_default_loop():
@@ -35,7 +37,12 @@ class MockClient:
         """Return the event loop used for async operations."""
         return self._default_loop
 
+    @property
+    def is_loop_running(self) -> bool:
+        return self._loop_running and self._default_loop.is_running()
+
     def close_sync(self):
+        self._loop_running = False
         try:
             self._default_loop.call_soon_threadsafe(self._default_loop.stop)
             self._default_loop_thread.join(timeout=1.0)
@@ -82,6 +89,12 @@ class MockResourceAsync(ResourceBase):
         self._record_call("async_method_with_exception")
         await asyncio.sleep(0.01)
         raise ValueError("Test exception")
+
+    async def slow_async_method(self, delay: float = 1.0) -> str:
+        """Test async method that sleeps, to exercise the sync-call deadline."""
+        self._record_call("slow_async_method")
+        await asyncio.sleep(delay)
+        return "slow_result"
 
     async def async_method_with_executor(self) -> str:
         """Test async method that uses run_in_executor, like wait_and_download."""
@@ -231,3 +244,30 @@ class TestSyncWrapperEventLoopScenarios:
             assert result == "executor_result"
         finally:
             loop.close()
+
+
+class TestSyncWrapperTimeoutAndShutdown:
+    """Tests for the sync-call deadline backstop and the stopped-loop guard."""
+
+    def _make_sync_resource(self, sync_call_timeout: float | None = None):
+        mock_client = MockClient(sync_call_timeout=sync_call_timeout)
+        MockResource = generate_sync_api(MockResourceAsync, "MockResource")  # noqa: N806
+        return MockResource(mock_client, value="testVal")
+
+    def test_call_after_close_raises_runtime_error(self):
+        """A sync call after the loop is closed fails fast instead of hanging."""
+        resource = self._make_sync_resource()
+        resource._async_impl.client.close_sync()
+        with pytest.raises(RuntimeError, match="Sift client is closed"):
+            resource.async_method("arg", 1)
+
+    def test_slow_call_times_out(self):
+        """A call that outlives the sync deadline raises TimeoutError, not a hang."""
+        resource = self._make_sync_resource(sync_call_timeout=0.1)
+        with pytest.raises(TimeoutError, match="did not respond in time"):
+            resource.slow_async_method(delay=5.0)
+
+    def test_fast_call_within_timeout_succeeds(self):
+        """A call that finishes within the deadline returns normally."""
+        resource = self._make_sync_resource(sync_call_timeout=5.0)
+        assert resource.slow_async_method(delay=0.01) == "slow_result"

--- a/python/lib/sift_client/client.py
+++ b/python/lib/sift_client/client.py
@@ -190,6 +190,16 @@ class SiftClient(
         return self._grpc_client
 
     @property
+    def is_loop_running(self) -> bool:
+        """Whether the background event loop is still accepting synchronous API work."""
+        return self._grpc_client.is_loop_running
+
+    @property
+    def sync_call_timeout(self) -> float | None:
+        """Deadline in seconds for a blocking synchronous API call, or None if disabled."""
+        return self._grpc_client.sync_call_timeout
+
+    @property
     def rest_client(self) -> RestClient:
         """The REST client used by the SiftClient for making REST API calls."""
         return self._rest_client

--- a/python/lib/sift_client/transport/grpc_transport.py
+++ b/python/lib/sift_client/transport/grpc_transport.py
@@ -15,12 +15,18 @@ from typing import Any
 from urllib.parse import urlparse
 
 from sift_client._internal.grpc_transport.transport import (
+    DEFAULT_REQUEST_TIMEOUT_SECONDS,
     SiftChannelConfig,
     use_sift_async_channel,
 )
 
 # Configure logging
 logger = logging.getLogger(__name__)
+
+# How far the blocking sync deadline sits above the per-RPC deadline. The gRPC
+# deadline should fire first and cancel the request; the sync backstop only trips
+# if that never happens.
+_SYNC_CALL_TIMEOUT_MARGIN_SECONDS = 15.0
 
 
 def _suppress_blocking_io(loop, context):
@@ -46,6 +52,7 @@ class GrpcConfig:
         use_ssl: bool = True,
         cert_via_openssl: bool = False,
         metadata: dict[str, str] | None = None,
+        request_timeout: float | None = DEFAULT_REQUEST_TIMEOUT_SECONDS,
     ):
         """Initialize the gRPC configuration.
 
@@ -56,6 +63,8 @@ class GrpcConfig:
             cert_via_openssl: Whether to use OpenSSL for SSL/TLS.
             use_async: Whether to use async gRPC client.
             metadata: Additional metadata to include in all requests.
+            request_timeout: Default deadline in seconds applied to unary RPCs that don't set
+                their own. Defaults to 60s. Set to None to disable the default deadline.
         """
         parsed_url = urlparse(url)
         normalized_url = url
@@ -72,6 +81,7 @@ class GrpcConfig:
         self.use_ssl = use_ssl
         self.cert_via_openssl = cert_via_openssl
         self.metadata = metadata or {}
+        self.request_timeout = request_timeout
 
     def _to_sift_channel_config(self) -> SiftChannelConfig:
         """Convert to a SiftChannelConfig.
@@ -84,6 +94,7 @@ class GrpcConfig:
             "apikey": self.api_key,
             "use_ssl": self.use_ssl,
             "cert_via_openssl": self.cert_via_openssl,
+            "request_timeout": self.request_timeout,
         }
 
 
@@ -130,6 +141,10 @@ class GrpcClient:
         channel = future.result()
         self._channels_async[self._default_loop] = channel
         self._stubs_async_map[self._default_loop] = {}
+        # Tracks whether the default loop is accepting work. Set False the moment
+        # a close begins so a concurrent sync call sees it immediately, before the
+        # loop has actually stopped.
+        self._loop_running = True
 
     @property
     def default_loop(self) -> asyncio.AbstractEventLoop:
@@ -139,6 +154,28 @@ class GrpcClient:
             The default asyncio event loop.
         """
         return self._default_loop
+
+    @property
+    def is_loop_running(self) -> bool:
+        """Whether the default loop is accepting synchronous API work.
+
+        False once a close has begun, so callers can fail fast instead of
+        scheduling a coroutine onto a loop that will never run it.
+        """
+        return self._loop_running and self._default_loop.is_running()
+
+    @property
+    def sync_call_timeout(self) -> float | None:
+        """Deadline in seconds for a blocking sync API call, or None if disabled.
+
+        Sits above the per-RPC deadline by a margin so the gRPC deadline fires
+        first and cancels the in-flight request; this is only a backstop for the
+        case where the RPC deadline never trips.
+        """
+        request_timeout = self._config.request_timeout
+        if request_timeout is None:
+            return None
+        return request_timeout + _SYNC_CALL_TIMEOUT_MARGIN_SECONDS
 
     def get_stub(self, stub_class: type[Any]) -> Any:
         """Get an async stub bound to the current event loop.
@@ -168,6 +205,7 @@ class GrpcClient:
         if self._closed:
             return
         self._closed = True
+        self._loop_running = False
         try:
             # Only drive the loop if it's still running; submitting a coroutine
             # to a stopped loop never resolves and would hang on .result().
@@ -188,6 +226,7 @@ class GrpcClient:
         if self._closed:
             return
         self._closed = True
+        self._loop_running = False
         for ch in self._channels_async.values():
             await ch.close()
         self._default_loop.call_soon_threadsafe(self._default_loop.stop)


### PR DESCRIPTION
## Summary

Synchronous SDK calls could hang indefinitely. A stalled gRPC connection, or a call issued after the client's background event loop had stopped during teardown, left the calling thread blocked forever because neither the RPC nor the blocking wait had a deadline. This adds a default request deadline plus two backstops so a stalled or post-shutdown call fails with a clear error instead of hanging.

## Changes

- **Default RPC deadline (primary).** Unary calls now carry a 60s deadline via the gRPC service config (`methodConfig.timeout`), alongside the existing retry policy. A stalled call fails with `DEADLINE_EXCEEDED` rather than hanging. Configurable per connection via `GrpcConfig(request_timeout=...)`, overridable per call, and disabled by passing `None`.
- **Bounded synchronous wait.** The sync wrapper's `.result()` now uses a deadline (RPC timeout plus a margin) and raises `TimeoutError` after cancelling the request. The gRPC deadline fires first, so this only trips if that fails.
- **Fail fast after close.** A call made once the background loop has stopped now raises a clear `RuntimeError` instead of scheduling onto a dead loop and blocking.

## Testing

- `_internal` unit suite passes, including new coverage for the sync deadline and the post-close guard.
- Confirmed the deadline lands in the channel service config: `60s` default, explicit override honored, omitted when disabled.

## Notes

The default of 60s sits above the retry budget (5 attempts, 5s max backoff). The service-config timeout applies to all methods via the wildcard matcher; this is safe because high-throughput streaming runs through the Rust stream bindings on a separate connection, not this channel.
