### PR TITLE
rust(feat): SiftStreamAutoRegister — inline flow registration wrapper

### DIFF
--- a/rust/crates/sift_stream/Cargo.toml
+++ b/rust/crates/sift_stream/Cargo.toml
@@ -66,6 +66,10 @@ harness = false
 required-features = ["unstable"]
 
 [[example]]
+name = "auto-register"
+path = "examples/auto-register/main.rs"
+
+[[example]]
 name = "backups-only"
 path = "examples/backups-only/main.rs"
 

--- a/rust/crates/sift_stream/examples/auto-register/main.rs
+++ b/rust/crates/sift_stream/examples/auto-register/main.rs
@@ -1,21 +1,22 @@
 // Demonstrates SiftStreamAutoRegister: inline flow registration without pre-declaring schemas.
 //
-// The stream is initialized with an empty flow list. On the first send for any flow name,
-// SiftStreamAutoRegister derives a FlowConfig from the Flow's channel values and registers
-// it with Sift automatically. Subsequent sends for the same flow name are cache-hits and
-// have no extra overhead.
+// Three flows show the full registration spectrum:
 //
-// Staged configs let you attach metadata (units, descriptions) to a flow without pre-declaring
-// it in IngestionConfigForm. On first send, SiftStreamAutoRegister validates the staged config
-// against the actual channel values and uses it for registration instead of deriving a bare one.
+//   1. Pre-registered — declared in IngestionConfigForm.flows before the stream is built.
+//      Sift already knows this flow; no registration round-trip occurs at runtime.
 //
-// This pattern is well-suited for:
-//   - Rapid prototyping where the full schema is not known ahead of time.
-//   - Dynamic telemetry where flow names are determined at runtime.
-//   - Cases where channel metadata matters but you still want on-demand registration.
+//   2. Staged — not declared in IngestionConfigForm, but a FlowConfig with units and
+//      descriptions is provided to SiftStreamAutoRegister before the first send. On first
+//      send, the staged config is validated against the actual channel values and used for
+//      registration, preserving the metadata. All subsequent sends are cache-hits.
+//
+//   3. Dynamic — not declared anywhere ahead of time. On first send, SiftStreamAutoRegister
+//      derives a minimal FlowConfig directly from the channel values (names and data types
+//      only) and registers it with Sift. No metadata can be attached this way, but it
+//      requires zero setup.
 //
 // If your schema is fully known at build time, pre-registering flows via IngestionConfigForm
-// avoids the registration round-trip on first send.
+// avoids the registration round-trip on first send entirely.
 
 use sift_stream::{
     ChannelConfig, ChannelDataType, ChannelValue, Credentials, Flow, FlowConfig,
@@ -54,12 +55,31 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let asset_name = format!("demo_asset_{suffix}");
     let run_name = format!("{asset_name}_run");
 
-    // Start with no pre-declared flows — SiftStreamAutoRegister will register them on demand.
+    // "gps-position" is pre-registered here. Sift already knows this flow when the stream
+    // is built, so SiftStreamAutoRegister will never issue a registration call for it.
     let stream = SiftStreamBuilder::new(credentials)
         .ingestion_config(IngestionConfigForm {
             asset_name: asset_name.clone(),
             client_key: format!("{asset_name}_v1"),
-            flows: vec![],
+            flows: vec![FlowConfig {
+                name: "gps-position".to_string(),
+                channels: vec![
+                    ChannelConfig {
+                        name: "latitude".to_string(),
+                        data_type: ChannelDataType::Double.into(),
+                        unit: "deg".to_string(),
+                        description: "WGS-84 latitude".to_string(),
+                        ..Default::default()
+                    },
+                    ChannelConfig {
+                        name: "longitude".to_string(),
+                        data_type: ChannelDataType::Double.into(),
+                        unit: "deg".to_string(),
+                        description: "WGS-84 longitude".to_string(),
+                        ..Default::default()
+                    },
+                ],
+            }],
         })
         .attach_run(RunForm {
             name: run_name.clone(),
@@ -70,59 +90,50 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .build()
         .await?;
 
-    // Staged configs attach metadata to flows that will be auto-registered on first send.
-    // Channel names and data types must match what you pass to Flow::new — SiftStreamAutoRegister
-    // validates the staged config before using it and returns StagedConfigMismatch on failure.
-    let staged_configs = vec![
-        FlowConfig {
-            name: "vehicle-dynamics".to_string(),
-            channels: vec![
-                ChannelConfig {
-                    name: "velocity".to_string(),
-                    data_type: ChannelDataType::Double.into(),
-                    unit: "m/s".to_string(),
-                    description: "Longitudinal vehicle speed".to_string(),
-                    ..Default::default()
-                },
-                ChannelConfig {
-                    name: "heading".to_string(),
-                    data_type: ChannelDataType::Float.into(),
-                    unit: "deg".to_string(),
-                    description: "Vehicle heading angle (0–360°, clockwise from north)".to_string(),
-                    ..Default::default()
-                },
-            ],
-        },
-        FlowConfig {
-            name: "engine-telemetry".to_string(),
-            channels: vec![
-                ChannelConfig {
-                    name: "rpm".to_string(),
-                    data_type: ChannelDataType::Float.into(),
-                    unit: "rpm".to_string(),
-                    description: "Engine crankshaft speed".to_string(),
-                    ..Default::default()
-                },
-                ChannelConfig {
-                    name: "oil-temp".to_string(),
-                    data_type: ChannelDataType::Double.into(),
-                    unit: "°C".to_string(),
-                    description: "Engine oil temperature".to_string(),
-                    ..Default::default()
-                },
-            ],
-        },
-    ];
+    // "vehicle-dynamics" is staged: not declared in IngestionConfigForm, but a FlowConfig
+    // with units and descriptions is provided here. On first send, SiftStreamAutoRegister
+    // validates the staged config against the actual channel values and uses it for
+    // registration. Channel names and data types must match or StagedConfigMismatch is returned.
+    let staged_configs = vec![FlowConfig {
+        name: "vehicle-dynamics".to_string(),
+        channels: vec![
+            ChannelConfig {
+                name: "velocity".to_string(),
+                data_type: ChannelDataType::Double.into(),
+                unit: "m/s".to_string(),
+                description: "Longitudinal vehicle speed".to_string(),
+                ..Default::default()
+            },
+            ChannelConfig {
+                name: "heading".to_string(),
+                data_type: ChannelDataType::Float.into(),
+                unit: "deg".to_string(),
+                description: "Vehicle heading angle (0-360, clockwise from north)".to_string(),
+                ..Default::default()
+            },
+        ],
+    }];
 
     let mut auto = SiftStreamAutoRegister::new(stream, staged_configs);
 
     for i in 0..NUM_SAMPLES {
         let t = i as f64;
 
-        // "vehicle-dynamics" is unknown to Sift on the first iteration.
-        // The staged FlowConfig is validated against these channel values and used for
-        // registration, preserving the units and descriptions. All subsequent iterations
-        // are cache-hits with no extra overhead.
+        // Pre-registered flow — Sift already knows "gps-position", so this send goes
+        // straight through with no registration overhead on any iteration.
+        auto.send(Flow::new(
+            "gps-position",
+            TimeValue::now(),
+            &[
+                ChannelValue::new("latitude", 37.7749 + t * 0.0001_f64),
+                ChannelValue::new("longitude", -122.4194 + t * 0.0001_f64),
+            ],
+        ))
+        .await?;
+
+        // Staged flow — on the first iteration, the staged FlowConfig is validated and used
+        // to register "vehicle-dynamics" with Sift, preserving units and descriptions.
+        // All subsequent iterations are cache-hits with no extra overhead.
         auto.send(Flow::new(
             "vehicle-dynamics",
             TimeValue::now(),
@@ -133,8 +144,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         ))
         .await?;
 
-        // "engine-telemetry" is a second, independent flow — also registered using its
-        // staged config on first send and cached for all subsequent sends.
+        // Dynamic flow — "engine-telemetry" has no pre-declared or staged config. On the
+        // first iteration, SiftStreamAutoRegister derives a minimal FlowConfig (channel names
+        // and data types only) and registers it. No units or descriptions can be attached
+        // this way, but it requires zero setup.
         auto.send(Flow::new(
             "engine-telemetry",
             TimeValue::now(),
@@ -150,7 +163,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     auto.finish().await?;
     tracing::info!(
-        "done — {} samples sent for 2 auto-registered flows",
+        "done — {} samples sent for 3 flows (pre-registered, staged, dynamic)",
         NUM_SAMPLES
     );
     Ok(())

--- a/rust/crates/sift_stream/examples/auto-register/main.rs
+++ b/rust/crates/sift_stream/examples/auto-register/main.rs
@@ -5,16 +5,21 @@
 // it with Sift automatically. Subsequent sends for the same flow name are cache-hits and
 // have no extra overhead.
 //
+// Staged configs let you attach metadata (units, descriptions) to a flow without pre-declaring
+// it in IngestionConfigForm. On first send, SiftStreamAutoRegister validates the staged config
+// against the actual channel values and uses it for registration instead of deriving a bare one.
+//
 // This pattern is well-suited for:
 //   - Rapid prototyping where the full schema is not known ahead of time.
 //   - Dynamic telemetry where flow names are determined at runtime.
+//   - Cases where channel metadata matters but you still want on-demand registration.
 //
 // If your schema is fully known at build time, pre-registering flows via IngestionConfigForm
 // avoids the registration round-trip on first send.
 
 use sift_stream::{
-    ChannelValue, Credentials, Flow, IngestionConfigForm, RunForm, SiftStreamAutoRegister,
-    SiftStreamBuilder, TimeValue,
+    ChannelConfig, ChannelDataType, ChannelValue, Credentials, Flow, FlowConfig,
+    IngestionConfigForm, RunForm, SiftStreamAutoRegister, SiftStreamBuilder, TimeValue,
 };
 use std::{
     env,
@@ -65,15 +70,59 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .build()
         .await?;
 
-    let mut auto = SiftStreamAutoRegister::new(stream, vec![]);
+    // Staged configs attach metadata to flows that will be auto-registered on first send.
+    // Channel names and data types must match what you pass to Flow::new — SiftStreamAutoRegister
+    // validates the staged config before using it and returns StagedConfigMismatch on failure.
+    let staged_configs = vec![
+        FlowConfig {
+            name: "vehicle-dynamics".to_string(),
+            channels: vec![
+                ChannelConfig {
+                    name: "velocity".to_string(),
+                    data_type: ChannelDataType::Double.into(),
+                    unit: "m/s".to_string(),
+                    description: "Longitudinal vehicle speed".to_string(),
+                    ..Default::default()
+                },
+                ChannelConfig {
+                    name: "heading".to_string(),
+                    data_type: ChannelDataType::Float.into(),
+                    unit: "deg".to_string(),
+                    description: "Vehicle heading angle (0–360°, clockwise from north)".to_string(),
+                    ..Default::default()
+                },
+            ],
+        },
+        FlowConfig {
+            name: "engine-telemetry".to_string(),
+            channels: vec![
+                ChannelConfig {
+                    name: "rpm".to_string(),
+                    data_type: ChannelDataType::Float.into(),
+                    unit: "rpm".to_string(),
+                    description: "Engine crankshaft speed".to_string(),
+                    ..Default::default()
+                },
+                ChannelConfig {
+                    name: "oil-temp".to_string(),
+                    data_type: ChannelDataType::Double.into(),
+                    unit: "°C".to_string(),
+                    description: "Engine oil temperature".to_string(),
+                    ..Default::default()
+                },
+            ],
+        },
+    ];
+
+    let mut auto = SiftStreamAutoRegister::new(stream, staged_configs);
 
     for i in 0..NUM_SAMPLES {
         let t = i as f64;
 
         // "vehicle-dynamics" is unknown to Sift on the first iteration.
-        // SiftStreamAutoRegister derives { name: "vehicle-dynamics", channels: [velocity(f64),
-        // heading(f32)] } and registers it before sending. All subsequent iterations skip
-        // registration and deliver directly.
+        // The staged FlowConfig is validated against these channel values and used for
+        // registration, preserving the units and descriptions. All subsequent iterations
+        // are cache-hits with no extra overhead.
         auto.send(Flow::new(
             "vehicle-dynamics",
             TimeValue::now(),
@@ -84,8 +133,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         ))
         .await?;
 
-        // "engine-telemetry" is a second, independent flow — also auto-registered on its
-        // first send and cached for all subsequent sends.
+        // "engine-telemetry" is a second, independent flow — also registered using its
+        // staged config on first send and cached for all subsequent sends.
         auto.send(Flow::new(
             "engine-telemetry",
             TimeValue::now(),

--- a/rust/crates/sift_stream/examples/auto-register/main.rs
+++ b/rust/crates/sift_stream/examples/auto-register/main.rs
@@ -1,0 +1,108 @@
+// Demonstrates SiftStreamAutoRegister: inline flow registration without pre-declaring schemas.
+//
+// The stream is initialized with an empty flow list. On the first send for any flow name,
+// SiftStreamAutoRegister derives a FlowConfig from the Flow's channel values and registers
+// it with Sift automatically. Subsequent sends for the same flow name are cache-hits and
+// have no extra overhead.
+//
+// This pattern is well-suited for:
+//   - Rapid prototyping where the full schema is not known ahead of time.
+//   - Dynamic telemetry where flow names are determined at runtime.
+//
+// If your schema is fully known at build time, pre-registering flows via IngestionConfigForm
+// avoids the registration round-trip on first send.
+
+use sift_stream::{
+    ChannelValue, Credentials, Flow, IngestionConfigForm, RunForm, SiftStreamAutoRegister,
+    SiftStreamBuilder, TimeValue,
+};
+use std::{
+    env,
+    error::Error,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+const SEND_INTERVAL: Duration = Duration::from_millis(200);
+const NUM_SAMPLES: u32 = 25;
+
+fn timestamp_suffix() -> String {
+    format!(
+        "{:x}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    )
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    tracing_subscriber::fmt().init();
+
+    dotenvy::dotenv()?;
+    let credentials = Credentials::Config {
+        apikey: env::var("SIFT_API_KEY")?,
+        uri: env::var("SIFT_GRPC_URL")?,
+    };
+
+    let suffix = timestamp_suffix();
+    let asset_name = format!("demo_asset_{suffix}");
+    let run_name = format!("{asset_name}_run");
+
+    // Start with no pre-declared flows — SiftStreamAutoRegister will register them on demand.
+    let stream = SiftStreamBuilder::new(credentials)
+        .ingestion_config(IngestionConfigForm {
+            asset_name: asset_name.clone(),
+            client_key: format!("{asset_name}_v1"),
+            flows: vec![],
+        })
+        .attach_run(RunForm {
+            name: run_name.clone(),
+            client_key: run_name,
+            ..Default::default()
+        })
+        .live_with_backups()
+        .build()
+        .await?;
+
+    let mut auto = SiftStreamAutoRegister::new(stream);
+
+    for i in 0..NUM_SAMPLES {
+        let t = i as f64;
+
+        // "vehicle-dynamics" is unknown to Sift on the first iteration.
+        // SiftStreamAutoRegister derives { name: "vehicle-dynamics", channels: [velocity(f64),
+        // heading(f32)] } and registers it before sending. All subsequent iterations skip
+        // registration and deliver directly.
+        auto.send(Flow::new(
+            "vehicle-dynamics",
+            TimeValue::now(),
+            &[
+                ChannelValue::new("velocity", t * 0.5_f64),
+                ChannelValue::new("heading", (t * 3.6) as f32),
+            ],
+        ))
+        .await?;
+
+        // "engine-telemetry" is a second, independent flow — also auto-registered on its
+        // first send and cached for all subsequent sends.
+        auto.send(Flow::new(
+            "engine-telemetry",
+            TimeValue::now(),
+            &[
+                ChannelValue::new("rpm", (3000.0 + t * 10.0) as f32),
+                ChannelValue::new("oil-temp", 85.0 + t * 0.1_f64),
+            ],
+        ))
+        .await?;
+
+        tokio::time::sleep(SEND_INTERVAL).await;
+    }
+
+    auto.finish().await?;
+    tracing::info!(
+        "done — {} samples sent for 2 auto-registered flows",
+        NUM_SAMPLES
+    );
+    Ok(())
+}

--- a/rust/crates/sift_stream/examples/auto-register/main.rs
+++ b/rust/crates/sift_stream/examples/auto-register/main.rs
@@ -65,7 +65,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .build()
         .await?;
 
-    let mut auto = SiftStreamAutoRegister::new(stream);
+    let mut auto = SiftStreamAutoRegister::new(stream, vec![]);
 
     for i in 0..NUM_SAMPLES {
         let t = i as f64;

--- a/rust/crates/sift_stream/src/lib.rs
+++ b/rust/crates/sift_stream/src/lib.rs
@@ -571,7 +571,7 @@ pub use sift_rs::{
     ingestion_configs::v2::{ChannelConfig, FlowConfig},
 };
 pub use stream::{
-    RetryPolicy, SiftStream,
+    AutoRegisterSendError, RetryPolicy, SiftStream, SiftStreamAutoRegister,
     builder::{
         FileBackupBuilder, IngestionConfigForm, LiveOnlyBuilder, LiveWithBackupsBuilder, RunForm,
         SiftStreamBuilder, StreamConfigBuilder,

--- a/rust/crates/sift_stream/src/stream/auto_register.rs
+++ b/rust/crates/sift_stream/src/stream/auto_register.rs
@@ -1,0 +1,278 @@
+use crate::SiftStream;
+use crate::stream::flow::FlowDescriptor;
+use crate::stream::mode::ingestion_config::{Flow, IngestionConfigEncoder};
+use crate::stream::run::RunSelector;
+use crate::stream::send_error::SiftStreamSendError;
+use crate::stream::{Encoder, MetricsSnapshot, Transport};
+use sift_error::prelude::{Error as SiftError, Result};
+use sift_rs::ingest::v1::IngestWithConfigDataStreamRequest;
+use sift_rs::ingestion_configs::v2::{ChannelConfig, FlowConfig};
+use sift_rs::runs::v2::Run;
+use std::fmt;
+
+fn flow_config_from_flow(flow: &Flow) -> FlowConfig {
+    FlowConfig {
+        name: flow.flow_name.clone(),
+        channels: flow
+            .values
+            .iter()
+            .map(|cv| ChannelConfig {
+                name: cv.name.clone(),
+                data_type: cv.value.pb_data_type().into(),
+                ..Default::default()
+            })
+            .collect(),
+    }
+}
+
+/// Returned by [`SiftStreamAutoRegister::send`] when delivery fails.
+#[derive(Debug)]
+pub enum AutoRegisterSendError<T> {
+    /// Flow registration with Sift failed before the send was attempted.
+    RegistrationFailed(SiftError),
+    /// The underlying stream send failed after registration succeeded.
+    StreamError(SiftStreamSendError<T>),
+}
+
+impl<T: fmt::Debug> fmt::Display for AutoRegisterSendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RegistrationFailed(e) => write!(f, "flow registration failed: {e}"),
+            Self::StreamError(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl<T: fmt::Debug> std::error::Error for AutoRegisterSendError<T> {}
+
+/// Convenience wrapper around [`SiftStream<IngestionConfigEncoder, T>`] that auto-registers
+/// flows on first `send`.
+///
+/// The trade-off: `send` may incur one round-trip to Sift when it encounters a flow for the
+/// first time. Subsequent sends for the same flow are cache-hits and have no extra overhead.
+pub struct SiftStreamAutoRegister<T>
+where
+    T: Transport<Encoder = IngestionConfigEncoder>,
+{
+    inner: SiftStream<IngestionConfigEncoder, T>,
+}
+
+impl<T> SiftStreamAutoRegister<T>
+where
+    T: Transport<Encoder = IngestionConfigEncoder, Message = IngestWithConfigDataStreamRequest>,
+    IngestionConfigEncoder: Encoder<Message = T::Message> + MetricsSnapshot,
+{
+    /// Wrap an existing `SiftStream`.
+    pub fn new(stream: SiftStream<IngestionConfigEncoder, T>) -> Self {
+        Self { inner: stream }
+    }
+
+    /// Send a flow, auto-registering it with Sift if not already in the local cache.
+    ///
+    /// On the first call for a given `flow_name`, a `FlowConfig` is derived from the `Flow`
+    /// itself — each channel's name and data type are used, with all other fields left as
+    /// defaults. The derived config is registered via [`IngestionConfigEncoder::add_new_flows`]
+    /// before the message is sent. Subsequent calls for the same flow skip registration entirely.
+    ///
+    /// # Errors
+    ///
+    /// - [`AutoRegisterSendError::RegistrationFailed`] — the Sift API call to register the
+    ///   flow failed. The flow was not sent.
+    /// - [`AutoRegisterSendError::StreamError`] — registration succeeded but the underlying
+    ///   channel send failed (encode error or channel closed).
+    pub async fn send(
+        &mut self,
+        flow: Flow,
+    ) -> std::result::Result<(), AutoRegisterSendError<T::Message>> {
+        if self.inner.get_flow_descriptor(&flow.flow_name).is_err() {
+            let flow_config = flow_config_from_flow(&flow);
+            self.inner
+                .add_new_flows(&[flow_config])
+                .await
+                .map_err(AutoRegisterSendError::RegistrationFailed)?;
+        }
+        self.inner
+            .send(flow)
+            .await
+            .map_err(AutoRegisterSendError::StreamError)
+    }
+
+    /// Drain remaining data and shut down the stream. Must be called when ingestion is complete.
+    pub async fn finish(self) -> Result<()> {
+        self.inner.finish().await
+    }
+
+    /// Get the flow descriptor for a given flow name from the local cache.
+    ///
+    /// Returns `Err` if the flow has not yet been registered (either via a prior `send` call or
+    /// during stream initialization).
+    pub fn get_flow_descriptor(&self, flow_name: &str) -> Result<FlowDescriptor<String>> {
+        self.inner.get_flow_descriptor(flow_name)
+    }
+
+    /// Attach a run to the stream.
+    ///
+    /// Any data provided through [`send`](Self::send) after this call will be associated with
+    /// the run.
+    pub async fn attach_run(&mut self, run_selector: RunSelector) -> Result<()> {
+        self.inner.attach_run(run_selector).await
+    }
+
+    /// Detach the run, if any, currently associated with the stream.
+    pub fn detach_run(&mut self) {
+        self.inner.detach_run()
+    }
+
+    /// Return the attached run, if one exists.
+    pub fn run(&self) -> Option<&Run> {
+        self.inner.run()
+    }
+
+    #[cfg(feature = "metrics-unstable")]
+    /// Retrieve a snapshot of the current stream metrics.
+    pub fn get_metrics_snapshot(&self) -> crate::metrics::SiftStreamMetricsSnapshot {
+        self.inner.get_metrics_snapshot()
+    }
+
+    /// Consume the wrapper and return the inner [`SiftStream`].
+    pub fn into_inner(self) -> SiftStream<IngestionConfigEncoder, T> {
+        self.inner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::stream::channel::ChannelValue;
+    use crate::stream::time::TimeValue;
+    use sift_error::prelude::{Error as SiftError, ErrorKind};
+    use sift_rs::common::r#type::v1::ChannelDataType;
+
+    #[test]
+    fn flow_config_from_flow_derives_channel_names_and_types() {
+        let flow = Flow::new(
+            "sensor-data",
+            TimeValue::default(),
+            &[
+                ChannelValue::new("velocity", 9.8_f64),
+                ChannelValue::new("temp", 72.1_f32),
+                ChannelValue::new("enabled", true),
+                ChannelValue::new("count", 42_i32),
+            ],
+        );
+
+        let config = flow_config_from_flow(&flow);
+
+        assert_eq!(config.name, "sensor-data");
+        assert_eq!(config.channels.len(), 4);
+
+        let expected = [
+            ("velocity", ChannelDataType::Double),
+            ("temp", ChannelDataType::Float),
+            ("enabled", ChannelDataType::Bool),
+            ("count", ChannelDataType::Int32),
+        ];
+        for (ch, (name, dt)) in config.channels.iter().zip(expected.iter()) {
+            assert_eq!(&ch.name, name);
+            assert_eq!(ch.data_type, *dt as i32);
+        }
+    }
+
+    #[test]
+    fn flow_config_from_flow_all_value_types() {
+        use crate::stream::channel::ChannelEnum;
+        let flow = Flow::new(
+            "all-types",
+            TimeValue::default(),
+            &[
+                ChannelValue::new("f64", 1.0_f64),
+                ChannelValue::new("f32", 1.0_f32),
+                ChannelValue::new("i32", 1_i32),
+                ChannelValue::new("i64", 1_i64),
+                ChannelValue::new("u32", 1_u32),
+                ChannelValue::new("u64", 1_u64),
+                ChannelValue::new("bool", true),
+                ChannelValue::new("str", "hello"),
+                ChannelValue::new("enum", ChannelEnum(0)),
+                ChannelValue::new("bits", vec![0u8, 1u8]),
+            ],
+        );
+
+        let config = flow_config_from_flow(&flow);
+
+        let expected_types = [
+            ChannelDataType::Double,
+            ChannelDataType::Float,
+            ChannelDataType::Int32,
+            ChannelDataType::Int64,
+            ChannelDataType::Uint32,
+            ChannelDataType::Uint64,
+            ChannelDataType::Bool,
+            ChannelDataType::String,
+            ChannelDataType::Enum,
+            ChannelDataType::BitField,
+        ];
+        for (ch, dt) in config.channels.iter().zip(expected_types.iter()) {
+            assert_eq!(ch.data_type, *dt as i32, "mismatch for channel {}", ch.name);
+        }
+    }
+
+    #[test]
+    fn flow_config_from_flow_empty_values_produces_empty_channels() {
+        let flow = Flow::new("empty", TimeValue::default(), &[]);
+        let config = flow_config_from_flow(&flow);
+        assert_eq!(config.name, "empty");
+        assert!(config.channels.is_empty());
+    }
+
+    #[test]
+    fn flow_config_from_flow_leaves_unit_and_description_empty() {
+        let flow = Flow::new(
+            "test",
+            TimeValue::default(),
+            &[ChannelValue::new("ch", 1.0_f64)],
+        );
+        let config = flow_config_from_flow(&flow);
+        assert!(config.channels[0].unit.is_empty());
+        assert!(config.channels[0].description.is_empty());
+    }
+
+    #[test]
+    fn auto_register_send_error_registration_failed_display() {
+        let err: AutoRegisterSendError<()> = AutoRegisterSendError::RegistrationFailed(
+            SiftError::new_msg(ErrorKind::GeneralError, "network timeout"),
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("flow registration failed"), "got: {msg}");
+        assert!(msg.contains("network timeout"), "got: {msg}");
+    }
+
+    #[test]
+    fn auto_register_send_error_stream_error_display() {
+        let err: AutoRegisterSendError<u32> =
+            AutoRegisterSendError::StreamError(SiftStreamSendError::ChannelClosed(0));
+        let msg = err.to_string();
+        assert!(msg.contains("channel closed"), "got: {msg}");
+    }
+
+    #[test]
+    fn auto_register_send_error_implements_std_error() {
+        fn assert_std_error<E: std::error::Error>(_: &E) {}
+        let err: AutoRegisterSendError<u32> = AutoRegisterSendError::RegistrationFailed(
+            SiftError::new_msg(ErrorKind::GeneralError, "x"),
+        );
+        assert_std_error(&err);
+    }
+
+    #[test]
+    fn auto_register_send_error_debug() {
+        let err: AutoRegisterSendError<u32> = AutoRegisterSendError::RegistrationFailed(
+            SiftError::new_msg(ErrorKind::GeneralError, "x"),
+        );
+        assert!(format!("{:?}", err).contains("RegistrationFailed"));
+
+        let err2: AutoRegisterSendError<u32> =
+            AutoRegisterSendError::StreamError(SiftStreamSendError::ChannelClosed(0));
+        assert!(format!("{:?}", err2).contains("StreamError"));
+    }
+}

--- a/rust/crates/sift_stream/src/stream/auto_register.rs
+++ b/rust/crates/sift_stream/src/stream/auto_register.rs
@@ -8,6 +8,7 @@ use sift_error::prelude::{Error as SiftError, Result};
 use sift_rs::ingest::v1::IngestWithConfigDataStreamRequest;
 use sift_rs::ingestion_configs::v2::{ChannelConfig, FlowConfig};
 use sift_rs::runs::v2::Run;
+use std::collections::HashMap;
 use std::fmt;
 
 fn flow_config_from_flow(flow: &Flow) -> FlowConfig {
@@ -25,6 +26,53 @@ fn flow_config_from_flow(flow: &Flow) -> FlowConfig {
     }
 }
 
+/// Returns `Err` with a human-readable description if the channel names or data types in
+/// `config` do not match those declared by `flow`. Comparison is set-based (order-independent).
+fn validate_staged_config(flow: &Flow, config: &FlowConfig) -> std::result::Result<(), String> {
+    let flow_channels: HashMap<&str, i32> = flow
+        .values
+        .iter()
+        .map(|cv| (cv.name.as_str(), cv.value.pb_data_type().into()))
+        .collect();
+
+    let config_channels: HashMap<&str, i32> = config
+        .channels
+        .iter()
+        .map(|ch| (ch.name.as_str(), ch.data_type))
+        .collect();
+
+    if flow_channels == config_channels {
+        return Ok(());
+    }
+
+    let mut problems: Vec<String> = Vec::new();
+
+    for (name, flow_type) in &flow_channels {
+        match config_channels.get(name) {
+            None => problems.push(format!(
+                "channel '{name}' present in flow but missing from staged config"
+            )),
+            Some(config_type) if config_type != flow_type => problems.push(format!(
+                "channel '{name}' data type mismatch (flow: {flow_type}, staged: {config_type})"
+            )),
+            _ => {}
+        }
+    }
+    for name in config_channels.keys() {
+        if !flow_channels.contains_key(name) {
+            problems.push(format!(
+                "channel '{name}' present in staged config but missing from flow"
+            ));
+        }
+    }
+
+    Err(format!(
+        "flow '{}': {}",
+        flow.flow_name,
+        problems.join("; ")
+    ))
+}
+
 /// Returned by [`SiftStreamAutoRegister::send`] when delivery fails.
 #[derive(Debug)]
 pub enum AutoRegisterSendError<T> {
@@ -32,6 +80,8 @@ pub enum AutoRegisterSendError<T> {
     RegistrationFailed(SiftError),
     /// The underlying stream send failed after registration succeeded.
     StreamError(SiftStreamSendError<T>),
+    /// A staged [`FlowConfig`] was found for the flow but its channels do not match.
+    StagedConfigMismatch(String),
 }
 
 impl<T: fmt::Debug> fmt::Display for AutoRegisterSendError<T> {
@@ -39,6 +89,7 @@ impl<T: fmt::Debug> fmt::Display for AutoRegisterSendError<T> {
         match self {
             Self::RegistrationFailed(e) => write!(f, "flow registration failed: {e}"),
             Self::StreamError(e) => write!(f, "{e}"),
+            Self::StagedConfigMismatch(msg) => write!(f, "staged config mismatch: {msg}"),
         }
     }
 }
@@ -50,11 +101,17 @@ impl<T: fmt::Debug> std::error::Error for AutoRegisterSendError<T> {}
 ///
 /// The trade-off: `send` may incur one round-trip to Sift when it encounters a flow for the
 /// first time. Subsequent sends for the same flow are cache-hits and have no extra overhead.
+///
+/// Staged [`FlowConfig`]s can be provided at construction time via [`Self::new`]. When a staged
+/// config exists for a flow, it is used for registration (preserving descriptions, units, and
+/// other metadata) instead of a minimal derived config. The staged config is consumed after
+/// successful registration.
 pub struct SiftStreamAutoRegister<T>
 where
     T: Transport<Encoder = IngestionConfigEncoder>,
 {
     inner: SiftStream<IngestionConfigEncoder, T>,
+    staged_configs: HashMap<String, FlowConfig>,
 }
 
 impl<T> SiftStreamAutoRegister<T>
@@ -62,20 +119,43 @@ where
     T: Transport<Encoder = IngestionConfigEncoder, Message = IngestWithConfigDataStreamRequest>,
     IngestionConfigEncoder: Encoder<Message = T::Message> + MetricsSnapshot,
 {
-    /// Wrap an existing `SiftStream`.
-    pub fn new(stream: SiftStream<IngestionConfigEncoder, T>) -> Self {
-        Self { inner: stream }
+    /// Wrap an existing `SiftStream`, optionally providing pre-built [`FlowConfig`]s to use
+    /// during registration.
+    ///
+    /// Each entry in `staged_configs` is keyed by its `name` field. When `send` encounters an
+    /// unregistered flow whose name matches a staged config, that config is used for
+    /// registration instead of a minimal derived one, and then removed from the staging cache.
+    /// Pass an empty `Vec` when no staged configs are needed.
+    pub fn new(
+        stream: SiftStream<IngestionConfigEncoder, T>,
+        staged_configs: Vec<FlowConfig>,
+    ) -> Self {
+        Self {
+            inner: stream,
+            staged_configs: staged_configs
+                .into_iter()
+                .map(|c| (c.name.clone(), c))
+                .collect(),
+        }
     }
 
     /// Send a flow, auto-registering it with Sift if not already in the local cache.
     ///
-    /// On the first call for a given `flow_name`, a `FlowConfig` is derived from the `Flow`
-    /// itself — each channel's name and data type are used, with all other fields left as
-    /// defaults. The derived config is registered via [`IngestionConfigEncoder::add_new_flows`]
-    /// before the message is sent. Subsequent calls for the same flow skip registration entirely.
+    /// On the first call for a given `flow_name`, the flow is registered via
+    /// [`IngestionConfigEncoder::add_new_flows`] before the message is sent. Subsequent calls
+    /// for the same flow skip registration entirely.
+    ///
+    /// If a staged [`FlowConfig`] was provided for this flow at construction time, it is used
+    /// for registration (preserving descriptions, units, and other metadata). The staged config
+    /// is validated against the flow's channel names and data types before use — if they do not
+    /// match, [`AutoRegisterSendError::StagedConfigMismatch`] is returned and the staged config
+    /// is retained for the next attempt. If no staged config exists, a minimal config is derived
+    /// from the flow itself.
     ///
     /// # Errors
     ///
+    /// - [`AutoRegisterSendError::StagedConfigMismatch`] — a staged config was found but its
+    ///   channels do not match the provided flow. The flow was not sent.
     /// - [`AutoRegisterSendError::RegistrationFailed`] — the Sift API call to register the
     ///   flow failed. The flow was not sent.
     /// - [`AutoRegisterSendError::StreamError`] — registration succeeded but the underlying
@@ -85,11 +165,27 @@ where
         flow: Flow,
     ) -> std::result::Result<(), AutoRegisterSendError<T::Message>> {
         if self.inner.get_flow_descriptor(&flow.flow_name).is_err() {
-            let flow_config = flow_config_from_flow(&flow);
+            // If there is a staged config, validate it against the flow and then
+            // register it.
+            //
+            // Otherwise, create a minimal flow config, and register that.
+            let flow_config = if let Some(staged) = self.staged_configs.get(&flow.flow_name) {
+                validate_staged_config(&flow, staged)
+                    .map_err(AutoRegisterSendError::StagedConfigMismatch)?;
+
+                std::slice::from_ref(staged)
+            } else {
+                &[flow_config_from_flow(&flow)]
+            };
+
+            // Register the new flow with Sift.
             self.inner
-                .add_new_flows(&[flow_config])
+                .add_new_flows(flow_config)
                 .await
                 .map_err(AutoRegisterSendError::RegistrationFailed)?;
+
+            // After successful registration, remove the staged flow.
+            self.staged_configs.remove(&flow.flow_name);
         }
         self.inner
             .send(flow)

--- a/rust/crates/sift_stream/src/stream/mod.rs
+++ b/rust/crates/sift_stream/src/stream/mod.rs
@@ -36,6 +36,10 @@ pub(crate) mod flow;
 /// Task-based architecture for non-blocking SiftStream operations
 pub mod tasks;
 
+/// Convenience wrapper that auto-registers flows on first send.
+pub mod auto_register;
+pub use auto_register::{AutoRegisterSendError, SiftStreamAutoRegister};
+
 /// Error types returned by [`Transport`] send methods.
 pub mod send_error;
 pub use send_error::{SendError, SiftStreamSendError, SiftStreamTrySendError, TrySendError};

--- a/rust/crates/sift_stream/tests/test_auto_register_streaming.rs
+++ b/rust/crates/sift_stream/tests/test_auto_register_streaming.rs
@@ -1,0 +1,834 @@
+// Integration tests for SiftStreamAutoRegister<T>.
+//
+// The test suite covers:
+//   - Flows are auto-registered on first send when not in the local cache.
+//   - A flow is registered exactly once regardless of how many messages share the flow name.
+//   - Multiple distinct flows are each registered independently.
+//   - Flows that were pre-registered during stream init are not re-registered.
+//   - `into_inner()` returns the stream with an up-to-date local flow cache.
+//   - `finish()` drains all queued messages before returning.
+
+use std::collections::HashMap;
+use std::io::Error as IoError;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicU32, Ordering},
+};
+
+use hyper_util::rt::TokioIo;
+use pbjson_types::Timestamp;
+use sift_connect::{SiftChannel, grpc::interceptor::AuthInterceptor};
+use sift_rs::assets::v1::asset_service_server::{AssetService, AssetServiceServer};
+use sift_rs::assets::v1::{
+    ArchiveAssetRequest, ArchiveAssetResponse, Asset, DeleteAssetRequest, DeleteAssetResponse,
+    GetAssetRequest, GetAssetResponse, ListAssetsRequest, ListAssetsResponse, UpdateAssetRequest,
+    UpdateAssetResponse,
+};
+use sift_rs::ingest::v1::{
+    IngestArbitraryProtobufDataStreamRequest, IngestArbitraryProtobufDataStreamResponse,
+    IngestWithConfigDataStreamRequest, IngestWithConfigDataStreamResponse,
+    ingest_service_server::{IngestService, IngestServiceServer},
+};
+use sift_rs::ingestion_configs::v2::ingestion_config_service_server::{
+    IngestionConfigService, IngestionConfigServiceServer,
+};
+use sift_rs::ingestion_configs::v2::{
+    CreateIngestionConfigFlowsRequest, CreateIngestionConfigFlowsResponse,
+    CreateIngestionConfigRequest, CreateIngestionConfigResponse, FlowConfig,
+    GetIngestionConfigRequest, GetIngestionConfigResponse, IngestionConfig,
+    ListIngestionConfigFlowsRequest, ListIngestionConfigFlowsResponse, ListIngestionConfigsRequest,
+    ListIngestionConfigsResponse,
+};
+use sift_rs::ping::v1::ping_service_server::{PingService, PingServiceServer};
+use sift_rs::ping::v1::{PingRequest, PingResponse};
+use sift_rs::runs::v2::run_service_server::{RunService, RunServiceServer};
+use sift_rs::runs::v2::{
+    CreateAdhocRunRequest, CreateAdhocRunResponse, CreateAutomaticRunAssociationForAssetsRequest,
+    CreateAutomaticRunAssociationForAssetsResponse, CreateRunRequest, CreateRunResponse,
+    DeleteRunRequest, DeleteRunResponse, GetRunRequest, GetRunResponse, ListRunsRequest,
+    ListRunsResponse, Run, StopRunRequest, StopRunResponse, UpdateRunRequest, UpdateRunResponse,
+};
+use sift_stream::{
+    ChannelConfig, ChannelDataType, ChannelValue, Flow, IngestionConfigForm,
+    SiftStreamAutoRegister, SiftStreamBuilder, TimeValue,
+};
+use tokio::task::JoinHandle;
+use tokio_stream::StreamExt;
+use tonic::transport::{Endpoint, Server, Uri};
+use tonic::{Request, Response, Status};
+use tower::{ServiceBuilder, service_fn};
+use uuid::Uuid;
+
+mod common;
+
+// ============================================================
+// Per-flow message counter (mirrors the pattern in
+// test_ingestion_config_streaming_ingestion.rs)
+// ============================================================
+
+#[derive(Clone, Default)]
+struct FlowMessageCounts(Arc<Mutex<HashMap<String, u32>>>);
+
+impl FlowMessageCounts {
+    fn record(&self, flow: &str) {
+        *self.0.lock().unwrap().entry(flow.to_owned()).or_insert(0) += 1;
+    }
+
+    fn get(&self, flow: &str) -> u32 {
+        self.0.lock().unwrap().get(flow).copied().unwrap_or(0)
+    }
+}
+
+struct FlowCountingIngestService {
+    counts: FlowMessageCounts,
+}
+
+impl FlowCountingIngestService {
+    fn new() -> (Self, FlowMessageCounts) {
+        let counts = FlowMessageCounts::default();
+        (
+            Self {
+                counts: counts.clone(),
+            },
+            counts,
+        )
+    }
+}
+
+#[tonic::async_trait]
+impl IngestService for FlowCountingIngestService {
+    async fn ingest_with_config_data_stream(
+        &self,
+        request: Request<tonic::Streaming<IngestWithConfigDataStreamRequest>>,
+    ) -> Result<Response<IngestWithConfigDataStreamResponse>, Status> {
+        let mut stream = request.into_inner();
+        while let Ok(Some(msg)) = stream.try_next().await {
+            self.counts.record(&msg.flow);
+        }
+        Ok(Response::new(IngestWithConfigDataStreamResponse {}))
+    }
+
+    async fn ingest_arbitrary_protobuf_data_stream(
+        &self,
+        _: Request<tonic::Streaming<IngestArbitraryProtobufDataStreamRequest>>,
+    ) -> Result<Response<IngestArbitraryProtobufDataStreamResponse>, Status> {
+        unimplemented!()
+    }
+}
+
+// ============================================================
+// Registration-counting ingestion config service
+//
+// Maintains a single IngestionConfig that is created on demand.
+// Counts every call to create_ingestion_config_flows so tests
+// can assert that auto-registration happens exactly once per
+// unique flow name.
+// ============================================================
+
+struct CountingIngestionConfigService {
+    registration_call_count: Arc<AtomicU32>,
+    config: Arc<Mutex<Option<IngestionConfig>>>,
+}
+
+impl CountingIngestionConfigService {
+    fn new(counter: Arc<AtomicU32>) -> Self {
+        Self {
+            registration_call_count: counter,
+            config: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl IngestionConfigService for CountingIngestionConfigService {
+    async fn list_ingestion_configs(
+        &self,
+        request: Request<ListIngestionConfigsRequest>,
+    ) -> Result<Response<ListIngestionConfigsResponse>, Status> {
+        let filter = request.into_inner().filter;
+        let guard = self.config.lock().unwrap();
+        let configs = guard
+            .iter()
+            .filter(|c| filter.is_empty() || filter.contains(&c.client_key))
+            .cloned()
+            .collect();
+        Ok(Response::new(ListIngestionConfigsResponse {
+            ingestion_configs: configs,
+            next_page_token: String::new(),
+        }))
+    }
+
+    async fn create_ingestion_config(
+        &self,
+        request: Request<CreateIngestionConfigRequest>,
+    ) -> Result<Response<CreateIngestionConfigResponse>, Status> {
+        let r = request.into_inner();
+        let new_config = IngestionConfig {
+            ingestion_config_id: Uuid::new_v4().to_string(),
+            asset_id: r.asset_name,
+            client_key: r.client_key,
+        };
+        *self.config.lock().unwrap() = Some(new_config.clone());
+        Ok(Response::new(CreateIngestionConfigResponse {
+            ingestion_config: Some(new_config),
+        }))
+    }
+
+    async fn get_ingestion_config(
+        &self,
+        request: Request<GetIngestionConfigRequest>,
+    ) -> Result<Response<GetIngestionConfigResponse>, Status> {
+        let id = request.into_inner().ingestion_config_id;
+        let guard = self.config.lock().unwrap();
+        match guard.as_ref().filter(|c| c.ingestion_config_id == id) {
+            Some(c) => Ok(Response::new(GetIngestionConfigResponse {
+                ingestion_config: Some(c.clone()),
+            })),
+            None => Err(Status::not_found("ingestion config not found")),
+        }
+    }
+
+    async fn list_ingestion_config_flows(
+        &self,
+        _: Request<ListIngestionConfigFlowsRequest>,
+    ) -> Result<Response<ListIngestionConfigFlowsResponse>, Status> {
+        Ok(Response::new(ListIngestionConfigFlowsResponse {
+            flows: vec![],
+            next_page_token: String::new(),
+        }))
+    }
+
+    async fn create_ingestion_config_flows(
+        &self,
+        _: Request<CreateIngestionConfigFlowsRequest>,
+    ) -> Result<Response<CreateIngestionConfigFlowsResponse>, Status> {
+        self.registration_call_count.fetch_add(1, Ordering::SeqCst);
+        Ok(Response::new(CreateIngestionConfigFlowsResponse {}))
+    }
+}
+
+// ============================================================
+// Minimal supporting services (ping, asset, run)
+// ============================================================
+
+struct MinimalPingService;
+
+#[tonic::async_trait]
+impl PingService for MinimalPingService {
+    async fn ping(&self, _: Request<PingRequest>) -> Result<Response<PingResponse>, Status> {
+        Ok(Response::new(PingResponse {
+            response: "pong".to_string(),
+        }))
+    }
+}
+
+struct MinimalAssetService;
+
+#[tonic::async_trait]
+impl AssetService for MinimalAssetService {
+    async fn get_asset(
+        &self,
+        request: Request<GetAssetRequest>,
+    ) -> Result<Response<GetAssetResponse>, Status> {
+        let asset_id = request.into_inner().asset_id;
+        Ok(Response::new(GetAssetResponse {
+            asset: Some(Asset {
+                name: asset_id.clone(),
+                asset_id,
+                organization_id: "test".to_string(),
+                created_by_user_id: "test".to_string(),
+                modified_by_user_id: "test".to_string(),
+                created_date: Some(Timestamp {
+                    seconds: 0,
+                    nanos: 0,
+                }),
+                modified_date: Some(Timestamp {
+                    seconds: 0,
+                    nanos: 0,
+                }),
+                tags: vec![],
+                metadata: vec![],
+                archived_date: None,
+                is_archived: false,
+            }),
+        }))
+    }
+    async fn update_asset(
+        &self,
+        _: Request<UpdateAssetRequest>,
+    ) -> Result<Response<UpdateAssetResponse>, Status> {
+        Err(Status::unimplemented(""))
+    }
+    async fn delete_asset(
+        &self,
+        _: Request<DeleteAssetRequest>,
+    ) -> Result<Response<DeleteAssetResponse>, Status> {
+        Err(Status::unimplemented(""))
+    }
+    async fn list_assets(
+        &self,
+        _: Request<ListAssetsRequest>,
+    ) -> Result<Response<ListAssetsResponse>, Status> {
+        Err(Status::unimplemented(""))
+    }
+    async fn archive_asset(
+        &self,
+        _: Request<ArchiveAssetRequest>,
+    ) -> Result<Response<ArchiveAssetResponse>, Status> {
+        Err(Status::unimplemented(""))
+    }
+}
+
+fn test_run() -> Run {
+    Run {
+        run_id: "test-run-id".to_string(),
+        name: "test-run".to_string(),
+        description: String::new(),
+        created_date: Some(Timestamp {
+            seconds: 0,
+            nanos: 0,
+        }),
+        modified_date: Some(Timestamp {
+            seconds: 0,
+            nanos: 0,
+        }),
+        created_by_user_id: "test".to_string(),
+        modified_by_user_id: "test".to_string(),
+        organization_id: "test".to_string(),
+        start_time: None,
+        stop_time: None,
+        is_pinned: false,
+        tags: vec![],
+        default_report_id: String::new(),
+        client_key: None,
+        metadata: vec![],
+        asset_ids: vec![],
+        archived_date: None,
+        is_adhoc: false,
+        duration: None,
+        is_archived: false,
+    }
+}
+
+struct MinimalRunService;
+
+#[tonic::async_trait]
+impl RunService for MinimalRunService {
+    async fn get_run(&self, _: Request<GetRunRequest>) -> Result<Response<GetRunResponse>, Status> {
+        Ok(Response::new(GetRunResponse {
+            run: Some(test_run()),
+        }))
+    }
+    async fn list_runs(
+        &self,
+        _: Request<ListRunsRequest>,
+    ) -> Result<Response<ListRunsResponse>, Status> {
+        Ok(Response::new(ListRunsResponse {
+            runs: vec![test_run()],
+            next_page_token: String::new(),
+        }))
+    }
+    async fn create_run(
+        &self,
+        _: Request<CreateRunRequest>,
+    ) -> Result<Response<CreateRunResponse>, Status> {
+        Ok(Response::new(CreateRunResponse {
+            run: Some(test_run()),
+        }))
+    }
+    async fn create_adhoc_run(
+        &self,
+        _: Request<CreateAdhocRunRequest>,
+    ) -> Result<Response<CreateAdhocRunResponse>, Status> {
+        Err(Status::unimplemented(""))
+    }
+    async fn update_run(
+        &self,
+        _: Request<UpdateRunRequest>,
+    ) -> Result<Response<UpdateRunResponse>, Status> {
+        Ok(Response::new(UpdateRunResponse {
+            run: Some(test_run()),
+        }))
+    }
+    async fn delete_run(
+        &self,
+        _: Request<DeleteRunRequest>,
+    ) -> Result<Response<DeleteRunResponse>, Status> {
+        Err(Status::unimplemented(""))
+    }
+    async fn stop_run(
+        &self,
+        _: Request<StopRunRequest>,
+    ) -> Result<Response<StopRunResponse>, Status> {
+        Err(Status::unimplemented(""))
+    }
+    async fn create_automatic_run_association_for_assets(
+        &self,
+        _: Request<CreateAutomaticRunAssociationForAssetsRequest>,
+    ) -> Result<Response<CreateAutomaticRunAssociationForAssetsResponse>, Status> {
+        Err(Status::unimplemented(""))
+    }
+}
+
+// ============================================================
+// Server helpers
+// ============================================================
+
+/// Start a server with a custom ingest service and the standard common mock services.
+/// Identical in structure to `common::start_test_ingest_server`.
+async fn start_standard_server(
+    ingest_service: impl IngestService,
+) -> (SiftChannel, JoinHandle<()>) {
+    start_full_server(ingest_service, None).await
+}
+
+/// Start a server where the IngestionConfigService counts registration calls.
+async fn start_server_with_registration_counter(
+    ingest_service: impl IngestService,
+    registration_counter: Arc<AtomicU32>,
+) -> (SiftChannel, JoinHandle<()>) {
+    start_full_server(
+        ingest_service,
+        Some(CountingIngestionConfigService::new(registration_counter)),
+    )
+    .await
+}
+
+async fn start_full_server(
+    ingest_service: impl IngestService,
+    ingestion_config_svc: Option<CountingIngestionConfigService>,
+) -> (SiftChannel, JoinHandle<()>) {
+    let (client_io, server_io) = tokio::io::duplex(1024);
+
+    let server = tokio::spawn(async move {
+        let mut builder = Server::builder();
+        let router = builder
+            .add_service(IngestServiceServer::new(ingest_service))
+            .add_service(PingServiceServer::new(MinimalPingService));
+
+        if let Some(svc) = ingestion_config_svc {
+            router
+                .add_service(IngestionConfigServiceServer::new(svc))
+                .add_service(AssetServiceServer::new(MinimalAssetService))
+                .add_service(RunServiceServer::new(MinimalRunService))
+                .serve_with_incoming(tokio_stream::once(Ok::<_, IoError>(server_io)))
+                .await
+                .unwrap();
+        } else {
+            router
+                .add_service(IngestionConfigServiceServer::new(
+                    common::MockIngestionConfigService::default(),
+                ))
+                .add_service(AssetServiceServer::new(common::MockAssetService))
+                .add_service(RunServiceServer::new(common::MockRunService))
+                .serve_with_incoming(tokio_stream::once(Ok::<_, IoError>(server_io)))
+                .await
+                .unwrap();
+        }
+    });
+
+    let mut client_io_opt = Some(client_io);
+    let channel = Endpoint::try_from("http://[::]:50051")
+        .unwrap()
+        .connect_with_connector(service_fn(move |_: Uri| {
+            let io = client_io_opt.take();
+            async move {
+                io.map(TokioIo::new)
+                    .ok_or_else(|| std::io::Error::other("connector already used"))
+            }
+        }))
+        .await
+        .unwrap();
+
+    let sift_channel: SiftChannel = ServiceBuilder::new()
+        .layer(tonic::service::interceptor::InterceptorLayer::new(
+            AuthInterceptor {
+                apikey: "test".to_string(),
+            },
+        ))
+        .service(channel);
+
+    (sift_channel, server)
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+#[tokio::test]
+async fn test_auto_register_sends_flow_not_in_initial_config() {
+    let (service, counts) = FlowCountingIngestService::new();
+    let (client, server) = start_standard_server(service).await;
+
+    let stream = SiftStreamBuilder::from_channel(client)
+        .ingestion_config(IngestionConfigForm {
+            asset_name: "test_asset".to_string(),
+            client_key: "test_client_key".to_string(),
+            flows: vec![],
+        })
+        .live_with_backups()
+        .build()
+        .await
+        .expect("failed to build stream");
+
+    let mut auto = SiftStreamAutoRegister::new(stream);
+
+    let n = 20u32;
+    for i in 0..n {
+        auto.send(Flow::new(
+            "dynamic-flow",
+            TimeValue::default(),
+            &[ChannelValue::new("value", i as f64)],
+        ))
+        .await
+        .expect("send failed");
+    }
+
+    auto.finish().await.expect("finish failed");
+
+    assert_eq!(counts.get("dynamic-flow"), n);
+    assert!(server.await.is_ok());
+}
+
+#[tokio::test]
+async fn test_auto_register_flow_in_local_cache_after_first_send() {
+    let (service, _counts) = FlowCountingIngestService::new();
+    let (client, server) = start_standard_server(service).await;
+
+    let stream = SiftStreamBuilder::from_channel(client)
+        .ingestion_config(IngestionConfigForm {
+            asset_name: "test_asset".to_string(),
+            client_key: "test_client_key".to_string(),
+            flows: vec![],
+        })
+        .live_with_backups()
+        .build()
+        .await
+        .expect("failed to build stream");
+
+    let auto = SiftStreamAutoRegister::new(stream);
+
+    // Before first send: flow is not in the local cache.
+    assert!(
+        auto.into_inner().get_flow_descriptor("new-flow").is_err(),
+        "flow should not be cached before any send"
+    );
+
+    // Rebuild (into_inner consumed the previous wrapper).
+    let (service2, _) = FlowCountingIngestService::new();
+    let (client2, server2) = start_standard_server(service2).await;
+
+    let stream2 = SiftStreamBuilder::from_channel(client2)
+        .ingestion_config(IngestionConfigForm {
+            asset_name: "test_asset".to_string(),
+            client_key: "test_client_key".to_string(),
+            flows: vec![],
+        })
+        .live_with_backups()
+        .build()
+        .await
+        .expect("failed to build stream");
+
+    let mut auto2 = SiftStreamAutoRegister::new(stream2);
+
+    auto2
+        .send(Flow::new(
+            "new-flow",
+            TimeValue::default(),
+            &[ChannelValue::new("x", 1.0_f64)],
+        ))
+        .await
+        .expect("send failed");
+
+    // After first send: flow is in the local cache.
+    let inner = auto2.into_inner();
+    assert!(
+        inner.get_flow_descriptor("new-flow").is_ok(),
+        "flow should be cached after first send"
+    );
+
+    inner.finish().await.expect("finish failed");
+    let _ = server.await;
+    let _ = server2.await;
+}
+
+#[tokio::test]
+async fn test_auto_register_multiple_distinct_flows_each_registered_independently() {
+    let (service, counts) = FlowCountingIngestService::new();
+    let (client, server) = start_standard_server(service).await;
+
+    let stream = SiftStreamBuilder::from_channel(client)
+        .ingestion_config(IngestionConfigForm {
+            asset_name: "test_asset".to_string(),
+            client_key: "test_client_key".to_string(),
+            flows: vec![],
+        })
+        .live_with_backups()
+        .build()
+        .await
+        .expect("failed to build stream");
+
+    let mut auto = SiftStreamAutoRegister::new(stream);
+
+    for i in 0..10u32 {
+        auto.send(Flow::new(
+            "flow-alpha",
+            TimeValue::default(),
+            &[ChannelValue::new("a", i as f64)],
+        ))
+        .await
+        .expect("send failed");
+
+        auto.send(Flow::new(
+            "flow-beta",
+            TimeValue::default(),
+            &[ChannelValue::new("b", i as f64)],
+        ))
+        .await
+        .expect("send failed");
+    }
+
+    // Both flows should be in the cache after sending.
+    let inner = auto.into_inner();
+    assert!(inner.get_flow_descriptor("flow-alpha").is_ok());
+    assert!(inner.get_flow_descriptor("flow-beta").is_ok());
+
+    inner.finish().await.expect("finish failed");
+
+    assert_eq!(counts.get("flow-alpha"), 10);
+    assert_eq!(counts.get("flow-beta"), 10);
+    assert!(server.await.is_ok());
+}
+
+#[tokio::test]
+async fn test_auto_register_same_flow_registered_exactly_once() {
+    let registration_counter = Arc::new(AtomicU32::new(0));
+    let (service, counts) = FlowCountingIngestService::new();
+    let (client, server) =
+        start_server_with_registration_counter(service, registration_counter.clone()).await;
+
+    let stream = SiftStreamBuilder::from_channel(client)
+        .ingestion_config(IngestionConfigForm {
+            asset_name: "test_asset".to_string(),
+            client_key: "auto-register-test-key".to_string(),
+            flows: vec![],
+        })
+        .live_with_backups()
+        .build()
+        .await
+        .expect("failed to build stream");
+
+    let mut auto = SiftStreamAutoRegister::new(stream);
+
+    let n = 100u32;
+    for i in 0..n {
+        auto.send(Flow::new(
+            "repeated-flow",
+            TimeValue::default(),
+            &[ChannelValue::new("v", i as f64)],
+        ))
+        .await
+        .expect("send failed");
+    }
+
+    auto.finish().await.expect("finish failed");
+
+    // The registration endpoint should be hit exactly once — only on the first send.
+    assert_eq!(
+        registration_counter.load(Ordering::SeqCst),
+        1,
+        "flow should be registered exactly once regardless of message count"
+    );
+
+    assert_eq!(counts.get("repeated-flow"), n);
+    assert!(server.await.is_ok());
+}
+
+#[tokio::test]
+async fn test_auto_register_pre_registered_flow_skips_registration() {
+    // "flow-0" is pre-registered in MockIngestionConfigService::default() and will
+    // be present in the local cache after build(). SiftStreamAutoRegister should
+    // skip registration entirely and send directly.
+    let (service, counts) = FlowCountingIngestService::new();
+
+    // Use the standard server (which starts with flow-0 pre-registered).
+    let (client, server) = start_standard_server(service).await;
+
+    let stream = SiftStreamBuilder::from_channel(client)
+        .ingestion_config(IngestionConfigForm {
+            asset_name: "test_asset".to_string(),
+            client_key: "test_client_key".to_string(),
+            flows: vec![FlowConfig {
+                name: "flow-0".to_string(),
+                channels: vec![ChannelConfig {
+                    name: "generator".to_string(),
+                    data_type: ChannelDataType::Double.into(),
+                    ..Default::default()
+                }],
+            }],
+        })
+        .live_with_backups()
+        .build()
+        .await
+        .expect("failed to build stream");
+
+    // flow-0 is in the cache from build(); no registration call should happen.
+    let mut auto = SiftStreamAutoRegister::new(stream);
+
+    let n = 30u32;
+    for i in 0..n {
+        auto.send(Flow::new(
+            "flow-0",
+            TimeValue::default(),
+            &[ChannelValue::new("generator", i as f64)],
+        ))
+        .await
+        .expect("send failed");
+    }
+
+    auto.finish().await.expect("finish failed");
+
+    assert_eq!(counts.get("flow-0"), n);
+    assert!(server.await.is_ok());
+}
+
+#[tokio::test]
+async fn test_auto_register_into_inner_returns_stream_with_populated_cache() {
+    let (service, _counts) = FlowCountingIngestService::new();
+    let (client, server) = start_standard_server(service).await;
+
+    let stream = SiftStreamBuilder::from_channel(client)
+        .ingestion_config(IngestionConfigForm {
+            asset_name: "test_asset".to_string(),
+            client_key: "test_client_key".to_string(),
+            flows: vec![],
+        })
+        .live_with_backups()
+        .build()
+        .await
+        .expect("failed to build stream");
+
+    let mut auto = SiftStreamAutoRegister::new(stream);
+
+    auto.send(Flow::new(
+        "extracted-flow",
+        TimeValue::default(),
+        &[ChannelValue::new("reading", 42.0_f64)],
+    ))
+    .await
+    .expect("send failed");
+
+    // Consume the wrapper and verify the inner stream's cache is populated.
+    let mut inner = auto.into_inner();
+
+    assert!(
+        inner.get_flow_descriptor("extracted-flow").is_ok(),
+        "extracted-flow should be in the inner stream's cache"
+    );
+
+    // The inner stream should still be usable for direct sends.
+    inner
+        .send(Flow::new(
+            "extracted-flow",
+            TimeValue::default(),
+            &[ChannelValue::new("reading", 99.0_f64)],
+        ))
+        .await
+        .expect("direct send on inner stream failed");
+
+    inner.finish().await.expect("finish failed");
+    assert!(server.await.is_ok());
+}
+
+#[tokio::test]
+async fn test_auto_register_finish_drains_all_queued_messages() {
+    let (service, counts) = FlowCountingIngestService::new();
+    let (client, server) = start_standard_server(service).await;
+
+    let stream = SiftStreamBuilder::from_channel(client)
+        .ingestion_config(IngestionConfigForm {
+            asset_name: "test_asset".to_string(),
+            client_key: "test_client_key".to_string(),
+            flows: vec![],
+        })
+        .live_with_backups()
+        .build()
+        .await
+        .expect("failed to build stream");
+
+    let mut auto = SiftStreamAutoRegister::new(stream);
+
+    let n = 50u32;
+    for i in 0..n {
+        auto.send(Flow::new(
+            "drain-test",
+            TimeValue::default(),
+            &[ChannelValue::new("v", i as f64)],
+        ))
+        .await
+        .expect("send failed");
+    }
+
+    // finish() must drain all queued messages before returning.
+    auto.finish().await.expect("finish failed");
+
+    assert_eq!(
+        counts.get("drain-test"),
+        n,
+        "all messages must be received after finish()"
+    );
+    assert!(server.await.is_ok());
+}
+
+#[tokio::test]
+async fn test_auto_register_mixed_new_and_pre_registered_flows() {
+    let (service, counts) = FlowCountingIngestService::new();
+    let (client, server) = start_standard_server(service).await;
+
+    let stream = SiftStreamBuilder::from_channel(client)
+        .ingestion_config(IngestionConfigForm {
+            asset_name: "test_asset".to_string(),
+            client_key: "test_client_key".to_string(),
+            flows: vec![FlowConfig {
+                name: "flow-0".to_string(),
+                channels: vec![ChannelConfig {
+                    name: "generator".to_string(),
+                    data_type: ChannelDataType::Double.into(),
+                    ..Default::default()
+                }],
+            }],
+        })
+        .live_with_backups()
+        .build()
+        .await
+        .expect("failed to build stream");
+
+    let mut auto = SiftStreamAutoRegister::new(stream);
+
+    let n = 15u32;
+    for i in 0..n {
+        // Pre-registered flow — should never hit add_new_flows.
+        auto.send(Flow::new(
+            "flow-0",
+            TimeValue::default(),
+            &[ChannelValue::new("generator", i as f64)],
+        ))
+        .await
+        .expect("send failed");
+
+        // Unregistered flow — auto-registered on the first send.
+        auto.send(Flow::new(
+            "new-sensor",
+            TimeValue::default(),
+            &[ChannelValue::new("reading", i as f64 * 2.0)],
+        ))
+        .await
+        .expect("send failed");
+    }
+
+    auto.finish().await.expect("finish failed");
+
+    assert_eq!(counts.get("flow-0"), n);
+    assert_eq!(counts.get("new-sensor"), n);
+    assert!(server.await.is_ok());
+}

--- a/rust/crates/sift_stream/tests/test_auto_register_streaming.rs
+++ b/rust/crates/sift_stream/tests/test_auto_register_streaming.rs
@@ -49,7 +49,7 @@ use sift_rs::runs::v2::{
     ListRunsResponse, Run, StopRunRequest, StopRunResponse, UpdateRunRequest, UpdateRunResponse,
 };
 use sift_stream::{
-    ChannelConfig, ChannelDataType, ChannelValue, Flow, IngestionConfigForm,
+    AutoRegisterSendError, ChannelConfig, ChannelDataType, ChannelValue, Flow, IngestionConfigForm,
     SiftStreamAutoRegister, SiftStreamBuilder, TimeValue,
 };
 use tokio::task::JoinHandle;
@@ -471,7 +471,7 @@ async fn test_auto_register_sends_flow_not_in_initial_config() {
         .await
         .expect("failed to build stream");
 
-    let mut auto = SiftStreamAutoRegister::new(stream);
+    let mut auto = SiftStreamAutoRegister::new(stream, vec![]);
 
     let n = 20u32;
     for i in 0..n {
@@ -506,7 +506,7 @@ async fn test_auto_register_flow_in_local_cache_after_first_send() {
         .await
         .expect("failed to build stream");
 
-    let auto = SiftStreamAutoRegister::new(stream);
+    let auto = SiftStreamAutoRegister::new(stream, vec![]);
 
     // Before first send: flow is not in the local cache.
     assert!(
@@ -529,7 +529,7 @@ async fn test_auto_register_flow_in_local_cache_after_first_send() {
         .await
         .expect("failed to build stream");
 
-    let mut auto2 = SiftStreamAutoRegister::new(stream2);
+    let mut auto2 = SiftStreamAutoRegister::new(stream2, vec![]);
 
     auto2
         .send(Flow::new(
@@ -568,7 +568,7 @@ async fn test_auto_register_multiple_distinct_flows_each_registered_independentl
         .await
         .expect("failed to build stream");
 
-    let mut auto = SiftStreamAutoRegister::new(stream);
+    let mut auto = SiftStreamAutoRegister::new(stream, vec![]);
 
     for i in 0..10u32 {
         auto.send(Flow::new(
@@ -618,7 +618,7 @@ async fn test_auto_register_same_flow_registered_exactly_once() {
         .await
         .expect("failed to build stream");
 
-    let mut auto = SiftStreamAutoRegister::new(stream);
+    let mut auto = SiftStreamAutoRegister::new(stream, vec![]);
 
     let n = 100u32;
     for i in 0..n {
@@ -673,7 +673,7 @@ async fn test_auto_register_pre_registered_flow_skips_registration() {
         .expect("failed to build stream");
 
     // flow-0 is in the cache from build(); no registration call should happen.
-    let mut auto = SiftStreamAutoRegister::new(stream);
+    let mut auto = SiftStreamAutoRegister::new(stream, vec![]);
 
     let n = 30u32;
     for i in 0..n {
@@ -708,7 +708,7 @@ async fn test_auto_register_into_inner_returns_stream_with_populated_cache() {
         .await
         .expect("failed to build stream");
 
-    let mut auto = SiftStreamAutoRegister::new(stream);
+    let mut auto = SiftStreamAutoRegister::new(stream, vec![]);
 
     auto.send(Flow::new(
         "extracted-flow",
@@ -756,7 +756,7 @@ async fn test_auto_register_finish_drains_all_queued_messages() {
         .await
         .expect("failed to build stream");
 
-    let mut auto = SiftStreamAutoRegister::new(stream);
+    let mut auto = SiftStreamAutoRegister::new(stream, vec![]);
 
     let n = 50u32;
     for i in 0..n {
@@ -803,7 +803,7 @@ async fn test_auto_register_mixed_new_and_pre_registered_flows() {
         .await
         .expect("failed to build stream");
 
-    let mut auto = SiftStreamAutoRegister::new(stream);
+    let mut auto = SiftStreamAutoRegister::new(stream, vec![]);
 
     let n = 15u32;
     for i in 0..n {
@@ -830,5 +830,384 @@ async fn test_auto_register_mixed_new_and_pre_registered_flows() {
 
     assert_eq!(counts.get("flow-0"), n);
     assert_eq!(counts.get("new-sensor"), n);
+    assert!(server.await.is_ok());
+}
+
+// ============================================================
+// Ingestion config service that captures registered FlowConfigs
+// ============================================================
+
+#[derive(Clone, Default)]
+struct CapturedRegistrations(Arc<Mutex<Vec<FlowConfig>>>);
+
+impl CapturedRegistrations {
+    fn all(&self) -> Vec<FlowConfig> {
+        self.0.lock().unwrap().clone()
+    }
+}
+
+struct CapturingIngestionConfigService {
+    captured: CapturedRegistrations,
+    call_count: Arc<AtomicU32>,
+    config: Arc<Mutex<Option<IngestionConfig>>>,
+}
+
+impl CapturingIngestionConfigService {
+    fn new() -> (Self, CapturedRegistrations, Arc<AtomicU32>) {
+        let captured = CapturedRegistrations::default();
+        let call_count = Arc::new(AtomicU32::new(0));
+        (
+            Self {
+                captured: captured.clone(),
+                call_count: call_count.clone(),
+                config: Arc::new(Mutex::new(None)),
+            },
+            captured,
+            call_count,
+        )
+    }
+}
+
+#[tonic::async_trait]
+impl IngestionConfigService for CapturingIngestionConfigService {
+    async fn list_ingestion_configs(
+        &self,
+        request: Request<ListIngestionConfigsRequest>,
+    ) -> Result<Response<ListIngestionConfigsResponse>, Status> {
+        let filter = request.into_inner().filter;
+        let guard = self.config.lock().unwrap();
+        let configs = guard
+            .iter()
+            .filter(|c| filter.is_empty() || filter.contains(&c.client_key))
+            .cloned()
+            .collect();
+        Ok(Response::new(ListIngestionConfigsResponse {
+            ingestion_configs: configs,
+            next_page_token: String::new(),
+        }))
+    }
+
+    async fn create_ingestion_config(
+        &self,
+        request: Request<CreateIngestionConfigRequest>,
+    ) -> Result<Response<CreateIngestionConfigResponse>, Status> {
+        let r = request.into_inner();
+        let new_config = IngestionConfig {
+            ingestion_config_id: Uuid::new_v4().to_string(),
+            asset_id: r.asset_name,
+            client_key: r.client_key,
+        };
+        *self.config.lock().unwrap() = Some(new_config.clone());
+        Ok(Response::new(CreateIngestionConfigResponse {
+            ingestion_config: Some(new_config),
+        }))
+    }
+
+    async fn get_ingestion_config(
+        &self,
+        request: Request<GetIngestionConfigRequest>,
+    ) -> Result<Response<GetIngestionConfigResponse>, Status> {
+        let id = request.into_inner().ingestion_config_id;
+        let guard = self.config.lock().unwrap();
+        match guard.as_ref().filter(|c| c.ingestion_config_id == id) {
+            Some(c) => Ok(Response::new(GetIngestionConfigResponse {
+                ingestion_config: Some(c.clone()),
+            })),
+            None => Err(Status::not_found("ingestion config not found")),
+        }
+    }
+
+    async fn list_ingestion_config_flows(
+        &self,
+        _: Request<ListIngestionConfigFlowsRequest>,
+    ) -> Result<Response<ListIngestionConfigFlowsResponse>, Status> {
+        Ok(Response::new(ListIngestionConfigFlowsResponse {
+            flows: vec![],
+            next_page_token: String::new(),
+        }))
+    }
+
+    async fn create_ingestion_config_flows(
+        &self,
+        request: Request<CreateIngestionConfigFlowsRequest>,
+    ) -> Result<Response<CreateIngestionConfigFlowsResponse>, Status> {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+        self.captured
+            .0
+            .lock()
+            .unwrap()
+            .extend(request.into_inner().flows);
+        Ok(Response::new(CreateIngestionConfigFlowsResponse {}))
+    }
+}
+
+async fn start_server_with_capturing(
+    ingest_service: impl IngestService,
+    config_svc: CapturingIngestionConfigService,
+) -> (SiftChannel, JoinHandle<()>) {
+    let (client_io, server_io) = tokio::io::duplex(1024);
+
+    let server = tokio::spawn(async move {
+        Server::builder()
+            .add_service(IngestServiceServer::new(ingest_service))
+            .add_service(PingServiceServer::new(MinimalPingService))
+            .add_service(IngestionConfigServiceServer::new(config_svc))
+            .add_service(AssetServiceServer::new(MinimalAssetService))
+            .add_service(RunServiceServer::new(MinimalRunService))
+            .serve_with_incoming(tokio_stream::once(Ok::<_, IoError>(server_io)))
+            .await
+            .unwrap();
+    });
+
+    let mut client_io_opt = Some(client_io);
+    let channel = Endpoint::try_from("http://[::]:50051")
+        .unwrap()
+        .connect_with_connector(service_fn(move |_: Uri| {
+            let io = client_io_opt.take();
+            async move {
+                io.map(TokioIo::new)
+                    .ok_or_else(|| std::io::Error::other("connector already used"))
+            }
+        }))
+        .await
+        .unwrap();
+
+    let sift_channel: SiftChannel = ServiceBuilder::new()
+        .layer(tonic::service::interceptor::InterceptorLayer::new(
+            AuthInterceptor {
+                apikey: "test".to_string(),
+            },
+        ))
+        .service(channel);
+
+    (sift_channel, server)
+}
+
+// ============================================================
+// Staged config tests
+// ============================================================
+
+// Verifies that when a staged FlowConfig is provided, its full channel metadata
+// (e.g. unit) is forwarded to the registration API rather than the minimal
+// auto-derived config.
+#[tokio::test]
+async fn test_staged_config_channels_are_used_for_registration() {
+    let (config_svc, registrations, call_count) = CapturingIngestionConfigService::new();
+    let (ingest_svc, _counts) = FlowCountingIngestService::new();
+    let (client, server) = start_server_with_capturing(ingest_svc, config_svc).await;
+
+    let staged = FlowConfig {
+        name: "sensor-flow".to_string(),
+        channels: vec![ChannelConfig {
+            name: "temperature".to_string(),
+            data_type: ChannelDataType::Double.into(),
+            unit: "celsius".to_string(),
+            ..Default::default()
+        }],
+    };
+
+    let stream = SiftStreamBuilder::from_channel(client)
+        .ingestion_config(IngestionConfigForm {
+            asset_name: "test_asset".to_string(),
+            client_key: "staged-channels-test".to_string(),
+            flows: vec![],
+        })
+        .live_with_backups()
+        .build()
+        .await
+        .expect("failed to build stream");
+
+    let mut auto = SiftStreamAutoRegister::new(stream, vec![staged]);
+
+    auto.send(Flow::new(
+        "sensor-flow",
+        TimeValue::default(),
+        &[ChannelValue::new("temperature", 22.5_f64)],
+    ))
+    .await
+    .expect("send failed");
+
+    auto.finish().await.expect("finish failed");
+
+    assert_eq!(call_count.load(Ordering::SeqCst), 1);
+
+    let registered = registrations.all();
+    assert_eq!(registered.len(), 1);
+    assert_eq!(registered[0].name, "sensor-flow");
+    assert_eq!(registered[0].channels.len(), 1);
+    assert_eq!(
+        registered[0].channels[0].unit, "celsius",
+        "staged config metadata should be forwarded, not overwritten by auto-derived config"
+    );
+
+    assert!(server.await.is_ok());
+}
+
+// Verifies that a channel name/type mismatch between the staged config and the
+// flow being sent returns StagedConfigMismatch without attempting registration.
+#[tokio::test]
+async fn test_staged_config_mismatch_returns_error() {
+    let (config_svc, _registrations, call_count) = CapturingIngestionConfigService::new();
+    let (ingest_svc, _counts) = FlowCountingIngestService::new();
+    let (client, server) = start_server_with_capturing(ingest_svc, config_svc).await;
+
+    let staged = FlowConfig {
+        name: "mismatch-flow".to_string(),
+        channels: vec![ChannelConfig {
+            name: "expected_channel".to_string(),
+            data_type: ChannelDataType::Double.into(),
+            ..Default::default()
+        }],
+    };
+
+    let stream = SiftStreamBuilder::from_channel(client)
+        .ingestion_config(IngestionConfigForm {
+            asset_name: "test_asset".to_string(),
+            client_key: "staged-mismatch-test".to_string(),
+            flows: vec![],
+        })
+        .live_with_backups()
+        .build()
+        .await
+        .expect("failed to build stream");
+
+    let mut auto = SiftStreamAutoRegister::new(stream, vec![staged]);
+
+    let err = auto
+        .send(Flow::new(
+            "mismatch-flow",
+            TimeValue::default(),
+            &[ChannelValue::new("wrong_channel", 1.0_f64)],
+        ))
+        .await
+        .expect_err("expected StagedConfigMismatch error");
+
+    assert!(
+        matches!(err, AutoRegisterSendError::StagedConfigMismatch(_)),
+        "expected StagedConfigMismatch, got: {err:?}"
+    );
+    assert_eq!(
+        call_count.load(Ordering::SeqCst),
+        0,
+        "registration should not be attempted when staged config fails validation"
+    );
+
+    server.abort();
+}
+
+// Verifies that after a StagedConfigMismatch error the staged config is retained,
+// so a corrected send can still use it for registration.
+#[tokio::test]
+async fn test_staged_config_retained_after_mismatch() {
+    let registration_counter = Arc::new(AtomicU32::new(0));
+    let (ingest_svc, _counts) = FlowCountingIngestService::new();
+    let (client, server) =
+        start_server_with_registration_counter(ingest_svc, registration_counter.clone()).await;
+
+    let staged = FlowConfig {
+        name: "retry-flow".to_string(),
+        channels: vec![ChannelConfig {
+            name: "correct_channel".to_string(),
+            data_type: ChannelDataType::Double.into(),
+            ..Default::default()
+        }],
+    };
+
+    let stream = SiftStreamBuilder::from_channel(client)
+        .ingestion_config(IngestionConfigForm {
+            asset_name: "test_asset".to_string(),
+            client_key: "staged-retry-test".to_string(),
+            flows: vec![],
+        })
+        .live_with_backups()
+        .build()
+        .await
+        .expect("failed to build stream");
+
+    let mut auto = SiftStreamAutoRegister::new(stream, vec![staged]);
+
+    // First attempt with the wrong channel — staged config is retained on error.
+    let err = auto
+        .send(Flow::new(
+            "retry-flow",
+            TimeValue::default(),
+            &[ChannelValue::new("wrong_channel", 1.0_f64)],
+        ))
+        .await
+        .expect_err("expected StagedConfigMismatch");
+    assert!(matches!(
+        err,
+        AutoRegisterSendError::StagedConfigMismatch(_)
+    ));
+
+    // Second attempt with the correct channel — staged config validates and is used.
+    auto.send(Flow::new(
+        "retry-flow",
+        TimeValue::default(),
+        &[ChannelValue::new("correct_channel", 2.0_f64)],
+    ))
+    .await
+    .expect("corrected send should succeed using retained staged config");
+
+    auto.finish().await.expect("finish failed");
+
+    assert_eq!(
+        registration_counter.load(Ordering::SeqCst),
+        1,
+        "registration should happen exactly once on the successful retry"
+    );
+    assert!(server.await.is_ok());
+}
+
+// Verifies that the staged config is removed after successful registration so
+// subsequent sends for the same flow hit the local cache and skip registration.
+#[tokio::test]
+async fn test_staged_config_consumed_after_successful_registration() {
+    let registration_counter = Arc::new(AtomicU32::new(0));
+    let (ingest_svc, counts) = FlowCountingIngestService::new();
+    let (client, server) =
+        start_server_with_registration_counter(ingest_svc, registration_counter.clone()).await;
+
+    let staged = FlowConfig {
+        name: "one-time-flow".to_string(),
+        channels: vec![ChannelConfig {
+            name: "reading".to_string(),
+            data_type: ChannelDataType::Double.into(),
+            ..Default::default()
+        }],
+    };
+
+    let stream = SiftStreamBuilder::from_channel(client)
+        .ingestion_config(IngestionConfigForm {
+            asset_name: "test_asset".to_string(),
+            client_key: "staged-consumed-test".to_string(),
+            flows: vec![],
+        })
+        .live_with_backups()
+        .build()
+        .await
+        .expect("failed to build stream");
+
+    let mut auto = SiftStreamAutoRegister::new(stream, vec![staged]);
+
+    let n = 10u32;
+    for i in 0..n {
+        auto.send(Flow::new(
+            "one-time-flow",
+            TimeValue::default(),
+            &[ChannelValue::new("reading", i as f64)],
+        ))
+        .await
+        .expect("send failed");
+    }
+
+    auto.finish().await.expect("finish failed");
+
+    assert_eq!(
+        registration_counter.load(Ordering::SeqCst),
+        1,
+        "staged config should trigger registration exactly once regardless of message count"
+    );
+    assert_eq!(counts.get("one-time-flow"), n);
     assert!(server.await.is_ok());
 }

--- a/rust/crates/sift_stream_bindings/src/lib.rs
+++ b/rust/crates/sift_stream_bindings/src/lib.rs
@@ -147,6 +147,7 @@ fn sift_stream_bindings(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<metrics::BackupMetricsSnapshotPy>()?;
     m.add_class::<stream::FlowPy>()?;
     m.add_class::<stream::SiftStreamPy>()?;
+    m.add_class::<stream::auto_register::SiftStreamAutoRegisterPy>()?;
     m.add_class::<stream::builder::SiftStreamBuilderPy>()?;
     m.add_class::<stream::builder::StreamConfigBuilderPy>()?;
     m.add_class::<stream::builder::LiveOnlyBuilderPy>()?;

--- a/rust/crates/sift_stream_bindings/src/stream/auto_register.rs
+++ b/rust/crates/sift_stream_bindings/src/stream/auto_register.rs
@@ -1,7 +1,7 @@
 use super::{FlowPy, SiftStreamInner, SiftStreamPy, stream_consumed_err};
 use crate::error::SiftErrorWrapper;
 use crate::metrics::SiftStreamMetricsSnapshotPy;
-use crate::stream::config::{FlowDescriptorPy, RunSelectorPy};
+use crate::stream::config::{FlowConfigPy, FlowDescriptorPy, RunSelectorPy};
 use pyo3::prelude::*;
 use pyo3_async_runtimes::tokio::future_into_py;
 use pyo3_stub_gen::derive::*;
@@ -59,9 +59,23 @@ impl SiftStreamAutoRegisterPy {
     ///
     /// After this call, the original `stream` object is in a consumed state and
     /// calling any method on it will raise `RuntimeError`.
+    ///
+    /// `staged_configs` is an optional list of `FlowConfig` objects. When a staged
+    /// config exists for a flow, it is used for registration instead of a minimal
+    /// derived config, then removed after successful registration.
     #[staticmethod]
-    pub fn from_stream(py: Python, stream: &SiftStreamPy) -> PyResult<Py<PyAny>> {
+    #[pyo3(signature = (stream, staged_configs = None))]
+    pub fn from_stream(
+        py: Python,
+        stream: &SiftStreamPy,
+        staged_configs: Option<Vec<FlowConfigPy>>,
+    ) -> PyResult<Py<PyAny>> {
         let stream_inner = stream.inner.clone();
+        let staged: Vec<sift_stream::FlowConfig> = staged_configs
+            .unwrap_or_default()
+            .into_iter()
+            .map(Into::into)
+            .collect();
 
         let awaitable = future_into_py(py, async move {
             let mut guard = stream_inner.lock().await;
@@ -69,13 +83,15 @@ impl SiftStreamAutoRegisterPy {
 
             let auto_inner = match inner {
                 SiftStreamInner::LiveOnly(s) => {
-                    SiftStreamAutoRegisterInner::LiveOnly(SiftStreamAutoRegister::new(s))
+                    SiftStreamAutoRegisterInner::LiveOnly(SiftStreamAutoRegister::new(s, staged))
                 }
                 SiftStreamInner::LiveWithBackups(s) => {
-                    SiftStreamAutoRegisterInner::LiveWithBackups(SiftStreamAutoRegister::new(s))
+                    SiftStreamAutoRegisterInner::LiveWithBackups(SiftStreamAutoRegister::new(
+                        s, staged,
+                    ))
                 }
                 SiftStreamInner::FileBackup(s) => {
-                    SiftStreamAutoRegisterInner::FileBackup(SiftStreamAutoRegister::new(s))
+                    SiftStreamAutoRegisterInner::FileBackup(SiftStreamAutoRegister::new(s, staged))
                 }
             };
 

--- a/rust/crates/sift_stream_bindings/src/stream/auto_register.rs
+++ b/rust/crates/sift_stream_bindings/src/stream/auto_register.rs
@@ -1,0 +1,190 @@
+use super::{FlowPy, SiftStreamInner, SiftStreamPy, stream_consumed_err};
+use crate::error::SiftErrorWrapper;
+use crate::metrics::SiftStreamMetricsSnapshotPy;
+use crate::stream::config::{FlowDescriptorPy, RunSelectorPy};
+use pyo3::prelude::*;
+use pyo3_async_runtimes::tokio::future_into_py;
+use pyo3_stub_gen::derive::*;
+use sift_stream::{
+    FileBackup, Flow, LiveStreamingOnly, LiveStreamingWithBackups, SiftStreamAutoRegister,
+};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+enum SiftStreamAutoRegisterInner {
+    LiveOnly(SiftStreamAutoRegister<LiveStreamingOnly>),
+    LiveWithBackups(SiftStreamAutoRegister<LiveStreamingWithBackups>),
+    FileBackup(SiftStreamAutoRegister<FileBackup>),
+}
+
+macro_rules! dispatch_auto_mut {
+    ($opt:expr, |$s:ident| $body:expr) => {
+        match $opt.as_mut().ok_or_else(stream_consumed_err)? {
+            SiftStreamAutoRegisterInner::LiveOnly($s) => $body,
+            SiftStreamAutoRegisterInner::LiveWithBackups($s) => $body,
+            SiftStreamAutoRegisterInner::FileBackup($s) => $body,
+        }
+    };
+}
+
+macro_rules! dispatch_auto_ref {
+    ($opt:expr, |$s:ident| $body:expr) => {
+        match $opt.as_ref().ok_or_else(stream_consumed_err)? {
+            SiftStreamAutoRegisterInner::LiveOnly($s) => $body,
+            SiftStreamAutoRegisterInner::LiveWithBackups($s) => $body,
+            SiftStreamAutoRegisterInner::FileBackup($s) => $body,
+        }
+    };
+}
+
+fn auto_register_err(e: impl std::fmt::Display) -> PyErr {
+    PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("{e}"))
+}
+
+/// Python binding for [`SiftStreamAutoRegister`](sift_stream::SiftStreamAutoRegister).
+///
+/// Convenience wrapper that auto-registers flows on first `send`.
+///
+/// Construct via `SiftStreamAutoRegisterPy.from_stream(stream)`.
+#[gen_stub_pyclass]
+#[pyclass]
+pub struct SiftStreamAutoRegisterPy {
+    inner: Arc<Mutex<Option<SiftStreamAutoRegisterInner>>>,
+}
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl SiftStreamAutoRegisterPy {
+    /// Construct from an existing `SiftStreamPy`, consuming it.
+    ///
+    /// After this call, the original `stream` object is in a consumed state and
+    /// calling any method on it will raise `RuntimeError`.
+    #[staticmethod]
+    pub fn from_stream(py: Python, stream: &SiftStreamPy) -> PyResult<Py<PyAny>> {
+        let stream_inner = stream.inner.clone();
+
+        let awaitable = future_into_py(py, async move {
+            let mut guard = stream_inner.lock().await;
+            let inner = guard.take().ok_or_else(stream_consumed_err)?;
+
+            let auto_inner = match inner {
+                SiftStreamInner::LiveOnly(s) => {
+                    SiftStreamAutoRegisterInner::LiveOnly(SiftStreamAutoRegister::new(s))
+                }
+                SiftStreamInner::LiveWithBackups(s) => {
+                    SiftStreamAutoRegisterInner::LiveWithBackups(SiftStreamAutoRegister::new(s))
+                }
+                SiftStreamInner::FileBackup(s) => {
+                    SiftStreamAutoRegisterInner::FileBackup(SiftStreamAutoRegister::new(s))
+                }
+            };
+
+            Ok(SiftStreamAutoRegisterPy {
+                inner: Arc::new(Mutex::new(Some(auto_inner))),
+            })
+        })?;
+
+        Ok(awaitable.into())
+    }
+
+    /// Send a flow, auto-registering it with Sift if not already cached.
+    ///
+    /// On the first call for a given flow name, a `FlowConfig` is derived from the `Flow`
+    /// using each channel's name and data type. Subsequent sends for the same flow are
+    /// cache-hits with no overhead.
+    ///
+    /// Raises `RuntimeError` if flow registration or the underlying send fails.
+    pub fn send(&self, py: Python, flow: FlowPy) -> PyResult<Py<PyAny>> {
+        let inner = self.inner.clone();
+        let flow_rs: Flow = flow.into();
+
+        let awaitable = future_into_py(py, async move {
+            let mut guard = inner.lock().await;
+            dispatch_auto_mut!(guard, |s| {
+                s.send(flow_rs).await.map_err(auto_register_err)
+            })
+        })?;
+
+        Ok(awaitable.into())
+    }
+
+    /// Drain remaining data and shut down the stream.
+    ///
+    /// Must be called when ingestion is complete. After this call, all other methods
+    /// will raise `RuntimeError`.
+    pub fn finish(&self, py: Python) -> PyResult<Py<PyAny>> {
+        let inner = self.inner.clone();
+
+        let awaitable = future_into_py(py, async move {
+            let mut guard = inner.lock().await;
+            let stream = guard.take().ok_or_else(|| {
+                PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                    "Stream has already been finished",
+                )
+            })?;
+
+            let result = match stream {
+                SiftStreamAutoRegisterInner::LiveOnly(s) => s.finish().await,
+                SiftStreamAutoRegisterInner::LiveWithBackups(s) => s.finish().await,
+                SiftStreamAutoRegisterInner::FileBackup(s) => s.finish().await,
+            };
+
+            result.map_err(auto_register_err)
+        })?;
+
+        Ok(awaitable.into())
+    }
+
+    /// Retrieve the flow descriptor for a given flow name from the local cache.
+    ///
+    /// Raises `RuntimeError` if the flow has not been registered yet.
+    pub fn get_flow_descriptor(&self, flow_name: &str) -> PyResult<FlowDescriptorPy> {
+        let inner_guard = self.inner.blocking_lock();
+        dispatch_auto_ref!(inner_guard, |s| {
+            s.get_flow_descriptor(flow_name)
+                .map(FlowDescriptorPy::from)
+                .map_err(|e| SiftErrorWrapper(e).into())
+        })
+    }
+
+    /// Attach a run to the stream.
+    ///
+    /// Data sent after this call will be associated with the specified run.
+    pub fn attach_run(&self, py: Python, run_selector: RunSelectorPy) -> PyResult<Py<PyAny>> {
+        let inner = self.inner.clone();
+
+        let awaitable = future_into_py(py, async move {
+            let mut guard = inner.lock().await;
+            dispatch_auto_mut!(guard, |s| {
+                s.attach_run(run_selector.into())
+                    .await
+                    .map_err(|e| SiftErrorWrapper(e).into())
+            })
+        })?;
+
+        Ok(awaitable.into())
+    }
+
+    /// Detach the run, if any, currently associated with the stream.
+    pub fn detach_run(&self) -> PyResult<()> {
+        let mut inner_guard = self.inner.blocking_lock();
+        dispatch_auto_mut!(inner_guard, |s| s.detach_run());
+        Ok(())
+    }
+
+    /// Return the ID of the attached run, or `None` if no run is attached.
+    pub fn run(&self) -> PyResult<Option<String>> {
+        let inner_guard = self.inner.blocking_lock();
+        Ok(dispatch_auto_ref!(inner_guard, |s| {
+            s.run().map(|r| r.run_id.clone())
+        }))
+    }
+
+    /// Retrieve a snapshot of the current stream metrics.
+    pub fn get_metrics_snapshot(&self) -> PyResult<SiftStreamMetricsSnapshotPy> {
+        let inner_guard = self.inner.blocking_lock();
+        Ok(dispatch_auto_ref!(inner_guard, |s| {
+            s.get_metrics_snapshot().into()
+        }))
+    }
+}

--- a/rust/crates/sift_stream_bindings/src/stream/mod.rs
+++ b/rust/crates/sift_stream_bindings/src/stream/mod.rs
@@ -1,3 +1,4 @@
+pub mod auto_register;
 pub mod builder;
 pub mod channel;
 pub mod config;


### PR DESCRIPTION
Adds `SiftStreamAutoRegister<T>` to sift_stream and `SiftStreamAutoRegisterPy` to sift_stream_bindings.

Flows are registered with Sift automatically on first send. If a `FlowConfig` for the flow was provided during construction of the `SiftStreamAutoRegister` struct, that will be used to register to the `Flow`. This allows providing types such as enums and bitarrays, as well as channel descriptions, units, and other metadata. Otherwise, a minimal config is generated based on the channel-name and type (the only available information at ingest time).

Known flows can still be pre-registered via `IngestionConfigForm` at init time to eliminate first-send latency. Subsequent sends for any registered flow are local cache-hits with no network overhead.