### PR TITLE
rust(feat): mcp list rules tool

### DIFF
--- a/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
+++ b/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
@@ -16,7 +16,7 @@ to combine them when working with Sift.
 
 1. **Sift MCP server** — started by `sift-cli mcp`. The preferred surface for
    agents. Exposes structured, authenticated tools:
-   - `list_assets`, `list_runs`, `list_channels`, `list_reports`: discover what exists.
+   - `list_assets`, `list_runs`, `list_channels`, `list_reports`, `list_rules`: discover what exists.
    - `get_data`: download channel data for an asset/run to a Parquet file.
    - `sql`: run SQL over one or more Parquet files (chain after `get_data`).
    - `upload_dataset`: stream a Parquet dataset into Sift.

--- a/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
@@ -28,7 +28,7 @@ to combine them when working with Sift.
 
 1. **Sift MCP server** — started by `sift-cli mcp`. The preferred surface for
    agents. Exposes structured, authenticated tools:
-   - `list_assets`, `list_runs`, `list_channels`, `list_reports`: discover what exists.
+   - `list_assets`, `list_runs`, `list_channels`, `list_reports`, `list_rules`: discover what exists.
    - `get_data`: download channel data for an asset/run to a Parquet file.
    - `sql`: run SQL over one or more Parquet files (chain after `get_data`).
    - `upload_dataset`: stream a Parquet dataset into Sift.

--- a/rust/crates/sift_mcp/src/server/mod.rs
+++ b/rust/crates/sift_mcp/src/server/mod.rs
@@ -11,7 +11,7 @@ use sift_rs::SiftChannel;
 
 use crate::service::{
     assets::AssetService, channels::ChannelService, data::DataService, ingest::IngestService,
-    reports::ReportService, runs::RunService, rules::RuleService
+    reports::ReportService, rules::RuleService, runs::RunService,
 };
 
 #[derive(Clone)]

--- a/rust/crates/sift_mcp/src/server/mod.rs
+++ b/rust/crates/sift_mcp/src/server/mod.rs
@@ -11,7 +11,7 @@ use sift_rs::SiftChannel;
 
 use crate::service::{
     assets::AssetService, channels::ChannelService, data::DataService, ingest::IngestService,
-    reports::ReportService, runs::RunService,
+    reports::ReportService, runs::RunService, rules::RuleService
 };
 
 #[derive(Clone)]
@@ -25,6 +25,7 @@ pub struct SiftMcpServer {
     pub ingest_service: IngestService,
     pub run_service: RunService,
     pub report_service: ReportService,
+    pub rule_service: RuleService,
 }
 
 #[tool_handler(
@@ -51,6 +52,7 @@ impl SiftMcpServer {
         let ingest_service = IngestService::new(channel.clone());
         let run_service = RunService::new(channel.clone());
         let report_service = ReportService::new(channel.clone());
+        let rule_service = RuleService::new(channel.clone());
 
         Self {
             asset_service,
@@ -59,6 +61,7 @@ impl SiftMcpServer {
             ingest_service,
             run_service,
             report_service,
+            rule_service,
             tool_router,
             prompt_router,
         }

--- a/rust/crates/sift_mcp/src/service/mod.rs
+++ b/rust/crates/sift_mcp/src/service/mod.rs
@@ -3,6 +3,7 @@ pub mod channels;
 pub mod data;
 pub mod ingest;
 pub mod reports;
+pub mod rules;
 pub mod runs;
 
 pub(crate) mod common;

--- a/rust/crates/sift_mcp/src/service/rules/mod.rs
+++ b/rust/crates/sift_mcp/src/service/rules/mod.rs
@@ -1,0 +1,65 @@
+use crate::service::common;
+use anyhow::{Context, Result};
+use sift_rs::{
+    SiftChannel,
+    rules::v1::{
+        ListRulesRequest, ListRulesResponse, Rule, rule_service_client::RuleServiceClient,
+    },
+};
+
+#[cfg(test)]
+mod test;
+
+#[derive(Clone)]
+pub struct RuleService {
+    channel: SiftChannel,
+}
+
+impl RuleService {
+    pub fn new(channel: SiftChannel) -> Self {
+        Self { channel }
+    }
+
+    pub async fn list_rules(
+        &self,
+        filter: String,
+        order_by: Option<String>,
+        limit: Option<u32>,
+    ) -> Result<Vec<Rule>> {
+        let (page_size, record_limit) = common::paging(limit);
+
+        let mut client = RuleServiceClient::new(self.channel.clone());
+        let mut page_token = String::new();
+        let mut results = Vec::new();
+
+        loop {
+            let resp = client
+                .list_rules(ListRulesRequest {
+                    filter: filter.clone(),
+                    page_size,
+                    page_token,
+                    order_by: order_by.clone().unwrap_or_default(),
+                })
+                .await
+                .context("failed to query rules")?;
+            
+            let ListRulesResponse { 
+                rules, 
+                next_page_token 
+            } = resp.into_inner();
+            if rules.is_empty() {
+                break;
+            }
+            results.extend(rules);
+
+            if results.len() >= record_limit || next_page_token.is_empty() {
+                break;
+            }
+            page_token = next_page_token;
+        }
+
+        results.truncate(record_limit);
+
+        Ok(results)
+    }
+}

--- a/rust/crates/sift_mcp/src/service/rules/mod.rs
+++ b/rust/crates/sift_mcp/src/service/rules/mod.rs
@@ -42,10 +42,10 @@ impl RuleService {
                 })
                 .await
                 .context("failed to query rules")?;
-            
-            let ListRulesResponse { 
-                rules, 
-                next_page_token 
+
+            let ListRulesResponse {
+                rules,
+                next_page_token,
             } = resp.into_inner();
             if rules.is_empty() {
                 break;

--- a/rust/crates/sift_mcp/src/service/rules/test.rs
+++ b/rust/crates/sift_mcp/src/service/rules/test.rs
@@ -1,0 +1,235 @@
+use sift_rs::rules::v1::{
+    ListRulesResponse, Rule, rule_service_server::RuleServiceServer,
+};
+use sift_test_util::{grpc::memory_sift_channel, mock::rules::v1::MockRuleServiceImpl};
+use tokio::task::JoinHandle;
+use tonic::{Response, Status, transport::Server};
+
+use super::RuleService;
+use crate::service::common::PAGE_SIZE;
+
+async fn service_with_mock(mock: MockRuleServiceImpl) -> (RuleService, JoinHandle<()>) {
+    let (client, server) = tokio::io::duplex(1024);
+    let channel = memory_sift_channel(client).await;
+
+    let handle = tokio::spawn(async move {
+        Server::builder()
+            .add_service(RuleServiceServer::new(mock))
+            .serve_with_incoming(tokio_stream::once(Ok::<_, std::io::Error>(server)))
+            .await
+            .unwrap();
+    });
+
+    (RuleService::new(channel), handle)
+}
+
+#[tokio::test]
+async fn list_rules_returns_single_page() {
+    let mut mock = MockRuleServiceImpl::new();
+    mock.expect_list_rules()
+        .withf(|req| req.get_ref().filter == "name == \"overtemp\"")
+        .returning(|_| {
+            Ok(Response::new(ListRulesResponse {
+                rules: vec![Rule {
+                    rule_id: "rule1".into(),
+                    name: "overtemp".into(),
+                    ..Default::default()
+                }],
+                next_page_token: String::new(),
+            }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let rules = service
+        .list_rules("name == \"overtemp\"".to_string(), None, None)
+        .await
+        .expect("list_rules failed");
+
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].rule_id, "rule1");
+}
+
+#[tokio::test]
+async fn list_rules_forwards_order_by() {
+    let mut mock = MockRuleServiceImpl::new();
+    mock.expect_list_rules()
+        .withf(|req| req.get_ref().order_by == "created_date desc")
+        .returning(|_| {
+            Ok(Response::new(ListRulesResponse {
+                rules: vec![Rule {
+                    rule_id: "rule1".into(),
+                    ..Default::default()
+                }],
+                next_page_token: String::new(),
+            }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let rules = service
+        .list_rules(String::new(), Some("created_date desc".to_string()), None)
+        .await
+        .expect("list_rules failed");
+
+    assert_eq!(rules.len(), 1);
+}
+
+#[tokio::test]
+async fn list_rules_paginates_until_token_empty() {
+    let mut mock = MockRuleServiceImpl::new();
+    mock.expect_list_rules().returning(|req| {
+        let req = req.into_inner();
+        assert_eq!(req.page_size, PAGE_SIZE);
+        let (rules, next) = match req.page_token.as_str() {
+            "" => (
+                vec![Rule {
+                    rule_id: "rule1".into(),
+                    ..Default::default()
+                }],
+                "page-2".to_string(),
+            ),
+            "page-2" => (
+                vec![Rule {
+                    rule_id: "rule2".into(),
+                    ..Default::default()
+                }],
+                String::new(),
+            ),
+            other => return Err(Status::invalid_argument(format!("bad token: {other}"))),
+        };
+        Ok(Response::new(ListRulesResponse {
+            rules,
+            next_page_token: next,
+        }))
+    });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let rules = service
+        .list_rules(String::new(), None, None)
+        .await
+        .expect("list_rules failed");
+
+    let ids: Vec<&str> = rules.iter().map(|r| r.rule_id.as_str()).collect();
+    assert_eq!(ids, vec!["rule1", "rule2"]);
+}
+
+#[tokio::test]
+async fn list_rules_respects_limit() {
+    let mut mock = MockRuleServiceImpl::new();
+    mock.expect_list_rules().times(1).returning(|req| {
+        let req = req.into_inner();
+        assert_eq!(req.page_size, 2);
+        Ok(Response::new(ListRulesResponse {
+            rules: vec![
+                Rule {
+                    rule_id: "rule1".into(),
+                    ..Default::default()
+                },
+                Rule {
+                    rule_id: "rule2".into(),
+                    ..Default::default()
+                },
+            ],
+            next_page_token: "page-2".into(),
+        }))
+    });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let rules = service
+        .list_rules(String::new(), None, Some(2))
+        .await
+        .expect("list_rules failed");
+
+    assert_eq!(rules.len(), 2);
+}
+
+#[tokio::test]
+async fn list_rules_truncates_to_limit_across_pages() {
+    let mut mock = MockRuleServiceImpl::new();
+    mock.expect_list_rules().returning(|req| {
+        let req = req.into_inner();
+        assert_eq!(req.page_size, 3);
+        let (rules, next) = match req.page_token.as_str() {
+            "" => (
+                vec![
+                    Rule {
+                        rule_id: "rule1".into(),
+                        ..Default::default()
+                    },
+                    Rule {
+                        rule_id: "rule2".into(),
+                        ..Default::default()
+                    },
+                ],
+                "page-2".to_string(),
+            ),
+            "page-2" => (
+                vec![
+                    Rule {
+                        rule_id: "rule3".into(),
+                        ..Default::default()
+                    },
+                    Rule {
+                        rule_id: "rule4".into(),
+                        ..Default::default()
+                    },
+                ],
+                String::new(),
+            ),
+            other => return Err(Status::invalid_argument(format!("bad token: {other}"))),
+        };
+        Ok(Response::new(ListRulesResponse {
+            rules,
+            next_page_token: next,
+        }))
+    });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let rules = service
+        .list_rules(String::new(), None, Some(3))
+        .await
+        .expect("list_rules failed");
+
+    let ids: Vec<&str> = rules.iter().map(|r| r.rule_id.as_str()).collect();
+    assert_eq!(ids, vec!["rule1", "rule2", "rule3"]);
+}
+
+#[tokio::test]
+async fn list_rules_breaks_on_empty_page() {
+    let mut mock = MockRuleServiceImpl::new();
+    mock.expect_list_rules().times(1).returning(|_| {
+        Ok(Response::new(ListRulesResponse {
+            rules: vec![],
+            next_page_token: "ignored".into(),
+        }))
+    });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let rules = service
+        .list_rules(String::new(), None, None)
+        .await
+        .expect("list_rules failed");
+
+    assert!(rules.is_empty());
+}
+
+#[tokio::test]
+async fn list_rules_propagates_grpc_error() {
+    let mut mock = MockRuleServiceImpl::new();
+    mock.expect_list_rules()
+        .returning(|_| Err(Status::not_found("no such rule")));
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let err = service
+        .list_rules(String::new(), None, None)
+        .await
+        .expect_err("expected error");
+
+    assert!(err.to_string().contains("failed to query rules"));
+}

--- a/rust/crates/sift_mcp/src/service/rules/test.rs
+++ b/rust/crates/sift_mcp/src/service/rules/test.rs
@@ -1,6 +1,4 @@
-use sift_rs::rules::v1::{
-    ListRulesResponse, Rule, rule_service_server::RuleServiceServer,
-};
+use sift_rs::rules::v1::{ListRulesResponse, Rule, rule_service_server::RuleServiceServer};
 use sift_test_util::{grpc::memory_sift_channel, mock::rules::v1::MockRuleServiceImpl};
 use tokio::task::JoinHandle;
 use tonic::{Response, Status, transport::Server};

--- a/rust/crates/sift_mcp/src/tool/list/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/list/mod.rs
@@ -232,4 +232,57 @@ impl SiftMcpServer {
 
         Ok(CallToolResult::structured(out))
     }
+
+    #[tool(
+        name = "list_rules",
+        description = "
+            List rules in Sift, optionally filtered by a CEL expression and ordered by one or more fields.
+
+            Output:
+              - `{ \"rules\": [Rule, ...] }`. Each item is the full Sift `Rule` shape including `rule_id`,
+                `client_key`, `name`, `description`, `is_enabled`, `is_external`, `is_archived`,
+                `archived_date`, `is_live_evaluation_enabled`, `organization_id`, `conditions`, `rule_version`,
+                `current_version_id`, `asset_configuration` (asset_ids + tag_ids), `contextual_channels`,
+                `metadata`, and timestamps.
+
+            Parameters:
+              - `filter`: CEL expression. Pass an empty string to list everything. Filterable fields:
+                `rule_id`, `client_key`, `name`, `description`, `is_external`, `asset_id`, `tag_id`,
+                `created_date`, `created_by_user_id`, `metadata`, `modified_date`, `modified_by_user_id`,
+                `deleted_date`, `is_archived`, `archived_date`, `is_live_evaluation_enabled`.
+                Reference metadata entries as `metadata.{key}` (e.g. `metadata.severity == \"high\"`).
+              - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields:
+                `created_date`, `modified_date`. Default sort is `created_date desc` (newest first).
+                Example: `\"created_date desc,modified_date\"`.
+              - `limit`: optional cap on returned items. Values in `1..=1000` cap the result set. Omitting it OR
+                passing a value above 1000 returns ALL matching rules (paginated server-side).
+
+            Errors:
+              - `INVALID_PARAMS` if `filter` is not a valid CEL expression or `order_by` references an unknown field.
+              - `INTERNAL_ERROR` for upstream gRPC failures.
+
+            Guidance:
+              - Scope with `asset_id == \"...\"` when the rule's target asset is known — it's the most selective
+                field for narrowing rule listings.
+              - Use `is_archived == false` to exclude archived rules unless they're explicitly needed.
+              - Use `is_live_evaluation_enabled == true` to find only rules that run against live data.
+        ",
+        annotations(title = "list_router/list_rules", read_only_hint = true)
+    )]
+    pub async fn list_rules(&self, params: Parameters<ListParams>) -> error::McpResult {
+        let Parameters(ListParams {
+            filter,
+            order_by,
+            limit,
+        }) = params;
+
+        let out = self
+            .rule_service
+            .list_rules(filter, order_by, limit)
+            .await
+            .map(|rules| serde_json::json!({ "rules": rules }))
+            .map_err(from_anyhow)?;
+
+        Ok(CallToolResult::structured(out))
+    }
 }

--- a/rust/crates/sift_test_util/src/mock/mod.rs
+++ b/rust/crates/sift_test_util/src/mock/mod.rs
@@ -2,6 +2,7 @@ pub mod assets;
 pub mod channels;
 pub mod data;
 pub mod reports;
+pub mod rules;
 pub mod runs;
 
 /// A test demonstrating a little bit of everything of how to leverage the mock API.

--- a/rust/crates/sift_test_util/src/mock/rules/mod.rs
+++ b/rust/crates/sift_test_util/src/mock/rules/mod.rs
@@ -1,0 +1,1 @@
+pub mod v1;

--- a/rust/crates/sift_test_util/src/mock/rules/v1.rs
+++ b/rust/crates/sift_test_util/src/mock/rules/v1.rs
@@ -1,0 +1,196 @@
+use async_trait::async_trait;
+use mockall::mock;
+use sift_rs::rules::v1::{
+    ArchiveRuleRequest, ArchiveRuleResponse, BatchArchiveRulesRequest, BatchArchiveRulesResponse,
+    BatchDeleteRulesRequest, BatchDeleteRulesResponse, BatchGetRuleVersionsRequest,
+    BatchGetRuleVersionsResponse, BatchGetRulesRequest, BatchGetRulesResponse,
+    BatchUnarchiveRulesRequest, BatchUnarchiveRulesResponse, BatchUndeleteRulesRequest,
+    BatchUndeleteRulesResponse, BatchUpdateRulesRequest, BatchUpdateRulesResponse,
+    CreateRuleRequest, CreateRuleResponse, DeleteRuleRequest, DeleteRuleResponse,
+    EvaluateRulesRequest, EvaluateRulesResponse, GetRuleRequest, GetRuleResponse,
+    GetRuleVersionRequest, GetRuleVersionResponse, ListRuleVersionsRequest,
+    ListRuleVersionsResponse, ListRulesRequest, ListRulesResponse, SearchRulesRequest,
+    SearchRulesResponse, UnarchiveRuleRequest, UnarchiveRuleResponse, UndeleteRuleRequest,
+    UndeleteRuleResponse, UpdateHumanFriendlyRulesRequest, UpdateHumanFriendlyRulesResponse,
+    UpdateJsonRulesRequest, UpdateJsonRulesResponse, UpdateRuleRequest, UpdateRuleResponse,
+    ValidateJsonRulesRequest, ValidateJsonRulesResponse, ViewHumanFriendlyRulesRequest,
+    ViewHumanFriendlyRulesResponse, ViewJsonRulesRequest, ViewJsonRulesResponse,
+    rule_service_server::RuleService,
+};
+use tonic::{Request, Response, Status};
+
+mock! {
+    pub RuleServiceImpl {}
+
+    #[async_trait]
+    impl RuleService for RuleServiceImpl {
+        async fn search_rules(
+            &self,
+            request: Request<SearchRulesRequest>,
+        ) -> std::result::Result<
+            Response<SearchRulesResponse>,
+            Status,
+        >;
+        async fn get_rule(
+            &self,
+            request: Request<GetRuleRequest>,
+        ) -> std::result::Result<
+            Response<GetRuleResponse>,
+            Status,
+        >;
+        async fn batch_get_rules(
+            &self,
+            request: Request<BatchGetRulesRequest>,
+        ) -> std::result::Result<
+            Response<BatchGetRulesResponse>,
+            Status,
+        >;
+        async fn create_rule(
+            &self,
+            request: Request<CreateRuleRequest>,
+        ) -> std::result::Result<
+            Response<CreateRuleResponse>,
+            Status,
+        >;
+        async fn update_rule(
+            &self,
+            request: Request<UpdateRuleRequest>,
+        ) -> std::result::Result<
+            Response<UpdateRuleResponse>,
+            Status,
+        >;
+        async fn batch_update_rules(
+            &self,
+            request: Request<BatchUpdateRulesRequest>,
+        ) -> std::result::Result<
+            Response<BatchUpdateRulesResponse>,
+            Status,
+        >;
+        async fn delete_rule(
+            &self,
+            request: Request<DeleteRuleRequest>,
+        ) -> std::result::Result<
+            Response<DeleteRuleResponse>,
+            Status,
+        >;
+        async fn archive_rule(
+            &self,
+            request: Request<ArchiveRuleRequest>,
+        ) -> std::result::Result<
+            Response<ArchiveRuleResponse>,
+            Status,
+        >;
+        async fn batch_delete_rules(
+            &self,
+            request: Request<BatchDeleteRulesRequest>,
+        ) -> std::result::Result<
+            Response<BatchDeleteRulesResponse>,
+            Status,
+        >;
+        async fn batch_archive_rules(
+            &self,
+            request: Request<BatchArchiveRulesRequest>,
+        ) -> std::result::Result<
+            Response<BatchArchiveRulesResponse>,
+            Status,
+        >;
+        async fn unarchive_rule(
+            &self,
+            request: Request<UnarchiveRuleRequest>,
+        ) -> std::result::Result<
+            Response<UnarchiveRuleResponse>,
+            Status,
+        >;
+        async fn batch_unarchive_rules(
+            &self,
+            request: Request<BatchUnarchiveRulesRequest>,
+        ) -> std::result::Result<
+            Response<BatchUnarchiveRulesResponse>,
+            Status,
+        >;
+        async fn undelete_rule(
+            &self,
+            request: Request<UndeleteRuleRequest>,
+        ) -> std::result::Result<
+            Response<UndeleteRuleResponse>,
+            Status,
+        >;
+        async fn batch_undelete_rules(
+            &self,
+            request: Request<BatchUndeleteRulesRequest>,
+        ) -> std::result::Result<
+            Response<BatchUndeleteRulesResponse>,
+            Status,
+        >;
+        async fn evaluate_rules(
+            &self,
+            request: Request<EvaluateRulesRequest>,
+        ) -> std::result::Result<
+            Response<EvaluateRulesResponse>,
+            Status,
+        >;
+        async fn view_human_friendly_rules(
+            &self,
+            request: Request<ViewHumanFriendlyRulesRequest>,
+        ) -> std::result::Result<
+            Response<ViewHumanFriendlyRulesResponse>,
+            Status,
+        >;
+        async fn view_json_rules(
+            &self,
+            request: Request<ViewJsonRulesRequest>,
+        ) -> std::result::Result<
+            Response<ViewJsonRulesResponse>,
+            Status,
+        >;
+        async fn update_human_friendly_rules(
+            &self,
+            request: Request<UpdateHumanFriendlyRulesRequest>,
+        ) -> std::result::Result<
+            Response<UpdateHumanFriendlyRulesResponse>,
+            Status,
+        >;
+        async fn validate_json_rules(
+            &self,
+            request: Request<ValidateJsonRulesRequest>,
+        ) -> std::result::Result<
+            Response<ValidateJsonRulesResponse>,
+            Status,
+        >;
+        async fn update_json_rules(
+            &self,
+            request: Request<UpdateJsonRulesRequest>,
+        ) -> std::result::Result<
+            Response<UpdateJsonRulesResponse>,
+            Status,
+        >;
+        async fn list_rules(
+            &self,
+            request: Request<ListRulesRequest>,
+        ) -> std::result::Result<
+            Response<ListRulesResponse>,
+            Status,
+        >;
+        async fn list_rule_versions(
+            &self,
+            request: Request<ListRuleVersionsRequest>,
+        ) -> std::result::Result<
+            Response<ListRuleVersionsResponse>,
+            Status,
+        >;
+        async fn get_rule_version(
+            &self,
+            request: Request<GetRuleVersionRequest>,
+        ) -> std::result::Result<
+            Response<GetRuleVersionResponse>,
+            Status,
+        >;
+        async fn batch_get_rule_versions(
+            &self,
+            request: Request<BatchGetRuleVersionsRequest>,
+        ) -> std::result::Result<
+            Response<BatchGetRuleVersionsResponse>,
+            Status,
+        >;
+    }
+}


### PR DESCRIPTION
# Description
- Implements `list_rules` mirroring other `list_foo` implementations. 
- It intakes `filter`, `order_by`, and `limit`. 
- Skill files updated.

# Validation
- Unit tests at the tool layer to make sure it responds properly with mocks
- Manual testing E2E