### PR TITLE
python(fix): skip progress bars when stdout is unavailable

### DIFF
--- a/python/lib/sift_client/_internal/util/file.py
+++ b/python/lib/sift_client/_internal/util/file.py
@@ -6,9 +6,8 @@ import warnings
 import zipfile
 from typing import TYPE_CHECKING
 
-from alive_progress import alive_bar  # type: ignore[import-untyped]
-
 import sift_client as _sift_client_module
+from sift_client._internal.util.progress import alive_bar
 from sift_client.errors import SiftWarning
 
 if TYPE_CHECKING:

--- a/python/lib/sift_client/_internal/util/progress.py
+++ b/python/lib/sift_client/_internal/util/progress.py
@@ -1,0 +1,44 @@
+"""Progress-bar helpers that degrade gracefully when stdout is unavailable.
+
+``alive_progress`` defaults its output to ``sys.stdout`` and requires a stream
+with ``write``/``flush``/``fileno``. When ``sys.stdout`` is ``None`` (for example
+a PyInstaller ``--noconsole`` executable, ``pythonw.exe``, or a detached
+process) it raises while setting up the bar, so these wrappers suppress the bar
+in that case instead of crashing.
+"""
+
+from __future__ import annotations
+
+import sys
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+from alive_progress import alive_bar as _alive_bar  # type: ignore[import-untyped]
+
+
+def _stdout_supports_progress() -> bool:
+    """Whether the current stdout can back an alive_progress bar."""
+    stream = sys.stdout
+    return stream is not None and all(
+        hasattr(stream, attr) for attr in ("write", "flush", "fileno")
+    )
+
+
+class _NoOpBar:
+    """Stand-in for an alive_progress bar handle used when progress is suppressed."""
+
+    def __call__(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def __getattr__(self, name: str) -> Any:
+        return lambda *args, **kwargs: None
+
+
+@contextmanager
+def alive_bar(*args: Any, **kwargs: Any) -> Iterator[Any]:
+    """Drop-in for ``alive_progress.alive_bar`` that no-ops when stdout can't back a bar."""
+    if not _stdout_supports_progress():
+        yield _NoOpBar()
+        return
+    with _alive_bar(*args, **kwargs) as bar:
+        yield bar

--- a/python/lib/sift_client/_tests/_internal/test_progress.py
+++ b/python/lib/sift_client/_tests/_internal/test_progress.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from sift_client._internal.util import progress
+
+
+class _FakeStream:
+    """Minimal stream exposing the attributes alive_progress probes for."""
+
+    def write(self, *_): ...
+
+    def flush(self): ...
+
+    def fileno(self):
+        return 1
+
+
+class _WriteOnlyStream:
+    """Stream missing fileno, which alive_progress rejects."""
+
+    def write(self, *_): ...
+
+    def flush(self): ...
+
+
+def test_stdout_supports_progress_true_for_streamlike(monkeypatch):
+    monkeypatch.setattr("sys.stdout", _FakeStream())
+    assert progress._stdout_supports_progress() is True
+
+
+def test_stdout_supports_progress_false_when_none(monkeypatch):
+    monkeypatch.setattr("sys.stdout", None)
+    assert progress._stdout_supports_progress() is False
+
+
+def test_stdout_supports_progress_false_when_missing_fileno(monkeypatch):
+    monkeypatch.setattr("sys.stdout", _WriteOnlyStream())
+    assert progress._stdout_supports_progress() is False
+
+
+def test_alive_bar_noop_does_not_raise_when_stdout_none(monkeypatch):
+    # Without the guard this raises ValueError: Invalid config value: file=None.
+    monkeypatch.setattr("sys.stdout", None)
+    with progress.alive_bar(100, disable=True) as bar:
+        bar(10)
+        bar.title("polling")  # arbitrary bar attribute resolves to a no-op callable
+
+
+def test_alive_bar_does_not_touch_real_bar_when_stdout_none(monkeypatch):
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("real alive_bar must not be called when stdout is None")
+
+    monkeypatch.setattr("sys.stdout", None)
+    monkeypatch.setattr(progress, "_alive_bar", _boom)
+    with progress.alive_bar(5) as bar:
+        bar(1)
+
+
+def test_alive_bar_delegates_to_real_bar_when_supported(monkeypatch):
+    sentinel = object()
+
+    @contextmanager
+    def _fake_alive_bar(*_args, **_kwargs):
+        yield sentinel
+
+    monkeypatch.setattr("sys.stdout", _FakeStream())
+    monkeypatch.setattr(progress, "_alive_bar", _fake_alive_bar)
+    with progress.alive_bar(5) as bar:
+        assert bar is sentinel

--- a/python/lib/sift_client/resources/jobs.py
+++ b/python/lib/sift_client/resources/jobs.py
@@ -7,11 +7,10 @@ import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from alive_progress import alive_bar  # type: ignore[import-untyped]
-
 from sift_client._internal.low_level_wrappers.jobs import JobsLowLevelClient
 from sift_client._internal.util.executor import run_sync_function
 from sift_client._internal.util.file import download_file, extract_zip
+from sift_client._internal.util.progress import alive_bar
 from sift_client.resources._base import ResourceBase
 from sift_client.sift_types.job import DataExportStatusDetails, Job, JobStatus, JobType
 from sift_client.util import cel_utils as cel


### PR DESCRIPTION
## Summary

Running sift_client with no console (PyInstaller `--noconsole`, `pythonw.exe`, GUI/embedded, detached processes) sets `sys.stdout` to `None`. alive-progress reads it when creating a bar and rejects `None` with `ValueError: Invalid config value: file=None`, crashing uploads, downloads, and job polling, even with `show_progress=False`.

Adds `sift_client/_internal/util/progress.py`, a drop-in for `alive_bar` that skips the bar when stdout can't back one, and routes the three call sites through it. Bars still render normally when a console is present.

## Test plan

- Unit tests covering both the no-stdout and normal-stdout paths.
- Manual QA with a pyinstaller executable for the no-console case (`sys.stdout = None`) and confirmed upload, download, and job polling complete; verified a normal stdout still renders a bar.
