### PR TITLE
python(fix): keep test-results logging from hanging sync calls

### DIFF
--- a/python/lib/sift_client/_internal/low_level_wrappers/_test_results_log.py
+++ b/python/lib/sift_client/_internal/low_level_wrappers/_test_results_log.py
@@ -39,7 +39,9 @@ Ad-hoc writers to the same path are not protected.
 
 from __future__ import annotations
 
+import asyncio
 import atexit
+import functools
 import json
 import os
 import re
@@ -165,7 +167,7 @@ class ReplayResult:
     measurements: list[TestMeasurement] = field(default_factory=list)
 
 
-def log_request_to_file(
+async def log_request_to_file(
     log_file: str | Path,
     request_type: str,
     request: Any,
@@ -179,8 +181,8 @@ def log_request_to_file(
     mid-write partial final line. See the module docstring for the full
     concurrency model.
 
-    This is synchronous and blocks on the lock; async callers should offload it
-    off the event loop (see ``_LOG_IO_EXECUTOR``).
+    The blocking lock + file I/O runs on ``_LOG_IO_EXECUTOR``, so a slow or
+    stuck lock cannot block the event loop.
 
     Args:
         log_file: Path to the log file.
@@ -194,6 +196,28 @@ def log_request_to_file(
     Raises:
         TimeoutError: If the lock is not acquired within ``timeout`` seconds.
     """
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(
+        _LOG_IO_EXECUTOR,
+        functools.partial(
+            _log_request_to_file_sync,
+            log_file,
+            request_type,
+            request,
+            response_id=response_id,
+            timeout=timeout,
+        ),
+    )
+
+
+def _log_request_to_file_sync(
+    log_file: str | Path,
+    request_type: str,
+    request: Any,
+    response_id: str | None = None,
+    timeout: float = LOG_LOCK_TIMEOUT_SECONDS,
+) -> None:
+    """Blocking core of :func:`log_request_to_file`; runs on the executor."""
     log_path = Path(log_file)
     log_path.parent.mkdir(parents=True, exist_ok=True)
     tag = f"{request_type}:{response_id}" if response_id else request_type
@@ -214,7 +238,7 @@ def log_request_to_file(
         ) from exc
 
 
-def _read_log_lines(
+async def _read_log_lines(
     log_path: str | Path,
     timeout: float = LOG_LOCK_TIMEOUT_SECONDS,
 ) -> list[str]:
@@ -225,12 +249,24 @@ def _read_log_lines(
     partial final line, then releases it. Parsing happens lock-free in
     :func:`parse_log_data_lines`.
 
-    This is synchronous and blocks on the lock; async callers should offload it
-    off the event loop (see ``_LOG_IO_EXECUTOR``).
+    The blocking lock + file I/O runs on ``_LOG_IO_EXECUTOR``, so a slow or
+    stuck lock cannot block the event loop.
 
     Raises:
         TimeoutError: If the lock is not acquired within ``timeout`` seconds.
     """
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(
+        _LOG_IO_EXECUTOR,
+        functools.partial(_read_log_lines_sync, log_path, timeout=timeout),
+    )
+
+
+def _read_log_lines_sync(
+    log_path: str | Path,
+    timeout: float = LOG_LOCK_TIMEOUT_SECONDS,
+) -> list[str]:
+    """Blocking core of :func:`_read_log_lines`; runs on the executor."""
     log_path = Path(log_path)
     lock_path = log_path.with_name(log_path.name + ".lock")
     try:
@@ -280,9 +316,9 @@ def iter_log_data_lines(
 ) -> Generator[tuple[str, str | None, str], None, None]:
     """Read and parse data lines from a log file.
 
-    Convenience wrapper that snapshots under the lock via :func:`_read_log_lines`
-    then parses with :func:`parse_log_data_lines`. Async callers should instead
-    offload :func:`_read_log_lines` off the event loop and parse the result with
+    Synchronous convenience wrapper that snapshots under the lock then parses
+    with :func:`parse_log_data_lines`. Async callers should instead await
+    :func:`_read_log_lines` and parse the result with
     :func:`parse_log_data_lines` directly.
     """
-    yield from parse_log_data_lines(_read_log_lines(log_path, timeout), start_line)
+    yield from parse_log_data_lines(_read_log_lines_sync(log_path, timeout), start_line)

--- a/python/lib/sift_client/_internal/low_level_wrappers/_test_results_log.py
+++ b/python/lib/sift_client/_internal/low_level_wrappers/_test_results_log.py
@@ -39,18 +39,33 @@ Ad-hoc writers to the same path are not protected.
 
 from __future__ import annotations
 
+import atexit
 import json
 import os
 import re
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generator
 
-from filelock import FileLock
+from filelock import FileLock, Timeout
 from google.protobuf import json_format
 
 if TYPE_CHECKING:
     from sift_client.sift_types.test_report import TestMeasurement, TestReport, TestStep
+
+
+# Seconds to wait for the sidecar lock before raising TimeoutError. Long enough
+# to absorb brief contention, short enough that a stale holder can't block forever.
+LOG_LOCK_TIMEOUT_SECONDS = 60.0
+
+# Dedicated pool for the blocking lock + file I/O, kept off the default executor
+# so contention here can't starve other offloaded work.
+_LOG_IO_EXECUTOR = ThreadPoolExecutor(max_workers=4, thread_name_prefix="sift-log-io")
+
+# Wake idle workers at interpreter exit so they don't delay shutdown. A worker
+# mid-acquire still drains, but only up to LOG_LOCK_TIMEOUT_SECONDS.
+atexit.register(_LOG_IO_EXECUTOR.shutdown, wait=False)
 
 
 def _client_version() -> str:
@@ -155,13 +170,17 @@ def log_request_to_file(
     request_type: str,
     request: Any,
     response_id: str | None = None,
+    timeout: float = LOG_LOCK_TIMEOUT_SECONDS,
 ) -> None:
     """Append a request as a JSON-encoded line to ``log_file``.
 
     Holds an exclusive :class:`filelock.FileLock` on the sidecar across the
-    append so a concurrent reader in :func:`iter_log_data_lines` can't see a
+    append so a concurrent reader in :func:`_read_log_lines` can't see a
     mid-write partial final line. See the module docstring for the full
     concurrency model.
+
+    This is synchronous and blocks on the lock; async callers should offload it
+    off the event loop (see ``_LOG_IO_EXECUTOR``).
 
     Args:
         log_file: Path to the log file.
@@ -170,6 +189,10 @@ def log_request_to_file(
         response_id: Optional ID from the simulated response, embedded in the tag
             for create operations so replay can map previously simulated IDs used
             by simulated updates.
+        timeout: Seconds to wait for the sidecar lock before raising TimeoutError.
+
+    Raises:
+        TimeoutError: If the lock is not acquired within ``timeout`` seconds.
     """
     log_path = Path(log_file)
     log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -177,37 +200,65 @@ def log_request_to_file(
     request_dict = json_format.MessageToDict(request)
     request_json = json.dumps(request_dict, separators=(",", ":"))
     line = f"[{tag}] {request_json}\n"
-    with FileLock(str(log_path.with_name(log_path.name + ".lock"))):
-        with open(log_path, "a") as f:
-            # The inner ``with`` flushes and closes the file before the
-            # FileLock is released, so no reader sees a partial line.
-            f.write(line)
+    lock_path = log_path.with_name(log_path.name + ".lock")
+    try:
+        with FileLock(str(lock_path), timeout=timeout):
+            with open(log_path, "a") as f:
+                # The inner ``with`` flushes and closes the file before the
+                # FileLock is released, so no reader sees a partial line.
+                f.write(line)
+    except Timeout as exc:
+        raise TimeoutError(
+            f"Timed out after {timeout}s acquiring the test-results log lock at "
+            f"{lock_path}; another process or thread is holding it."
+        ) from exc
 
 
-def iter_log_data_lines(
+def _read_log_lines(
     log_path: str | Path,
+    timeout: float = LOG_LOCK_TIMEOUT_SECONDS,
+) -> list[str]:
+    """Snapshot the log file's raw lines under the sidecar lock.
+
+    Holds the exclusive :class:`filelock.FileLock` only across the ``readlines``
+    so a concurrent :func:`log_request_to_file` append can't be observed as a
+    partial final line, then releases it. Parsing happens lock-free in
+    :func:`parse_log_data_lines`.
+
+    This is synchronous and blocks on the lock; async callers should offload it
+    off the event loop (see ``_LOG_IO_EXECUTOR``).
+
+    Raises:
+        TimeoutError: If the lock is not acquired within ``timeout`` seconds.
+    """
+    log_path = Path(log_path)
+    lock_path = log_path.with_name(log_path.name + ".lock")
+    try:
+        with FileLock(str(lock_path), timeout=timeout):
+            with open(log_path) as f:
+                return f.readlines()
+    except Timeout as exc:
+        raise TimeoutError(
+            f"Timed out after {timeout}s acquiring the test-results log lock at "
+            f"{lock_path}; another process or thread is holding it."
+        ) from exc
+
+
+def parse_log_data_lines(
+    raw_lines: list[str],
     start_line: int = 0,
 ) -> Generator[tuple[str, str | None, str], None, None]:
-    """Parse data lines from a log file.
+    """Parse a snapshot of raw log lines into data-line tuples.
 
-    Yields ``(request_type, response_id, json_str)`` tuples. Each yielded item
-    corresponds to one logged API call.
+    Yields ``(request_type, response_id, json_str)`` tuples, one per logged API
+    call. Pure and lock-free: operates on the in-memory snapshot returned by
+    :func:`_read_log_lines`.
 
     ``start_line`` is the count of data lines (1-based) already uploaded; the
     iterator skips the first ``start_line`` lines and yields the rest. Pass 0
     to read all data lines.
-
-    Holds the sidecar :class:`filelock.FileLock` only while snapshotting the
-    file into memory, then releases before yielding. Lines appended by a
-    concurrent :func:`log_request_to_file` after the snapshot are not visible
-    this call -- they will be picked up on the next invocation.
     """
     line_pattern = re.compile(r"^\[(\w+)(?::([^\]]+))?\]\s*(.+)$")
-    log_path = Path(log_path)
-    with FileLock(str(log_path.with_name(log_path.name + ".lock"))):
-        with open(log_path) as f:
-            raw_lines = f.readlines()
-
     data_line_count = 0
     for raw_line in raw_lines:
         line = raw_line.strip()
@@ -220,3 +271,18 @@ def iter_log_data_lines(
         if data_line_count <= start_line:
             continue
         yield (match.group(1), match.group(2), match.group(3))
+
+
+def iter_log_data_lines(
+    log_path: str | Path,
+    start_line: int = 0,
+    timeout: float = LOG_LOCK_TIMEOUT_SECONDS,
+) -> Generator[tuple[str, str | None, str], None, None]:
+    """Read and parse data lines from a log file.
+
+    Convenience wrapper that snapshots under the lock via :func:`_read_log_lines`
+    then parses with :func:`parse_log_data_lines`. Async callers should instead
+    offload :func:`_read_log_lines` off the event loop and parse the result with
+    :func:`parse_log_data_lines` directly.
+    """
+    yield from parse_log_data_lines(_read_log_lines(log_path, timeout), start_line)

--- a/python/lib/sift_client/_internal/low_level_wrappers/_test_results_log.py
+++ b/python/lib/sift_client/_internal/low_level_wrappers/_test_results_log.py
@@ -4,12 +4,13 @@ Three files per run:
 
 * **Log file** (e.g. ``foo.jsonl``) - append-only record of each logged API call,
   one line per call. Written by :func:`log_request_to_file` in the test process
-  and read by :func:`iter_log_data_lines` / the replay subprocess. Has no header:
+  and read by :func:`_read_log_lines` / the replay subprocess. Has no header:
   every line is a data line.
-* **Lock sidecar** (``foo.jsonl.lock``) - empty file used by :class:`filelock.FileLock`
+* **Lock sidecar** (``foo.jsonl.lock``) - empty file used by ``filelock`` locks
   to coordinate appends and snapshot reads across processes. Created on demand;
-  ``filelock`` unlinks it on release on Unix, and on Windows it may linger but is
-  harmless to leave or delete after the run.
+  ``filelock`` leaves it in place on release on Unix (unlinking is racy) and
+  removes it on Windows when uncontended. Either way it is harmless to leave
+  or delete after the run.
 * **Tracking sidecar** (``foo.jsonl.tracking``) - small JSON file holding the
   incremental replay cursor (``lastUploadedLine``) and the simulated-to-real ID
   map. Written only by the replay subprocess via :meth:`LogTracking.save` using
@@ -21,13 +22,21 @@ Three files per run:
 
 With tracking moved out of the main log, the log file is strictly append-only
 and has exactly one in-place mutator (the writer) and one scanner (the replay
-subprocess). Both serialize through a cross-platform exclusive ``FileLock`` on
-the lock sidecar: the writer holds it across a single append, the reader holds
-it across the snapshot ``readlines()``. That keeps a concurrent reader from
-observing a mid-append partial final line on any OS, including Windows where
-POSIX advisory ``flock`` is unavailable. The exclusive-only lock means a hot
-reader briefly blocks the writer (and vice versa), which is acceptable because
-writes are tiny and we only have one reader.
+subprocess). Both serialize through a cross-platform exclusive
+:class:`filelock.AsyncFileLock` on the lock sidecar: the writer holds it across
+a single append, the reader holds it across the snapshot ``readlines()``. That
+keeps a concurrent reader from observing a mid-append partial final line on any
+OS, including Windows where POSIX advisory ``flock`` is unavailable. The
+exclusive-only lock means a hot reader briefly blocks the writer (and vice
+versa), which is acceptable because writes are tiny and we only have one reader.
+
+Waiting for the lock is cooperative: ``AsyncFileLock`` retries a non-blocking
+acquire and sleeps on the event loop between attempts, so a contended or stale
+lock never blocks the loop thread (the hang in ENG-12003). The acquire is also
+bounded by ``LOG_LOCK_TIMEOUT_SECONDS``, surfacing a stuck lock as
+``TimeoutError`` instead of waiting forever. The file read/write under the lock
+runs inline on the loop; it is a tiny local-file operation, the same class of
+brief synchronous work async methods do throughout this client.
 
 The tracking sidecar has a single writer (the replay subprocess) and no live
 reader, so it needs no locking. Atomic rename is still used to keep the on-disk
@@ -39,18 +48,14 @@ Ad-hoc writers to the same path are not protected.
 
 from __future__ import annotations
 
-import asyncio
-import atexit
-import functools
 import json
 import os
 import re
-from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generator
 
-from filelock import FileLock, Timeout
+from filelock import AsyncFileLock, Timeout
 from google.protobuf import json_format
 
 if TYPE_CHECKING:
@@ -59,15 +64,8 @@ if TYPE_CHECKING:
 
 # Seconds to wait for the sidecar lock before raising TimeoutError. Long enough
 # to absorb brief contention, short enough that a stale holder can't block forever.
+# AsyncFileLock's own default is -1 (wait forever), which is the original hang.
 LOG_LOCK_TIMEOUT_SECONDS = 60.0
-
-# Dedicated pool for the blocking lock + file I/O, kept off the default executor
-# so contention here can't starve other offloaded work.
-_LOG_IO_EXECUTOR = ThreadPoolExecutor(max_workers=4, thread_name_prefix="sift-log-io")
-
-# Wake idle workers at interpreter exit so they don't delay shutdown. A worker
-# mid-acquire still drains, but only up to LOG_LOCK_TIMEOUT_SECONDS.
-atexit.register(_LOG_IO_EXECUTOR.shutdown, wait=False)
 
 
 def _client_version() -> str:
@@ -176,13 +174,11 @@ async def log_request_to_file(
 ) -> None:
     """Append a request as a JSON-encoded line to ``log_file``.
 
-    Holds an exclusive :class:`filelock.FileLock` on the sidecar across the
+    Holds an exclusive :class:`filelock.AsyncFileLock` on the sidecar across the
     append so a concurrent reader in :func:`_read_log_lines` can't see a
-    mid-write partial final line. See the module docstring for the full
-    concurrency model.
-
-    The blocking lock + file I/O runs on ``_LOG_IO_EXECUTOR``, so a slow or
-    stuck lock cannot block the event loop.
+    mid-write partial final line. Waiting for the lock is cooperative and never
+    blocks the event loop; see the module docstring for the full concurrency
+    model.
 
     Args:
         log_file: Path to the log file.
@@ -196,28 +192,6 @@ async def log_request_to_file(
     Raises:
         TimeoutError: If the lock is not acquired within ``timeout`` seconds.
     """
-    loop = asyncio.get_running_loop()
-    await loop.run_in_executor(
-        _LOG_IO_EXECUTOR,
-        functools.partial(
-            _log_request_to_file_sync,
-            log_file,
-            request_type,
-            request,
-            response_id=response_id,
-            timeout=timeout,
-        ),
-    )
-
-
-def _log_request_to_file_sync(
-    log_file: str | Path,
-    request_type: str,
-    request: Any,
-    response_id: str | None = None,
-    timeout: float = LOG_LOCK_TIMEOUT_SECONDS,
-) -> None:
-    """Blocking core of :func:`log_request_to_file`; runs on the executor."""
     log_path = Path(log_file)
     log_path.parent.mkdir(parents=True, exist_ok=True)
     tag = f"{request_type}:{response_id}" if response_id else request_type
@@ -226,10 +200,17 @@ def _log_request_to_file_sync(
     line = f"[{tag}] {request_json}\n"
     lock_path = log_path.with_name(log_path.name + ".lock")
     try:
-        with FileLock(str(lock_path), timeout=timeout):
+        # run_in_executor=False keeps each (instant, non-blocking) acquire
+        # attempt inline on the loop thread. With the default executor-based
+        # attempts, a task cancellation landing during the attempt's executor
+        # round-trip strands the lock: the worker still takes the flock, but
+        # CancelledError skips release and the fd is held until process exit.
+        # Inline, the only cancellation point is the poll sleep between failed
+        # attempts, where no fd is held. Waiting stays cooperative either way.
+        async with AsyncFileLock(str(lock_path), timeout=timeout, run_in_executor=False):
             with open(log_path, "a") as f:
                 # The inner ``with`` flushes and closes the file before the
-                # FileLock is released, so no reader sees a partial line.
+                # lock is released, so no reader sees a partial line.
                 f.write(line)
     except Timeout as exc:
         raise TimeoutError(
@@ -244,33 +225,20 @@ async def _read_log_lines(
 ) -> list[str]:
     """Snapshot the log file's raw lines under the sidecar lock.
 
-    Holds the exclusive :class:`filelock.FileLock` only across the ``readlines``
-    so a concurrent :func:`log_request_to_file` append can't be observed as a
-    partial final line, then releases it. Parsing happens lock-free in
+    Holds the exclusive :class:`filelock.AsyncFileLock` only across the
+    ``readlines`` so a concurrent :func:`log_request_to_file` append can't be
+    observed as a partial final line, then releases it. Waiting for the lock is
+    cooperative and never blocks the event loop. Parsing happens lock-free in
     :func:`parse_log_data_lines`.
-
-    The blocking lock + file I/O runs on ``_LOG_IO_EXECUTOR``, so a slow or
-    stuck lock cannot block the event loop.
 
     Raises:
         TimeoutError: If the lock is not acquired within ``timeout`` seconds.
     """
-    loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(
-        _LOG_IO_EXECUTOR,
-        functools.partial(_read_log_lines_sync, log_path, timeout=timeout),
-    )
-
-
-def _read_log_lines_sync(
-    log_path: str | Path,
-    timeout: float = LOG_LOCK_TIMEOUT_SECONDS,
-) -> list[str]:
-    """Blocking core of :func:`_read_log_lines`; runs on the executor."""
     log_path = Path(log_path)
     lock_path = log_path.with_name(log_path.name + ".lock")
     try:
-        with FileLock(str(lock_path), timeout=timeout):
+        # run_in_executor=False for cancel-safety; see log_request_to_file.
+        async with AsyncFileLock(str(lock_path), timeout=timeout, run_in_executor=False):
             with open(log_path) as f:
                 return f.readlines()
     except Timeout as exc:
@@ -307,18 +275,3 @@ def parse_log_data_lines(
         if data_line_count <= start_line:
             continue
         yield (match.group(1), match.group(2), match.group(3))
-
-
-def iter_log_data_lines(
-    log_path: str | Path,
-    start_line: int = 0,
-    timeout: float = LOG_LOCK_TIMEOUT_SECONDS,
-) -> Generator[tuple[str, str | None, str], None, None]:
-    """Read and parse data lines from a log file.
-
-    Synchronous convenience wrapper that snapshots under the lock then parses
-    with :func:`parse_log_data_lines`. Async callers should instead await
-    :func:`_read_log_lines` and parse the result with
-    :func:`parse_log_data_lines` directly.
-    """
-    yield from parse_log_data_lines(_read_log_lines_sync(log_path, timeout), start_line)

--- a/python/lib/sift_client/_internal/low_level_wrappers/test_results.py
+++ b/python/lib/sift_client/_internal/low_level_wrappers/test_results.py
@@ -41,7 +41,6 @@ from sift.test_reports.v1.test_reports_pb2 import TestStep as TestStepProto
 from sift.test_reports.v1.test_reports_pb2_grpc import TestReportServiceStub
 
 from sift_client._internal.low_level_wrappers._test_results_log import (
-    _LOG_IO_EXECUTOR,
     LogTracking,
     ReplayResult,
     _read_log_lines,
@@ -50,7 +49,6 @@ from sift_client._internal.low_level_wrappers._test_results_log import (
     parse_log_data_lines,
 )
 from sift_client._internal.low_level_wrappers.base import DEFAULT_PAGE_SIZE, LowLevelClientBase
-from sift_client._internal.util.executor import run_sync_function
 from sift_client.sift_types.test_report import (
     TestMeasurement,
     TestMeasurementCreate,
@@ -384,14 +382,11 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         if log_file is not None or simulate:
             simulated_proto = self.simulate_create_test_report_response(request)
             if log_file is not None:
-                await run_sync_function(
-                    lambda: log_request_to_file(
-                        log_file,
-                        "CreateTestReport",
-                        request,
-                        response_id=simulated_proto.test_report_id,
-                    ),
-                    executor=_LOG_IO_EXECUTOR,
+                await log_request_to_file(
+                    log_file,
+                    "CreateTestReport",
+                    request,
+                    response_id=simulated_proto.test_report_id,
                 )
             return TestReport._from_proto(simulated_proto)
 
@@ -510,10 +505,7 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
 
         if log_file is not None or simulate:
             if log_file is not None:
-                await run_sync_function(
-                    lambda: log_request_to_file(log_file, "UpdateTestReport", request),
-                    executor=_LOG_IO_EXECUTOR,
-                )
+                await log_request_to_file(log_file, "UpdateTestReport", request)
             return self.simulate_update_test_report_response(request, existing=existing)
 
         response = await self._grpc_client.get_stub(TestReportServiceStub).UpdateTestReport(request)
@@ -563,14 +555,11 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         if log_file is not None or simulate:
             simulated_proto = self.simulate_create_test_step_response(request)
             if log_file is not None:
-                await run_sync_function(
-                    lambda: log_request_to_file(
-                        log_file,
-                        "CreateTestStep",
-                        request,
-                        response_id=simulated_proto.test_step_id,
-                    ),
-                    executor=_LOG_IO_EXECUTOR,
+                await log_request_to_file(
+                    log_file,
+                    "CreateTestStep",
+                    request,
+                    response_id=simulated_proto.test_step_id,
                 )
             return TestStep._from_proto(simulated_proto)
 
@@ -672,10 +661,7 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
 
         if log_file is not None or simulate:
             if log_file is not None:
-                await run_sync_function(
-                    lambda: log_request_to_file(log_file, "UpdateTestStep", request),
-                    executor=_LOG_IO_EXECUTOR,
-                )
+                await log_request_to_file(log_file, "UpdateTestStep", request)
             return self.simulate_update_test_step_response(request, existing=existing)
 
         response = await self._grpc_client.get_stub(TestReportServiceStub).UpdateTestStep(request)
@@ -725,14 +711,11 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         if log_file is not None or simulate:
             simulated_proto = self.simulate_create_test_measurement_response(request)
             if log_file is not None:
-                await run_sync_function(
-                    lambda: log_request_to_file(
-                        log_file,
-                        "CreateTestMeasurement",
-                        request,
-                        response_id=simulated_proto.measurement_id,
-                    ),
-                    executor=_LOG_IO_EXECUTOR,
+                await log_request_to_file(
+                    log_file,
+                    "CreateTestMeasurement",
+                    request,
+                    response_id=simulated_proto.measurement_id,
                 )
             return TestMeasurement._from_proto(simulated_proto)
 
@@ -769,14 +752,11 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         if log_file is not None or simulate:
             count, measurement_ids = self.simulate_create_test_measurements_response(request)
             if log_file is not None:
-                await run_sync_function(
-                    lambda: log_request_to_file(
-                        log_file,
-                        "CreateTestMeasurements",
-                        request,
-                        response_id=",".join(measurement_ids),
-                    ),
-                    executor=_LOG_IO_EXECUTOR,
+                await log_request_to_file(
+                    log_file,
+                    "CreateTestMeasurements",
+                    request,
+                    response_id=",".join(measurement_ids),
                 )
             return count, measurement_ids
 
@@ -881,10 +861,7 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
 
         if log_file is not None or simulate:
             if log_file is not None:
-                await run_sync_function(
-                    lambda: log_request_to_file(log_file, "UpdateTestMeasurement", request),
-                    executor=_LOG_IO_EXECUTOR,
-                )
+                await log_request_to_file(log_file, "UpdateTestMeasurement", request)
             return self.simulate_update_test_measurement_response(request, existing=existing)
 
         response = await self._grpc_client.get_stub(TestReportServiceStub).UpdateTestMeasurement(
@@ -1142,9 +1119,7 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         id_map: dict[str, str] = {}
         state = _ReplayState()
 
-        raw_lines = await run_sync_function(
-            lambda: _read_log_lines(log_path), executor=_LOG_IO_EXECUTOR
-        )
+        raw_lines = await _read_log_lines(log_path)
         for request_type, response_id, json_str in parse_log_data_lines(raw_lines):
             await self._import_entry(
                 request_type,
@@ -1214,9 +1189,7 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         id_map = tracking.id_map
         state = _ReplayState()
 
-        raw_lines = await run_sync_function(
-            lambda: _read_log_lines(log_path), executor=_LOG_IO_EXECUTOR
-        )
+        raw_lines = await _read_log_lines(log_path)
         for request_type, response_id, json_str in parse_log_data_lines(
             raw_lines, start_line=tracking.last_uploaded_line
         ):

--- a/python/lib/sift_client/_internal/low_level_wrappers/test_results.py
+++ b/python/lib/sift_client/_internal/low_level_wrappers/test_results.py
@@ -41,13 +41,16 @@ from sift.test_reports.v1.test_reports_pb2 import TestStep as TestStepProto
 from sift.test_reports.v1.test_reports_pb2_grpc import TestReportServiceStub
 
 from sift_client._internal.low_level_wrappers._test_results_log import (
+    _LOG_IO_EXECUTOR,
     LogTracking,
     ReplayResult,
+    _read_log_lines,
     _ReplayState,
-    iter_log_data_lines,
     log_request_to_file,
+    parse_log_data_lines,
 )
 from sift_client._internal.low_level_wrappers.base import DEFAULT_PAGE_SIZE, LowLevelClientBase
+from sift_client._internal.util.executor import run_sync_function
 from sift_client.sift_types.test_report import (
     TestMeasurement,
     TestMeasurementCreate,
@@ -381,11 +384,14 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         if log_file is not None or simulate:
             simulated_proto = self.simulate_create_test_report_response(request)
             if log_file is not None:
-                log_request_to_file(
-                    log_file,
-                    "CreateTestReport",
-                    request,
-                    response_id=simulated_proto.test_report_id,
+                await run_sync_function(
+                    lambda: log_request_to_file(
+                        log_file,
+                        "CreateTestReport",
+                        request,
+                        response_id=simulated_proto.test_report_id,
+                    ),
+                    executor=_LOG_IO_EXECUTOR,
                 )
             return TestReport._from_proto(simulated_proto)
 
@@ -504,7 +510,10 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
 
         if log_file is not None or simulate:
             if log_file is not None:
-                log_request_to_file(log_file, "UpdateTestReport", request)
+                await run_sync_function(
+                    lambda: log_request_to_file(log_file, "UpdateTestReport", request),
+                    executor=_LOG_IO_EXECUTOR,
+                )
             return self.simulate_update_test_report_response(request, existing=existing)
 
         response = await self._grpc_client.get_stub(TestReportServiceStub).UpdateTestReport(request)
@@ -554,11 +563,14 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         if log_file is not None or simulate:
             simulated_proto = self.simulate_create_test_step_response(request)
             if log_file is not None:
-                log_request_to_file(
-                    log_file,
-                    "CreateTestStep",
-                    request,
-                    response_id=simulated_proto.test_step_id,
+                await run_sync_function(
+                    lambda: log_request_to_file(
+                        log_file,
+                        "CreateTestStep",
+                        request,
+                        response_id=simulated_proto.test_step_id,
+                    ),
+                    executor=_LOG_IO_EXECUTOR,
                 )
             return TestStep._from_proto(simulated_proto)
 
@@ -660,7 +672,10 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
 
         if log_file is not None or simulate:
             if log_file is not None:
-                log_request_to_file(log_file, "UpdateTestStep", request)
+                await run_sync_function(
+                    lambda: log_request_to_file(log_file, "UpdateTestStep", request),
+                    executor=_LOG_IO_EXECUTOR,
+                )
             return self.simulate_update_test_step_response(request, existing=existing)
 
         response = await self._grpc_client.get_stub(TestReportServiceStub).UpdateTestStep(request)
@@ -710,11 +725,14 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         if log_file is not None or simulate:
             simulated_proto = self.simulate_create_test_measurement_response(request)
             if log_file is not None:
-                log_request_to_file(
-                    log_file,
-                    "CreateTestMeasurement",
-                    request,
-                    response_id=simulated_proto.measurement_id,
+                await run_sync_function(
+                    lambda: log_request_to_file(
+                        log_file,
+                        "CreateTestMeasurement",
+                        request,
+                        response_id=simulated_proto.measurement_id,
+                    ),
+                    executor=_LOG_IO_EXECUTOR,
                 )
             return TestMeasurement._from_proto(simulated_proto)
 
@@ -751,11 +769,14 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         if log_file is not None or simulate:
             count, measurement_ids = self.simulate_create_test_measurements_response(request)
             if log_file is not None:
-                log_request_to_file(
-                    log_file,
-                    "CreateTestMeasurements",
-                    request,
-                    response_id=",".join(measurement_ids),
+                await run_sync_function(
+                    lambda: log_request_to_file(
+                        log_file,
+                        "CreateTestMeasurements",
+                        request,
+                        response_id=",".join(measurement_ids),
+                    ),
+                    executor=_LOG_IO_EXECUTOR,
                 )
             return count, measurement_ids
 
@@ -860,7 +881,10 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
 
         if log_file is not None or simulate:
             if log_file is not None:
-                log_request_to_file(log_file, "UpdateTestMeasurement", request)
+                await run_sync_function(
+                    lambda: log_request_to_file(log_file, "UpdateTestMeasurement", request),
+                    executor=_LOG_IO_EXECUTOR,
+                )
             return self.simulate_update_test_measurement_response(request, existing=existing)
 
         response = await self._grpc_client.get_stub(TestReportServiceStub).UpdateTestMeasurement(
@@ -1118,7 +1142,10 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         id_map: dict[str, str] = {}
         state = _ReplayState()
 
-        for request_type, response_id, json_str in iter_log_data_lines(log_path):
+        raw_lines = await run_sync_function(
+            lambda: _read_log_lines(log_path), executor=_LOG_IO_EXECUTOR
+        )
+        for request_type, response_id, json_str in parse_log_data_lines(raw_lines):
             await self._import_entry(
                 request_type,
                 response_id,
@@ -1187,8 +1214,11 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         id_map = tracking.id_map
         state = _ReplayState()
 
-        for request_type, response_id, json_str in iter_log_data_lines(
-            log_path, start_line=tracking.last_uploaded_line
+        raw_lines = await run_sync_function(
+            lambda: _read_log_lines(log_path), executor=_LOG_IO_EXECUTOR
+        )
+        for request_type, response_id, json_str in parse_log_data_lines(
+            raw_lines, start_line=tracking.last_uploaded_line
         ):
             await self._import_entry(
                 request_type,

--- a/python/lib/sift_client/_internal/util/executor.py
+++ b/python/lib/sift_client/_internal/util/executor.py
@@ -1,19 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any, Callable
-
-if TYPE_CHECKING:
-    from concurrent.futures import Executor
+from typing import Any, Callable
 
 
-async def run_sync_function(
-    fn: Callable[..., Any], *args: Any, executor: Executor | None = None
-) -> Any:
-    """Run a synchronous function in a thread pool to avoid blocking the event loop.
-
-    Pass ``executor`` to run on a dedicated pool instead of the loop's default
-    one, isolating slow or blocking work from other offloaded calls.
-    """
+async def run_sync_function(fn: Callable[..., Any], *args: Any) -> Any:
+    """Run a synchronous function in a thread pool to avoid blocking the event loop."""
     loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(executor, fn, *args)
+    return await loop.run_in_executor(None, fn, *args)

--- a/python/lib/sift_client/_internal/util/executor.py
+++ b/python/lib/sift_client/_internal/util/executor.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from concurrent.futures import Executor
 
 
-async def run_sync_function(fn: Callable[..., Any], *args: Any) -> Any:
-    """Run a synchronous function in a thread pool to avoid blocking the event loop."""
+async def run_sync_function(
+    fn: Callable[..., Any], *args: Any, executor: Executor | None = None
+) -> Any:
+    """Run a synchronous function in a thread pool to avoid blocking the event loop.
+
+    Pass ``executor`` to run on a dedicated pool instead of the loop's default
+    one, isolating slow or blocking work from other offloaded calls.
+    """
     loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(None, fn, *args)
+    return await loop.run_in_executor(executor, fn, *args)

--- a/python/lib/sift_client/_tests/_internal/low_level_wrappers/test_results_log.py
+++ b/python/lib/sift_client/_tests/_internal/low_level_wrappers/test_results_log.py
@@ -1,0 +1,188 @@
+"""Unit tests for the test-results log lock + offload behavior.
+
+These cover the hang fix directly: the sidecar FileLock now has a finite
+timeout, and the blocking lock + file I/O is offloaded off the event loop so a
+contended or stale lock can no longer freeze every synchronous API call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+from filelock import FileLock
+from sift.test_reports.v1.test_reports_pb2 import CreateTestReportRequest
+
+from sift_client._internal.low_level_wrappers._test_results_log import (
+    _LOG_IO_EXECUTOR,
+    LOG_LOCK_TIMEOUT_SECONDS,
+    _read_log_lines,
+    log_request_to_file,
+    parse_log_data_lines,
+)
+from sift_client._internal.low_level_wrappers.test_results import TestResultsLowLevelClient
+from sift_client._internal.util.executor import run_sync_function
+
+
+def _lock_path(log_file) -> str:
+    return str(log_file.with_name(log_file.name + ".lock"))
+
+
+class TestLogLockTimeout:
+    """A held lock surfaces a clear TimeoutError instead of blocking forever."""
+
+    def test_writer_raises_timeout_when_lock_held(self, tmp_path):
+        log_file = tmp_path / "log.jsonl"
+        held = FileLock(_lock_path(log_file))
+        held.acquire()
+        try:
+            with pytest.raises(TimeoutError, match="test-results log lock"):
+                log_request_to_file(
+                    log_file, "CreateTestReport", CreateTestReportRequest(), timeout=0.2
+                )
+        finally:
+            held.release()
+
+    def test_reader_raises_timeout_when_lock_held(self, tmp_path):
+        log_file = tmp_path / "log.jsonl"
+        log_file.write_text("[CreateTestReport] {}\n")
+        held = FileLock(_lock_path(log_file))
+        held.acquire()
+        try:
+            with pytest.raises(TimeoutError, match="test-results log lock"):
+                _read_log_lines(log_file, timeout=0.2)
+        finally:
+            held.release()
+
+    def test_default_lock_timeout_is_finite_and_positive(self):
+        # Guards against an accidental None/inf default that would reintroduce
+        # the unbounded wait.
+        assert 0 < LOG_LOCK_TIMEOUT_SECONDS < float("inf")
+
+
+class TestLogParsing:
+    """The split read/parse helpers preserve the original snapshot semantics."""
+
+    def test_read_and_parse_round_trip(self, tmp_path):
+        log_file = tmp_path / "log.jsonl"
+        log_request_to_file(
+            log_file, "CreateTestReport", CreateTestReportRequest(), response_id="r1"
+        )
+        log_request_to_file(log_file, "UpdateTestReport", CreateTestReportRequest())
+
+        parsed = list(parse_log_data_lines(_read_log_lines(log_file)))
+
+        assert [p[0] for p in parsed] == ["CreateTestReport", "UpdateTestReport"]
+        assert parsed[0][1] == "r1"
+        assert parsed[1][1] is None
+
+    def test_parse_skips_start_line_and_blank_lines(self):
+        raw = ["[CreateTestReport] {}\n", "\n", "[UpdateTestReport] {}\n"]
+
+        parsed = list(parse_log_data_lines(raw, start_line=1))
+
+        assert [p[0] for p in parsed] == ["UpdateTestReport"]
+
+    def test_parse_raises_on_malformed_line(self):
+        with pytest.raises(ValueError, match="Invalid log line"):
+            list(parse_log_data_lines(["not a valid log line\n"]))
+
+    def test_parse_start_line_beyond_data_yields_nothing(self):
+        raw = ["[CreateTestReport] {}\n", "[UpdateTestReport] {}\n"]
+
+        assert list(parse_log_data_lines(raw, start_line=10)) == []
+
+
+class TestLogOffload:
+    """The blocking log I/O runs off the loop, so a stuck lock cannot cascade."""
+
+    def test_import_does_not_block_event_loop_while_lock_held(self, tmp_path):
+        """A held lock parks the import in the executor, leaving the loop free.
+
+        Without the offload the log read would run on the shared loop thread and
+        the unrelated ``ping`` coroutine below would never complete.
+        """
+        log_file = tmp_path / "log.jsonl"
+        log_file.write_text("")
+        client = TestResultsLowLevelClient(grpc_client=MagicMock())
+
+        loop = asyncio.new_event_loop()
+        loop_thread = threading.Thread(target=loop.run_forever, daemon=True)
+        loop_thread.start()
+
+        held = FileLock(_lock_path(log_file))
+        held.acquire()
+        try:
+            importing = asyncio.run_coroutine_threadsafe(
+                client._batch_import_log_file(log_file), loop
+            )
+
+            async def ping() -> str:
+                await asyncio.sleep(0)
+                return "pong"
+
+            quick = asyncio.run_coroutine_threadsafe(ping(), loop)
+            assert quick.result(timeout=2.0) == "pong"
+            # Still parked on the held lock in the executor, not on the loop.
+            assert not importing.done()
+        finally:
+            held.release()
+
+        # Once the lock frees, the read returns and the empty log raises.
+        with pytest.raises(ValueError, match="No CreateTestReport"):
+            importing.result(timeout=5.0)
+
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join(timeout=2.0)
+
+    def test_offloaded_read_uses_dedicated_executor(self, tmp_path):
+        """Log I/O runs on the dedicated pool, isolating it from the default one."""
+        log_file = tmp_path / "log.jsonl"
+        log_file.write_text("")
+
+        async def driver() -> str:
+            def _worker():
+                return threading.current_thread().name
+
+            return await run_sync_function(_worker, executor=_LOG_IO_EXECUTOR)
+
+        thread_name = asyncio.run(driver())
+        assert thread_name.startswith("sift-log-io")
+
+    def test_writer_and_reader_call_sites_use_dedicated_executor(self, tmp_path, monkeypatch):
+        """Both call sites must pass executor=_LOG_IO_EXECUTOR, not the default pool.
+
+        Guards against a refactor dropping ``executor=`` at a call site, which
+        would silently fall back to the shared default pool.
+        """
+        from sift.test_reports.v1.test_reports_pb2 import CreateTestReportRequest
+
+        from sift_client._internal.low_level_wrappers import test_results as tr
+
+        seen: list = []
+        real = tr.run_sync_function
+
+        async def spy(fn, *args, executor=None):
+            seen.append(executor)
+            return await real(fn, *args, executor=executor)
+
+        monkeypatch.setattr(tr, "run_sync_function", spy)
+
+        client = TestResultsLowLevelClient(grpc_client=MagicMock())
+        log_file = tmp_path / "log.jsonl"
+
+        async def drive():
+            # Writer call site (log branch returns before any gRPC call).
+            await client.create_test_report(request=CreateTestReportRequest(), log_file=log_file)
+            # Reader call site (offloaded read runs before any replay API call).
+            try:
+                await client._batch_import_log_file(log_file)
+            except Exception:
+                pass
+
+        asyncio.run(drive())
+
+        assert len(seen) >= 2
+        assert all(executor is tr._LOG_IO_EXECUTOR for executor in seen)

--- a/python/lib/sift_client/_tests/_internal/low_level_wrappers/test_results_log.py
+++ b/python/lib/sift_client/_tests/_internal/low_level_wrappers/test_results_log.py
@@ -1,14 +1,15 @@
-"""Unit tests for the test-results log lock + offload behavior.
+"""Unit tests for the test-results log lock behavior.
 
-These cover the hang fix directly: the sidecar FileLock now has a finite
-timeout, and ``log_request_to_file`` / ``_read_log_lines`` offload the blocking
-lock + file I/O off the event loop internally, so a contended or stale lock can
-no longer freeze every synchronous API call.
+These cover the hang fix directly: the sidecar lock has a finite timeout, and
+``log_request_to_file`` / ``_read_log_lines`` wait for it cooperatively via
+``AsyncFileLock``, so a contended or stale lock can no longer freeze the event
+loop and with it every synchronous API call.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import threading
 from unittest.mock import MagicMock
 
@@ -16,7 +17,6 @@ import pytest
 from filelock import FileLock
 from sift.test_reports.v1.test_reports_pb2 import CreateTestReportRequest
 
-from sift_client._internal.low_level_wrappers import _test_results_log as trl
 from sift_client._internal.low_level_wrappers._test_results_log import (
     LOG_LOCK_TIMEOUT_SECONDS,
     _read_log_lines,
@@ -60,7 +60,7 @@ class TestLogLockTimeout:
 
     def test_default_lock_timeout_is_finite_and_positive(self):
         # Guards against an accidental None/inf default that would reintroduce
-        # the unbounded wait.
+        # the unbounded wait (AsyncFileLock's own default is wait-forever).
         assert 0 < LOG_LOCK_TIMEOUT_SECONDS < float("inf")
 
 
@@ -95,14 +95,15 @@ class TestLogParsing:
             list(parse_log_data_lines(["not a valid log line\n"]))
 
 
-class TestLogOffload:
-    """The blocking log I/O runs off the loop, so a stuck lock cannot cascade."""
+class TestLogLoopSafety:
+    """A contended lock parks only the waiting coroutine, never the loop."""
 
     def test_import_does_not_block_event_loop_while_lock_held(self, tmp_path):
-        """A held lock parks the import in the executor, leaving the loop free.
+        """A held lock parks the import on the cooperative wait, leaving the loop free.
 
-        Without the offload the log read would run on the shared loop thread and
-        the unrelated ``ping`` coroutine below would never complete.
+        With a blocking lock acquire on the loop thread the unrelated ``ping``
+        coroutine below would never complete; with ``AsyncFileLock`` the waiter
+        sleeps between acquire attempts and the loop keeps serving other tasks.
         """
         log_file = tmp_path / "log.jsonl"
         log_file.write_text("")
@@ -125,7 +126,7 @@ class TestLogOffload:
 
             quick = asyncio.run_coroutine_threadsafe(ping(), loop)
             assert quick.result(timeout=2.0) == "pong"
-            # Still parked on the held lock in the executor, not on the loop.
+            # Still parked on the held lock's cooperative wait, not on the loop.
             assert not importing.done()
         finally:
             held.release()
@@ -137,34 +138,67 @@ class TestLogOffload:
         loop.call_soon_threadsafe(loop.stop)
         loop_thread.join(timeout=2.0)
 
-    def test_write_and_read_run_on_dedicated_executor(self, tmp_path, monkeypatch):
-        """The async wrappers run their blocking cores on the sift-log-io pool.
-
-        Guards against a refactor moving the offload back onto the loop thread
-        or the shared default pool.
-        """
-        seen: list[str] = []
-        real_write = trl._log_request_to_file_sync
-        real_read = trl._read_log_lines_sync
-
-        def spy_write(*args, **kwargs):
-            seen.append(threading.current_thread().name)
-            return real_write(*args, **kwargs)
-
-        def spy_read(*args, **kwargs):
-            seen.append(threading.current_thread().name)
-            return real_read(*args, **kwargs)
-
-        monkeypatch.setattr(trl, "_log_request_to_file_sync", spy_write)
-        monkeypatch.setattr(trl, "_read_log_lines_sync", spy_read)
-
+    def test_write_does_not_block_event_loop_while_lock_held(self, tmp_path):
+        """Same property for the writer path: a held lock cannot freeze the loop."""
         log_file = tmp_path / "log.jsonl"
 
-        async def drive():
-            await log_request_to_file(log_file, "CreateTestReport", CreateTestReportRequest())
-            await _read_log_lines(log_file)
+        loop = asyncio.new_event_loop()
+        loop_thread = threading.Thread(target=loop.run_forever, daemon=True)
+        loop_thread.start()
+
+        held = FileLock(_lock_path(log_file))
+        held.acquire()
+        try:
+            writing = asyncio.run_coroutine_threadsafe(
+                log_request_to_file(log_file, "CreateTestReport", CreateTestReportRequest()),
+                loop,
+            )
+
+            async def ping() -> str:
+                await asyncio.sleep(0)
+                return "pong"
+
+            quick = asyncio.run_coroutine_threadsafe(ping(), loop)
+            assert quick.result(timeout=2.0) == "pong"
+            # Still parked on the held lock's cooperative wait, not on the loop.
+            assert not writing.done()
+        finally:
+            held.release()
+
+        # Once the lock frees, the append completes and the line is on disk.
+        writing.result(timeout=5.0)
+        assert "[CreateTestReport]" in log_file.read_text()
+
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join(timeout=2.0)
+
+
+class TestLockCancelSafety:
+    """Cancelling a logging task cannot strand the sidecar lock."""
+
+    def test_cancelled_write_does_not_strand_the_lock(self, tmp_path):
+        """A cancelled append must leave the lock free for the next caller.
+
+        Pins ``run_in_executor=False`` on the ``AsyncFileLock``: with
+        executor-based acquire attempts, a cancel landing during the attempt's
+        executor round-trip leaves the flock taken with no owner to release
+        it, and every later append/read on the file times out.
+        """
+        log_file = tmp_path / "log.jsonl"
+
+        async def drive() -> None:
+            for _ in range(20):
+                task = asyncio.ensure_future(
+                    log_request_to_file(log_file, "CreateTestReport", CreateTestReportRequest())
+                )
+                await asyncio.sleep(0)
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+            # If any cancelled attempt stranded the lock, this times out.
+            await log_request_to_file(
+                log_file, "CreateTestReport", CreateTestReportRequest(), timeout=2.0
+            )
 
         asyncio.run(drive())
-
-        assert len(seen) == 2
-        assert all(name.startswith("sift-log-io") for name in seen)
+        assert "[CreateTestReport]" in log_file.read_text()

--- a/python/lib/sift_client/_tests/_internal/low_level_wrappers/test_results_log.py
+++ b/python/lib/sift_client/_tests/_internal/low_level_wrappers/test_results_log.py
@@ -1,8 +1,9 @@
 """Unit tests for the test-results log lock + offload behavior.
 
 These cover the hang fix directly: the sidecar FileLock now has a finite
-timeout, and the blocking lock + file I/O is offloaded off the event loop so a
-contended or stale lock can no longer freeze every synchronous API call.
+timeout, and ``log_request_to_file`` / ``_read_log_lines`` offload the blocking
+lock + file I/O off the event loop internally, so a contended or stale lock can
+no longer freeze every synchronous API call.
 """
 
 from __future__ import annotations
@@ -15,15 +16,14 @@ import pytest
 from filelock import FileLock
 from sift.test_reports.v1.test_reports_pb2 import CreateTestReportRequest
 
+from sift_client._internal.low_level_wrappers import _test_results_log as trl
 from sift_client._internal.low_level_wrappers._test_results_log import (
-    _LOG_IO_EXECUTOR,
     LOG_LOCK_TIMEOUT_SECONDS,
     _read_log_lines,
     log_request_to_file,
     parse_log_data_lines,
 )
 from sift_client._internal.low_level_wrappers.test_results import TestResultsLowLevelClient
-from sift_client._internal.util.executor import run_sync_function
 
 
 def _lock_path(log_file) -> str:
@@ -39,8 +39,10 @@ class TestLogLockTimeout:
         held.acquire()
         try:
             with pytest.raises(TimeoutError, match="test-results log lock"):
-                log_request_to_file(
-                    log_file, "CreateTestReport", CreateTestReportRequest(), timeout=0.2
+                asyncio.run(
+                    log_request_to_file(
+                        log_file, "CreateTestReport", CreateTestReportRequest(), timeout=0.2
+                    )
                 )
         finally:
             held.release()
@@ -52,7 +54,7 @@ class TestLogLockTimeout:
         held.acquire()
         try:
             with pytest.raises(TimeoutError, match="test-results log lock"):
-                _read_log_lines(log_file, timeout=0.2)
+                asyncio.run(_read_log_lines(log_file, timeout=0.2))
         finally:
             held.release()
 
@@ -67,12 +69,15 @@ class TestLogParsing:
 
     def test_read_and_parse_round_trip(self, tmp_path):
         log_file = tmp_path / "log.jsonl"
-        log_request_to_file(
-            log_file, "CreateTestReport", CreateTestReportRequest(), response_id="r1"
-        )
-        log_request_to_file(log_file, "UpdateTestReport", CreateTestReportRequest())
 
-        parsed = list(parse_log_data_lines(_read_log_lines(log_file)))
+        async def drive() -> list:
+            await log_request_to_file(
+                log_file, "CreateTestReport", CreateTestReportRequest(), response_id="r1"
+            )
+            await log_request_to_file(log_file, "UpdateTestReport", CreateTestReportRequest())
+            return list(parse_log_data_lines(await _read_log_lines(log_file)))
+
+        parsed = asyncio.run(drive())
 
         assert [p[0] for p in parsed] == ["CreateTestReport", "UpdateTestReport"]
         assert parsed[0][1] == "r1"
@@ -132,52 +137,34 @@ class TestLogOffload:
         loop.call_soon_threadsafe(loop.stop)
         loop_thread.join(timeout=2.0)
 
-    def test_offloaded_read_uses_dedicated_executor(self, tmp_path):
-        """Log I/O runs on the dedicated pool, isolating it from the default one."""
-        log_file = tmp_path / "log.jsonl"
-        log_file.write_text("")
+    def test_write_and_read_run_on_dedicated_executor(self, tmp_path, monkeypatch):
+        """The async wrappers run their blocking cores on the sift-log-io pool.
 
-        async def driver() -> str:
-            def _worker():
-                return threading.current_thread().name
-
-            return await run_sync_function(_worker, executor=_LOG_IO_EXECUTOR)
-
-        thread_name = asyncio.run(driver())
-        assert thread_name.startswith("sift-log-io")
-
-    def test_writer_and_reader_call_sites_use_dedicated_executor(self, tmp_path, monkeypatch):
-        """Both call sites must pass executor=_LOG_IO_EXECUTOR, not the default pool.
-
-        Guards against a refactor dropping ``executor=`` at a call site, which
-        would silently fall back to the shared default pool.
+        Guards against a refactor moving the offload back onto the loop thread
+        or the shared default pool.
         """
-        from sift.test_reports.v1.test_reports_pb2 import CreateTestReportRequest
+        seen: list[str] = []
+        real_write = trl._log_request_to_file_sync
+        real_read = trl._read_log_lines_sync
 
-        from sift_client._internal.low_level_wrappers import test_results as tr
+        def spy_write(*args, **kwargs):
+            seen.append(threading.current_thread().name)
+            return real_write(*args, **kwargs)
 
-        seen: list = []
-        real = tr.run_sync_function
+        def spy_read(*args, **kwargs):
+            seen.append(threading.current_thread().name)
+            return real_read(*args, **kwargs)
 
-        async def spy(fn, *args, executor=None):
-            seen.append(executor)
-            return await real(fn, *args, executor=executor)
+        monkeypatch.setattr(trl, "_log_request_to_file_sync", spy_write)
+        monkeypatch.setattr(trl, "_read_log_lines_sync", spy_read)
 
-        monkeypatch.setattr(tr, "run_sync_function", spy)
-
-        client = TestResultsLowLevelClient(grpc_client=MagicMock())
         log_file = tmp_path / "log.jsonl"
 
         async def drive():
-            # Writer call site (log branch returns before any gRPC call).
-            await client.create_test_report(request=CreateTestReportRequest(), log_file=log_file)
-            # Reader call site (offloaded read runs before any replay API call).
-            try:
-                await client._batch_import_log_file(log_file)
-            except Exception:
-                pass
+            await log_request_to_file(log_file, "CreateTestReport", CreateTestReportRequest())
+            await _read_log_lines(log_file)
 
         asyncio.run(drive())
 
-        assert len(seen) >= 2
-        assert all(executor is tr._LOG_IO_EXECUTOR for executor in seen)
+        assert len(seen) == 2
+        assert all(name.startswith("sift-log-io") for name in seen)

--- a/python/lib/sift_client/_tests/_internal/low_level_wrappers/test_results_log.py
+++ b/python/lib/sift_client/_tests/_internal/low_level_wrappers/test_results_log.py
@@ -89,11 +89,6 @@ class TestLogParsing:
         with pytest.raises(ValueError, match="Invalid log line"):
             list(parse_log_data_lines(["not a valid log line\n"]))
 
-    def test_parse_start_line_beyond_data_yields_nothing(self):
-        raw = ["[CreateTestReport] {}\n", "[UpdateTestReport] {}\n"]
-
-        assert list(parse_log_data_lines(raw, start_line=10)) == []
-
 
 class TestLogOffload:
     """The blocking log I/O runs off the loop, so a stuck lock cannot cascade."""

--- a/python/lib/sift_client/_tests/resources/test_test_results.py
+++ b/python/lib/sift_client/_tests/resources/test_test_results.py
@@ -751,7 +751,7 @@ class TestImportLogFile:
 
         from sift_client._internal.low_level_wrappers._test_results_log import (
             LogTracking,
-            log_request_to_file,
+            _log_request_to_file_sync,
         )
 
         log_file = tmp_path / "race.jsonl"
@@ -762,7 +762,7 @@ class TestImportLogFile:
 
         def writer() -> None:
             for i in range(n_appends):
-                log_request_to_file(log_file, "CreateTestReport", request, response_id=str(i))
+                _log_request_to_file_sync(log_file, "CreateTestReport", request, response_id=str(i))
 
         def updater() -> None:
             tracking = LogTracking(last_uploaded_line=0)

--- a/python/lib/sift_client/_tests/resources/test_test_results.py
+++ b/python/lib/sift_client/_tests/resources/test_test_results.py
@@ -744,6 +744,7 @@ class TestImportLogFile:
         that invariant: 500 writer appends run alongside a hot updater looping
         on sidecar writes, and every append must survive.
         """
+        import asyncio
         import threading
         import time
 
@@ -751,7 +752,7 @@ class TestImportLogFile:
 
         from sift_client._internal.low_level_wrappers._test_results_log import (
             LogTracking,
-            _log_request_to_file_sync,
+            log_request_to_file,
         )
 
         log_file = tmp_path / "race.jsonl"
@@ -761,8 +762,13 @@ class TestImportLogFile:
         request = CreateTestReportRequest()
 
         def writer() -> None:
-            for i in range(n_appends):
-                _log_request_to_file_sync(log_file, "CreateTestReport", request, response_id=str(i))
+            async def append_all() -> None:
+                for i in range(n_appends):
+                    await log_request_to_file(
+                        log_file, "CreateTestReport", request, response_id=str(i)
+                    )
+
+            asyncio.run(append_all())
 
         def updater() -> None:
             tracking = LogTracking(last_uploaded_line=0)
@@ -1085,7 +1091,8 @@ class TestEndToEndLogFileRouting:
         from sift.test_reports.v1.test_reports_pb2 import UpdateTestReportRequest
 
         from sift_client._internal.low_level_wrappers._test_results_log import (
-            iter_log_data_lines,
+            _read_log_lines,
+            parse_log_data_lines,
         )
         from sift_client.util.metadata import metadata_proto_to_dict
 
@@ -1114,7 +1121,7 @@ class TestEndToEndLogFileRouting:
         # Find the UpdateTestReport line and decode it the same way replay does.
         update_entries = [
             (rt, rid, js)
-            for rt, rid, js in iter_log_data_lines(log_file)
+            for rt, rid, js in parse_log_data_lines(await _read_log_lines(log_file))
             if rt == "UpdateTestReport"
         ]
         assert len(update_entries) == 1

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "types-requests~=2.25",
     "googleapis-common-protos>=1.60",
     "protoc-gen-openapiv2>=0.0.1",
-    "filelock~=3.13",
+    "filelock~=3.15",
 ]
 
 [project.urls]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -4544,7 +4544,7 @@ requires-dist = [
     { name = "cffi", marker = "extra == 'docs-build'", specifier = "~=1.14" },
     { name = "cffi", marker = "extra == 'openssl'", specifier = "~=1.14" },
     { name = "eval-type-backport", specifier = "~=0.2" },
-    { name = "filelock", specifier = "~=3.13" },
+    { name = "filelock", specifier = "~=3.15" },
     { name = "googleapis-common-protos", specifier = ">=1.60" },
     { name = "griffe-pydantic", marker = "python_full_version >= '3.10' and extra == 'docs'", specifier = "==1.3.1" },
     { name = "griffe-pydantic", marker = "python_full_version >= '3.10' and extra == 'docs-build'", specifier = "==1.3.1" },


### PR DESCRIPTION
## Summary

The test-results offline-log path acquired a file lock with no timeout on the shared event-loop thread; a contended or stale lock froze the loop and every synchronous API call hung indefinitely.

This change moves the log helpers to `filelock.AsyncFileLock` (floor raised to `~=3.15`):

- Lock waiting is cooperative, so a stuck lock parks only the waiting call, never the event loop.
- The wait is bounded at 60s and raises `TimeoutError` instead of hanging (the lib default waits forever).
- `run_in_executor=False` makes acquisition cancel-safe; a cancelled task could otherwise strand the lock for the process lifetime.

## Test plan

- Writer and reader fail fast with `TimeoutError` while the lock is held.
- Unrelated coroutines still complete while a call waits on the held lock.
- Cancels never strand the lock (pins `run_in_executor=False`).
- Read/parse round trip and the 500-append race test cover the data path.
- Passes local integration tests
