### PR TITLE
rust(fix): fixes file attachement bug

### DIFF
--- a/rust/crates/sift_cli/src/cmd/import/csv.rs
+++ b/rust/crates/sift_cli/src/cmd/import/csv.rs
@@ -72,7 +72,7 @@ pub async fn run(ctx: Context, args: ImportCsvArgs) -> Result<ExitCode> {
         .into_inner();
 
     csv_file.rewind()?;
-    let job_id = upload_gzipped_file(&ctx, &upload_url, csv_file, "text/csv")
+    let job_id = upload_gzipped_file(&ctx, &upload_url, csv_file, &args.path, "text/csv")
         .await
         .context("failed to upload CSV file")?;
 

--- a/rust/crates/sift_cli/src/cmd/import/hdf5/import.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/import.rs
@@ -81,9 +81,15 @@ pub async fn run(ctx: Context, args: ImportHdf5Args) -> Result<ExitCode> {
         .context("error creating data import for hdf5")?
         .into_inner();
 
-    let job_id = upload_gzipped_file(&ctx, &upload_url, file, "application/x-hdf5")
-        .await
-        .context("failed to upload hdf5 file")?;
+    let job_id = upload_gzipped_file(
+        &ctx,
+        &upload_url,
+        file,
+        &args.common.path,
+        "application/x-hdf5",
+    )
+    .await
+    .context("failed to upload hdf5 file")?;
 
     let location = args.common.run.as_ref().map_or_else(
         || format!("asset '{}'", args.common.asset.cyan()),

--- a/rust/crates/sift_cli/src/cmd/import/parquet/channel_per_row_dataset.rs
+++ b/rust/crates/sift_cli/src/cmd/import/parquet/channel_per_row_dataset.rs
@@ -115,9 +115,15 @@ pub async fn run(ctx: Context, args: ChannelPerRowArgs) -> Result<ExitCode> {
         .into_inner();
 
     file.rewind()?;
-    let job_id = upload_gzipped_file(&ctx, &upload_url, file, "application/vnd.apache.parquet")
-        .await
-        .context("failed to upload Parquet file")?;
+    let job_id = upload_gzipped_file(
+        &ctx,
+        &upload_url,
+        file,
+        &args.common.path,
+        "application/vnd.apache.parquet",
+    )
+    .await
+    .context("failed to upload Parquet file")?;
 
     let location = args.common.run.as_ref().map_or_else(
         || format!("asset '{}'", args.common.asset.cyan()),

--- a/rust/crates/sift_cli/src/cmd/import/parquet/flat_dataset.rs
+++ b/rust/crates/sift_cli/src/cmd/import/parquet/flat_dataset.rs
@@ -95,9 +95,15 @@ pub async fn run(ctx: Context, args: FlatDatasetArgs) -> Result<ExitCode> {
         .into_inner();
 
     file.rewind()?;
-    let job_id = upload_gzipped_file(&ctx, &upload_url, file, "application/vnd.apache.parquet")
-        .await
-        .context("failed to upload Parquet file")?;
+    let job_id = upload_gzipped_file(
+        &ctx,
+        &upload_url,
+        file,
+        &args.common.path,
+        "application/vnd.apache.parquet",
+    )
+    .await
+    .context("failed to upload Parquet file")?;
 
     let location = args.common.run.as_ref().map_or_else(
         || format!("asset '{}'", args.common.asset.cyan()),

--- a/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
+++ b/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
@@ -69,9 +69,15 @@ pub async fn run(ctx: Context, args: ImportTdmsArgs) -> Result<ExitCode> {
         .context("error creating data import for tdms")?
         .into_inner();
 
-    let job_id = upload_gzipped_file(&ctx, &upload_url, file, "application/octet-stream")
-        .await
-        .context("failed to upload tdms file")?;
+    let job_id = upload_gzipped_file(
+        &ctx,
+        &upload_url,
+        file,
+        &args.common.path,
+        "application/octet-stream",
+    )
+    .await
+    .context("failed to upload tdms file")?;
 
     let location = args.common.run.as_ref().map_or_else(
         || format!("asset '{}'", args.common.asset.cyan()),

--- a/rust/crates/sift_cli/src/cmd/import/utils.rs
+++ b/rust/crates/sift_cli/src/cmd/import/utils.rs
@@ -1,31 +1,46 @@
 use std::{
     fs::File,
     io::{self, BufReader, Read},
+    path::Path,
 };
 
 use anyhow::{Context, Result, anyhow};
 use flate2::{Compression, write::GzEncoder};
-use reqwest::header::{CONTENT_ENCODING, CONTENT_TYPE};
+use reqwest::header::{CONTENT_DISPOSITION, CONTENT_ENCODING, CONTENT_TYPE};
 use sift_rs::common::r#type::v1::{ChannelBitFieldElement, ChannelEnumType};
 
 use crate::{cli::time::TimeFormat, cmd::Context as CmdContext, util::api::create_rest_client};
 
 /// Gzip and upload a file to a pre-signed upload URL with the given content type.
-/// Reads from the file's current cursor position. Returns the job ID from the
-/// upload response.
+/// Reads from the file's current cursor position. The basename of `source_path`
+/// is forwarded as the Content-Disposition filename so the server preserves it
+/// as the download name; the server sanitizes it further. Returns the job ID
+/// from the upload response.
 pub async fn upload_gzipped_file(
     ctx: &CmdContext,
     upload_url: &str,
     file: File,
+    source_path: &Path,
     content_type: &str,
 ) -> Result<String> {
     let compressed_data = gzip_file(file)?;
     let rest_client = create_rest_client(ctx).context("failed to create rest client")?;
 
+    let file_name = source_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n.replace(['"', '\\'], "_"))
+        .filter(|n| !n.is_empty())
+        .unwrap_or_else(|| "upload".to_string());
+
     let res = rest_client
         .post(upload_url)
         .header(CONTENT_ENCODING, "gzip")
         .header(CONTENT_TYPE, content_type)
+        .header(
+            CONTENT_DISPOSITION,
+            format!("attachment; filename=\"{file_name}\""),
+        )
         .body(compressed_data)
         .send()
         .await


### PR DESCRIPTION
# Description

Fixes file attachment not working when importing files into sift via the CLI.
In `import/utils` when making the rest request to upload the zipped file we were not including `CONTENT_DISPOSITION` header to the request, as such our file names would not be preserved when ingested and not accessible via the run.

# Validation

Manual validation of all file types.