### PR TITLE
rust(fix): fix enum json stringfy

### DIFF
--- a/rust/crates/sift_mcp/CLAUDE.md
+++ b/rust/crates/sift_mcp/CLAUDE.md
@@ -29,6 +29,16 @@ Use this section ordering. Skip a section only when it has no content; do not re
 - No marketing or filler ("powerful", "easy to use"). Every line should change what the agent does.
 - Cap length around 30–40 lines. Beyond that, agents start truncating mentally; trim the guidance section first.
 
+### Parameter shapes — keep them flat
+
+Tool parameters MUST be scalars, arrays of scalars, or `Option`s of either. Do not use nested enums or nested objects as the value of a parameter field.
+
+Some MCP clients JSON-stringify object-typed argument values before transport. The server then receives the value as a `Value::String` instead of `Value::Object` and `serde_json`'s `deserialize_enum` treats the entire JSON string as the variant name, surfacing as `unknown variant \`{"Names":[...]}\`, expected \`Names\` or \`Regex\``. Scalar and array params round-trip cleanly, so the failure is specific to nested-enum/object params.
+
+When a parameter has mutually-exclusive shapes (the case that used to call for an externally-tagged enum), flatten it into sibling `Option<...>` fields and validate "exactly one is set" in the handler — return `INVALID_PARAMS` if zero or both are set. `tool/data/mod.rs::get_data` (`channel_names` / `channel_regex`) is the reference pattern.
+
+If a tagged variant is genuinely unavoidable, use `#[serde(tag = "type")]` so the discriminator is a sibling scalar field rather than the parent key — that survives the stringification bug.
+
 ### Reference
 
 `tool/data/mod.rs::get_data` is the canonical example. Mirror its layout when adding a new tool.

--- a/rust/crates/sift_mcp/src/prompt/mod.rs
+++ b/rust/crates/sift_mcp/src/prompt/mod.rs
@@ -91,7 +91,7 @@ impl SiftMcpServer {
              2. Confirm the target channels exist with `list_channels` scoped by `asset_id`. If no \
              channels were named, choose a sensible set and tell the user which you picked.\n\
              3. Pull data with `get_data`. Pass `run_name` so the run's start/stop bounds apply \
-             automatically; do not hand-compute timestamps. Use `channel_search.Names` with exact \
+             automatically; do not hand-compute timestamps. Use `channel_names` with exact \
              channel names. Choose `sample_ms` to suit the run length: decimate (e.g. 100-1000 ms) \
              for long runs and use 0 only when raw fidelity is required. Write to a Parquet path in a \
              working directory.\n\
@@ -140,7 +140,7 @@ impl SiftMcpServer {
              1. Resolve the source asset and run with `list_assets` and `list_runs`. Identify the \
              channels the transform needs via `list_channels` scoped by `asset_id`.\n\
              2. Extract with `get_data`, passing `run_name` so the run bounds apply. Choose \
-             `channel_search.Names` and a `sample_ms` suited to the transform.\n\
+             `channel_names` and a `sample_ms` suited to the transform.\n\
              3. Apply the transform with `sql`. CRITICAL: column 0 of any dataset uploaded to Sift \
              MUST be `timestamp_unix_nanos` (Int64, non-null). Project it first in the SELECT and never \
              rename or drop it. For aggregations that collapse rows, bucket on a time expression \

--- a/rust/crates/sift_mcp/src/tool/data/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/data/mod.rs
@@ -24,19 +24,14 @@ use crate::{
 };
 
 #[derive(Debug, Deserialize, JsonSchema)]
-pub enum ChannelSearch {
-    Names(Vec<String>),
-    Regex(String),
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
 pub struct GetDataParams {
     asset_name: String,
     run_name: Option<String>,
     start_time_unix_nanos: Option<i64>,
     end_time_unix_nanos: Option<i64>,
     sample_ms: u32,
-    channel_search: ChannelSearch,
+    channel_names: Option<Vec<String>>,
+    channel_regex: Option<String>,
     output: PathBuf,
 }
 
@@ -120,15 +115,17 @@ impl SiftMcpServer {
                 used as the time range; `start_time_unix_nanos` and/or `end_time_unix_nanos` may narrow either side.
                 When omitted, BOTH `start_time_unix_nanos` and `end_time_unix_nanos` are required.
               - `sample_ms`: decimation interval in milliseconds. Use `0` for raw samples; larger values reduce volume.
-              - `channel_search`: one of `Names: [..]` (exact channel names) or `Regex: \"..\"` (RE2 pattern against the
-                channel name). Prefer `Names` when the set is known — it's more predictable.
+              - `channel_names`: optional array of exact channel names. Mutually exclusive with `channel_regex`;
+                exactly one of the two MUST be set. Prefer this form when the set is known — it's more predictable.
+              - `channel_regex`: optional RE2 pattern matched against the channel name. Mutually exclusive with
+                `channel_names`; exactly one of the two MUST be set.
               - `output`: filesystem path for the Parquet file. The file is opened in truncate mode; existing
                 contents are overwritten.
 
             Errors:
               - `RESOURCE_NOT_FOUND` if the asset or run is missing or there are no matching channels.
-              - `INVALID_PARAMS` if `run_name` is absent and the full time range is not supplied, or if
-                `channel_search.Names` is empty.
+              - `INVALID_PARAMS` if `run_name` is absent and the full time range is not supplied, if neither
+                `channel_names` nor `channel_regex` is set, if both are set, or if `channel_names` is empty.
 
             Guidance:
               - Data is buffered in memory until size/row thresholds are hit, so very large time ranges or wide
@@ -144,7 +141,8 @@ impl SiftMcpServer {
         let Parameters(GetDataParams {
             asset_name,
             run_name,
-            channel_search,
+            channel_names,
+            channel_regex,
             start_time_unix_nanos,
             end_time_unix_nanos,
             sample_ms,
@@ -196,11 +194,23 @@ impl SiftMcpServer {
             None => None,
         };
 
-        let channel_search_filter = match channel_search {
-            ChannelSearch::Names(names) => {
+        let channel_search_filter = match (channel_names, channel_regex) {
+            (Some(_), Some(_)) => {
+                return Err(ErrorData::invalid_params(
+                    "exactly one of `channel_names` or `channel_regex` must be set, not both",
+                    None,
+                ));
+            }
+            (None, None) => {
+                return Err(ErrorData::invalid_params(
+                    "one of `channel_names` or `channel_regex` must be set",
+                    None,
+                ));
+            }
+            (Some(names), None) => {
                 if names.is_empty() {
                     return Err(ErrorData::invalid_params(
-                        "channel_search.Names must contain at least one name",
+                        "`channel_names` must contain at least one name",
                         None,
                     ));
                 }
@@ -211,7 +221,7 @@ impl SiftMcpServer {
                     .join(", ");
                 format!("name in [{items}]")
             }
-            ChannelSearch::Regex(pattern) => {
+            (None, Some(pattern)) => {
                 format!("name.matches(\"{}\")", cel_escape(&pattern))
             }
         };


### PR DESCRIPTION
# Description
The Client JSON stringifies object-valued parameters before making the request. So, when we get the JSON RPC we try to translate it into rust types via serde. When serde sees the enum type stringified it maps the whole string blob to the enum, which is why the error `unknown variant` comes back.

We separate out `channel_search` into two args for `get_data`. We instruct the agent that they are mutually exclusive and the handler checks and will throw an error if both `channel_names` and `channel_regex` or none are passed through.
# Verification
- Manual E2E testing
- Checking claude tool usage and confirming it is using `get_data` and it is returning properly