### PR TITLE
Add unit tests and fix incremental upload bug

### DIFF
--- a/python/lib/sift_client/_internal/low_level_wrappers/_test_results_log.py
+++ b/python/lib/sift_client/_internal/low_level_wrappers/_test_results_log.py
@@ -143,9 +143,13 @@ class _ReplayState:
 
 @dataclass
 class ReplayResult:
-    """Result of replaying a log file."""
+    """Result of replaying a log file.
 
-    report: TestReport
+    ``report`` is None on an incremental resume tick that uploaded only steps or
+    measurements; the report itself was created on an earlier tick.
+    """
+
+    report: TestReport | None = None
     steps: list[TestStep] = field(default_factory=list)
     measurements: list[TestMeasurement] = field(default_factory=list)
 

--- a/python/lib/sift_client/_internal/low_level_wrappers/test_results.py
+++ b/python/lib/sift_client/_internal/low_level_wrappers/test_results.py
@@ -1072,13 +1072,17 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         id_map: dict[str, str],
         state: _ReplayState,
     ) -> None:
-        if state.report is None:
-            raise ValueError("UpdateTestReport found before CreateTestReport")
         request = UpdateTestReportRequest()
         json_format.Parse(json_str, request)
         request.test_report.test_report_id = self._map_id(
             id_map, request.test_report.test_report_id
         )
+        # Batch/simulate replays the whole log in order, so a missing report means
+        # the log is malformed. Incremental replay may have created the report on an
+        # earlier tick (its real ID lives in id_map), so state.report is legitimately
+        # None here -- the mapped ID is enough to issue the update.
+        if simulate and state.report is None:
+            raise ValueError("UpdateTestReport found before CreateTestReport")
         state.report = await self.update_test_report(
             request=request, simulate=simulate, existing=state.report
         )
@@ -1203,6 +1207,7 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         next tick.
         """
         tracking = LogTracking.load(log_path)
+        resuming = tracking.last_uploaded_line > 0
         id_map = tracking.id_map
         state = _ReplayState()
 
@@ -1221,7 +1226,13 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
             tracking.last_uploaded_line += 1
             tracking.save(log_path)
 
-        if state.report is None:
+        # On a resume tick the CreateTestReport line was consumed on an earlier
+        # tick, so state.report is expected to be None; the report already exists
+        # on the server. Only a genuine first pass over an empty log is an error.
+        # On a resume tick the CreateTestReport line was consumed on an earlier
+        # tick, so state.report is expected to be None; the report already exists
+        # on the server. Only a genuine first pass over an empty log is an error.
+        if state.report is None and not resuming:
             raise ValueError("No CreateTestReport found in log file")
 
         return ReplayResult(

--- a/python/lib/sift_client/_internal/low_level_wrappers/test_results.py
+++ b/python/lib/sift_client/_internal/low_level_wrappers/test_results.py
@@ -1229,9 +1229,6 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         # On a resume tick the CreateTestReport line was consumed on an earlier
         # tick, so state.report is expected to be None; the report already exists
         # on the server. Only a genuine first pass over an empty log is an error.
-        # On a resume tick the CreateTestReport line was consumed on an earlier
-        # tick, so state.report is expected to be None; the report already exists
-        # on the server. Only a genuine first pass over an empty log is an error.
         if state.report is None and not resuming:
             raise ValueError("No CreateTestReport found in log file")
 

--- a/python/lib/sift_client/_tests/_internal/low_level_wrappers/test_incremental_replay.py
+++ b/python/lib/sift_client/_tests/_internal/low_level_wrappers/test_incremental_replay.py
@@ -100,7 +100,8 @@ async def test_resume_applies_trailing_report_update(tmp_path):
     sent = client.update_test_report.await_args.kwargs["request"]
     assert sent.test_report.test_report_id == "real-report"
     assert sent.test_report.status == TestStatus.FAILED.value
-    assert result.report is not None and result.report.id_ == "real-report"
+    assert result.report is not None
+    assert result.report.id_ == "real-report"
 
 
 @pytest.mark.asyncio

--- a/python/lib/sift_client/_tests/_internal/low_level_wrappers/test_incremental_replay.py
+++ b/python/lib/sift_client/_tests/_internal/low_level_wrappers/test_incremental_replay.py
@@ -1,0 +1,142 @@
+"""Unit tests for incremental log-replay resume, with no live backend.
+
+These pin the resume-tick behavior of
+``TestResultsLowLevelClient.import_log_file(incremental=True)``: the
+CreateTestReport line is uploaded on an earlier tick, so a resuming tick rebuilds
+replay state from scratch and must apply the remaining lines without an
+in-memory report. The real gRPC create/update calls are stubbed, so these run
+offline -- unlike the end-to-end resume test, which needs the integration server.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from sift_client._internal.low_level_wrappers._test_results_log import LogTracking
+from sift_client._internal.low_level_wrappers.test_results import (
+    # Aliased so pytest doesn't try to collect the `Test`-prefixed client as a suite.
+    TestResultsLowLevelClient as ResultsLowLevelClient,
+)
+from sift_client.sift_types.test_report import (
+    TestReport,
+    TestReportCreate,
+    TestReportUpdate,
+    TestStatus,
+    TestStep,
+    TestStepCreate,
+    TestStepType,
+)
+
+T0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _make_report(id_: str) -> TestReport:
+    return TestReport(
+        id_=id_,
+        status=TestStatus.FAILED,
+        name="n",
+        test_system_name="s",
+        test_case="c",
+        start_time=T0,
+        end_time=T0,
+        metadata={},
+        is_archived=False,
+    )
+
+
+def _make_step(id_: str) -> TestStep:
+    return TestStep(
+        id_=id_,
+        test_report_id="real-report",
+        name="step",
+        step_type=TestStepType.ACTION,
+        step_path="1",
+        status=TestStatus.PASSED,
+        start_time=T0,
+        end_time=T0,
+    )
+
+
+def _report_create() -> TestReportCreate:
+    return TestReportCreate(
+        status=TestStatus.IN_PROGRESS,
+        name="n",
+        test_system_name="s",
+        test_case="c",
+        start_time=T0,
+        end_time=T0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_applies_trailing_report_update(tmp_path):
+    """Resume whose remaining chunk is the final UpdateTestReport must apply it.
+
+    Pre-fix this raised "UpdateTestReport found before CreateTestReport"; the
+    status update then never landed and the report stayed IN_PROGRESS.
+    """
+    log_file = tmp_path / "resume_report_update.jsonl"
+    client = ResultsLowLevelClient(grpc_client=MagicMock())
+
+    # Build the log offline via the simulate path: CreateTestReport + UpdateTestReport.
+    report = await client.create_test_report(test_report=_report_create(), log_file=log_file)
+    update = TestReportUpdate(status=TestStatus.FAILED)
+    update.resource_id = report.id_
+    await client.update_test_report(update=update, log_file=log_file)
+
+    # An earlier tick already uploaded the CreateTestReport (line 1); the report
+    # exists on the server under its real ID.
+    LogTracking(last_uploaded_line=1, id_map={report.id_: "real-report"}).save(log_file)
+
+    # Stub the real RPC the resumed tick will issue.
+    client.update_test_report = AsyncMock(return_value=_make_report("real-report"))
+
+    result = await client.import_log_file(log_file, incremental=True)
+
+    client.update_test_report.assert_awaited_once()
+    sent = client.update_test_report.await_args.kwargs["request"]
+    assert sent.test_report.test_report_id == "real-report"
+    assert sent.test_report.status == TestStatus.FAILED.value
+    assert result.report is not None and result.report.id_ == "real-report"
+
+
+@pytest.mark.asyncio
+async def test_resume_with_only_steps_does_not_require_report(tmp_path):
+    """A resume tick carrying only steps must not demand an in-memory report.
+
+    Pre-fix this raised "No CreateTestReport found in log file" (the field-report
+    trace), aborting replay of the remaining step lines.
+    """
+    log_file = tmp_path / "resume_steps_only.jsonl"
+    client = ResultsLowLevelClient(grpc_client=MagicMock())
+
+    report = await client.create_test_report(test_report=_report_create(), log_file=log_file)
+    await client.create_test_step(
+        test_step=TestStepCreate(
+            test_report_id=report.id_,
+            name="s1",
+            step_type=TestStepType.ACTION,
+            step_path="1",
+            status=TestStatus.PASSED,
+            start_time=T0,
+            end_time=T0,
+        ),
+        log_file=log_file,
+    )
+
+    LogTracking(last_uploaded_line=1, id_map={report.id_: "real-report"}).save(log_file)
+
+    client.create_test_step = AsyncMock(return_value=_make_step("real-step"))
+
+    result = await client.import_log_file(log_file, incremental=True)
+
+    client.create_test_step.assert_awaited_once()
+    sent = client.create_test_step.await_args.kwargs["request"]
+    # The step's report ID was remapped from the simulated ID to the real one.
+    assert sent.test_step.test_report_id == "real-report"
+    # The report was created on the earlier tick, so this resume tick has no report.
+    assert result.report is None
+    assert len(result.steps) == 1

--- a/python/lib/sift_client/_tests/resources/test_test_results.py
+++ b/python/lib/sift_client/_tests/resources/test_test_results.py
@@ -715,6 +715,75 @@ class TestImportLogFile:
             replayed_m = replayed_measurements_by_name[direct_m.name]
             compare_test_measurement_fields(replayed_m, direct_m)
 
+    def test_incremental_import_resumes_after_report_created(
+        self, sift_client, nostromo_run, tmp_path
+    ):
+        """Incremental replay must survive a resume after the report was created.
+
+        Regression: a resume tick rebuilds replay state from scratch, so the
+        CreateTestReport line (already uploaded on an earlier tick) is skipped and
+        the in-memory report is None. The replay must still apply the remaining
+        lines -- including the final UpdateTestReport -- rather than raising
+        "No CreateTestReport found" and leaving the report stuck IN_PROGRESS.
+        """
+        t0 = datetime.now(timezone.utc)
+        log_file = tmp_path / "incremental_resume.jsonl"
+
+        # Build a complete simulation log (no real resources created yet).
+        report = sift_client.test_results.create(
+            {
+                "status": TestStatus.IN_PROGRESS,
+                "name": "Incremental Resume Report",
+                "test_system_name": "IR System",
+                "test_case": "IR Case",
+                "start_time": t0,
+                "end_time": t0 + timedelta(seconds=30),
+                "run_id": nostromo_run.id_,
+            },
+            log_file=log_file,
+        )
+        step = sift_client.test_results.create_step(
+            TestStepCreate(
+                test_report_id=report.id_,
+                name="IR Step 1",
+                step_type=TestStepType.ACTION,
+                step_path="1",
+                status=TestStatus.IN_PROGRESS,
+                start_time=t0,
+                end_time=t0 + timedelta(seconds=10),
+            ),
+            log_file=log_file,
+        )
+        sift_client.test_results.update_step(
+            step,
+            {"status": TestStatus.FAILED},
+            log_file=log_file,
+        )
+        sift_client.test_results.update(
+            test_report=report,
+            update=TestReportUpdate(status=TestStatus.FAILED),
+            log_file=log_file,
+        )
+
+        all_lines = log_file.read_text().splitlines()
+        assert all_lines[0].startswith("[CreateTestReport:")
+
+        # First tick: only the CreateTestReport is present. This creates the real
+        # report and advances the tracking cursor past line 1.
+        log_file.write_text(all_lines[0] + "\n")
+        first = sift_client.test_results.import_log_file(log_file, incremental=True)
+        real_report_id = first.report.id_
+        assert real_report_id is not None
+
+        # Later tick: the rest of the log is now available. Resuming past the
+        # CreateTestReport line must not raise, and the final UpdateTestReport must
+        # land so the report ends FAILED rather than IN_PROGRESS.
+        log_file.write_text("\n".join(all_lines) + "\n")
+        sift_client.test_results.import_log_file(log_file, incremental=True)
+
+        refetched = sift_client.test_results.get(test_report_id=real_report_id)
+        assert refetched.status == TestStatus.FAILED
+
     @pytest.mark.asyncio
     async def test_malformed_log_line_skipped(self, tmp_path):
         """Malformed lines raise a ValueError during iteration."""

--- a/python/lib/sift_client/_tests/util/test_report_context.py
+++ b/python/lib/sift_client/_tests/util/test_report_context.py
@@ -76,7 +76,9 @@ def test_worker_timeout_kills_and_warns() -> None:
     assert rc._import_proc.poll() is not None
     messages = "\n".join(str(w.message) for w in recorded)
     assert "did not exit in 0.2s" in messages
-    assert "import-test-result-log" in messages
+    # Recovery must resume from the tracking cursor, not batch-replay (which would
+    # duplicate already-uploaded entries), so the hint carries --incremental.
+    assert "import-test-result-log --incremental" in messages
 
 
 def test_worker_nonzero_exit_warns_stderr_no_raise() -> None:
@@ -96,4 +98,4 @@ def test_worker_nonzero_exit_warns_stderr_no_raise() -> None:
     messages = "\n".join(str(w.message) for w in recorded)
     assert "exited with code 2" in messages
     assert "rpc deadline exceeded" in messages
-    assert "import-test-result-log" in messages
+    assert "import-test-result-log --incremental" in messages

--- a/python/lib/sift_client/resources/test_results.py
+++ b/python/lib/sift_client/resources/test_results.py
@@ -671,7 +671,8 @@ class TestResultsAPIAsync(ResourceBase):
             A ReplayResult containing the created report, steps, and measurements.
         """
         result = await self._low_level_client.import_log_file(log_file, incremental=incremental)
-        result.report = self._apply_client_to_instance(result.report)
+        if result.report is not None:
+            result.report = self._apply_client_to_instance(result.report)
         result.steps = self._apply_client_to_instances(result.steps)
         result.measurements = self._apply_client_to_instances(result.measurements)
         return result

--- a/python/lib/sift_client/scripts/import_test_result_log.py
+++ b/python/lib/sift_client/scripts/import_test_result_log.py
@@ -20,7 +20,8 @@ logger = logging.getLogger(__name__)
 
 
 def _print_result(result: ReplayResult) -> None:
-    print(f"Report: {result.report.name} (id={result.report.id_})")
+    if result.report is not None:
+        print(f"Report: {result.report.name} (id={result.report.id_})")
     print(f"Steps:  {len(result.steps)}")
     for step in result.steps:
         print(f"  - {step.step_path} [{step.status}]")

--- a/python/lib/sift_client/util/test_results/context_manager.py
+++ b/python/lib/sift_client/util/test_results/context_manager.py
@@ -81,7 +81,7 @@ def log_replay_instructions(log_file: str | Path | None) -> None:
         return
     warnings.warn(
         f"Sift log file was not fully replayed: {log_file}. "
-        f"Re-run with `import-test-result-log {log_file}` to complete the upload.",
+        f"Re-run with `import-test-result-log --incremental {log_file}` to complete the upload.",
         SiftWarning,
         stacklevel=2,
     )


### PR DESCRIPTION
## Summary

Incremental upload of test-result logs failed whenever a replay resumed after its first tick, which left the corresponding report stuck in an in-progress state. This fixes the resume path, corrects the recovery instruction, and adds regression coverage.

## Root cause

The pytest plugin streams a test-result log to Sift incrementally: a background worker re-runs the importer about once a second, advancing a per-line cursor stored in a `.tracking` sidecar. Each invocation rebuilt replay state from scratch but still required an in-memory `CreateTestReport`. On any resume (cursor already past the report line), that line had been uploaded on an earlier tick and was skipped, so the importer raised instead of applying the remaining lines. Depending on which entries fell in the resumed chunk, this surfaced as one of:

- `No CreateTestReport found in log file`
- `UpdateTestReport found before CreateTestReport`

Since the final report-status update never landed, the report never left the in-progress state. Short runs that completed within a single tick never resumed, so the problem only appeared on longer sessions.

## Changes

- Incremental replay no longer requires an in-memory report on a resume tick. The report's real ID is read from the tracking ID map and updates are issued against it. The "missing report" guards now apply only to batch and first-pass replay, where a full in-order replay is expected.
- `ReplayResult.report` is now optional, since a resume tick may carry only steps or measurements. Both consumers are guarded accordingly.
- The recovery instruction now points at `import-test-result-log --incremental <log>`, so a manual retry resumes from the cursor instead of batch-replaying the file and creating a duplicate report.

## Tests

- New fast unit tests (no backend required) covering both resume failure modes, with the gRPC create/update calls stubbed.
- A new integration test that uploads a report on a first tick, then resumes over the full log and asserts the final status is applied.
- Strengthened the worker recovery-path tests to assert the recovery hint includes `--incremental`.
