### PR TITLE
python(feat): add audit logging to pytest plugin

### DIFF
--- a/.github/workflows/python_ci.yaml
+++ b/.github/workflows/python_ci.yaml
@@ -136,6 +136,7 @@ jobs:
       #     SIFT_GRPC_URI: ${{ vars.SIFT_GRPC_URI }}
       #     SIFT_REST_URI: ${{ vars.SIFT_REST_URI }}
       #     SIFT_API_KEY: ${{ secrets.SIFT_API_KEY }}
+      #     SIFT_REPORT_TEST_SYSTEM_NAME: github-actions
       #   run: |
       #     uv run --python ${{ matrix.python-version }} --no-project --with-editable '.[dev-all]' pytest -m "integration"
 

--- a/python/docs/guides/pytest_plugin/configuration.md
+++ b/python/docs/guides/pytest_plugin/configuration.md
@@ -116,7 +116,8 @@ def sift_client() -> SiftClient:
 
 | Name | Kind | Scope | Purpose |
 |---|---|---|---|
-| `report_context` | fixture (autouse) | session | The `ReportContext` backing the run's `TestReport`. Use it to attach metadata or open ad-hoc steps. |
+| `report_context` | fixture (autouse) | session | The `ReportContext` backing the run's `TestReport`. Use it to open ad-hoc steps. |
+| `sift_report_metadata` | fixture | session | Returns `{}` by default. Override in your conftest to add runtime report metadata; merged over the `[tool.sift.pytest.report.metadata]` table. |
 | `step` | fixture (autouse) | function | A `NewStep` created for the current test function. Exposes `measure*`, `substep`, `report_outcome`, `pytest_fail_if_step_failed`, and `current_step`. |
 | `_sift_parents` | internal fixture (autouse) | function | Resolves the report-tree parents for the current test: a parent step for each `pytest.Package`, `pytest.Module`, and `pytest.Class` ancestor, then one per `@pytest.mark.parametrize` axis (and fixture parametrization) nested inside them. Parents are created once and reused across tests in any order, so test execution order is never changed. Each layer is gated independently; see [settings reference](#settings-reference). |
 | `client_has_connection` | fixture | session | Calls `sift_client.ping.ping()`; consulted by `report_context` at session start in online mode (the default). Override to skip the ping or use a different reachability signal. |
@@ -176,7 +177,7 @@ suggestion, so typos like `SIFT_REPORT_SERIALNUM` surface immediately.
 | Operator running the test. Defaults to the OS user. | `[tool.sift.pytest.report] system_operator` | `SIFT_REPORT_SYSTEM_OPERATOR` |
 | Serial number of the unit under test. | `[tool.sift.pytest.report] serial_number` | `SIFT_REPORT_SERIAL_NUMBER` |
 | Part number of the unit under test. | `[tool.sift.pytest.report] part_number` | `SIFT_REPORT_PART_NUMBER` |
-| Free-form report metadata, as a TOML table of scalar values. For dynamic per-run keys, attach them in conftest via the report_context fixture. | `[tool.sift.pytest.report.metadata]` (table) | — |
+| Free-form report metadata, as a TOML table of scalar values. For dynamic per-run keys, override the sift_report_metadata fixture in conftest. | `[tool.sift.pytest.report.metadata]` (table) | — |
 <!-- END settings-reference -->
 
 ### Quick-start examples
@@ -312,9 +313,27 @@ lane     = 2          # ints, floats, and bools come through with their TOML typ
 verbose  = true
 ```
 
-For per-run dynamic entries (CI build IDs, cycling serial numbers), attach them
-in your `conftest.py` through the `report_context` fixture rather than the TOML
-table.
+For per-run dynamic entries the static table can't express (CI build IDs, SDK or
+Python version, cycling serial numbers), override the `sift_report_metadata`
+fixture in your `conftest.py`. It returns `{}` by default; whatever you return
+merges over the TOML table:
+
+```python title="conftest.py — runtime metadata, additive to the TOML table"
+import os
+from importlib.metadata import version
+
+
+@pytest.fixture(scope="session")
+def sift_report_metadata() -> dict[str, str | float | bool]:
+    return {
+        "environment": "ci" if os.environ.get("CI") else "local",
+        "sdk_version": version("sift_stack_py"),
+    }
+```
+
+The plugin resolves this fixture only while building the report, so it never
+forces a report to be created. A run with the Sift gate off (a plain unit suite)
+never calls it.
 
 Nested tables, lists, and `null` values in
 `[tool.sift.pytest.report.metadata]` are skipped with a warning since the

--- a/python/docs/guides/pytest_plugin/configuration.md
+++ b/python/docs/guides/pytest_plugin/configuration.md
@@ -146,6 +146,7 @@ suggestion, so typos like `SIFT_REPORT_SERIALNUM` surface immediately.
 | Setting | CLI flag | Ini (`[tool.pytest.ini_options]`) |
 |---|---|---|
 | Path to the JSONL log of create/update calls (path \| true \| false \| none). | `--sift-log-file` | `sift_log_file` |
+| DEBUG-level audit trace of plugin behavior (path \| true \| false). On by default to a temp file, with warnings echoed to stdout; set a path to pin the file, or false to disable. | `--sift-audit-log` | `sift_audit_log` |
 | Capture git repo/branch/commit on the report. | `--no-sift-git-metadata` | `sift_git_metadata` |
 | Skip the session-start ping; route create/update through the JSONL log. | `--sift-offline` | `sift_offline` |
 | Disable Sift entirely (no API calls, no log file). Supersedes --sift-offline. | `--sift-disabled` | `sift_disabled` |

--- a/python/docs/guides/pytest_plugin/index.md
+++ b/python/docs/guides/pytest_plugin/index.md
@@ -115,6 +115,34 @@ Every pytest outcome (pass, assertion failure, exception, skip, xfail, hard
 exit) maps to a `TestStatus`, and failures roll up to the parent steps and the
 report. See [Pass/Fail Behavior](pass_fail_behavior.md).
 
+## Getting support
+
+Every run writes a DEBUG audit trace (resolved settings, connection check, step
+open/close, replay activity) on by default, so a misbehaving run is already
+recorded and you don't have to reproduce it. The path prints in the `audit log`
+section of the end-of-run summary:
+
+```text
+--------------------------------- audit log ----------------------------------
+File: /tmp/sift_test_results/ab12cd/ab12cd-audit.log
+Replay: /tmp/sift_test_results/ab12cd/ab12cd-audit.replay.log
+```
+
+`File` is the main-process trace; `Replay` (online mode only) is the background
+upload worker's sibling file. By default both share a per-session directory with
+the JSONL log of every create/update call (`/tmp/sift_test_results/ab12cd/`
+above). When you open a support request with Sift, zip that directory and attach
+it. The contents are safe to share since the only secret, the API key, is
+redacted.
+
+Pin the trace to a known path or turn it off with `--sift-audit-log` (see
+[Configuration & Defaults](configuration.md)):
+
+```bash
+pytest --sift-audit-log=./sift-audit.log   # pin to a known path
+pytest --sift-audit-log=false              # disable
+```
+
 ## Try the runnable demo
 
 The [Pytest Plugin Quickstart](../../examples/pytest_plugin_quickstart.md) walks

--- a/python/examples/pytest_plugin/pyproject.toml
+++ b/python/examples/pytest_plugin/pyproject.toml
@@ -24,7 +24,7 @@
 name = "pytest-plugin demo ({count} tests) {timestamp}"
 # Grouping key across runs (same placeholders available). Omit to default to
 # {target} (what ran).
-test_case = "pytest-plugin-demo {git_branch}"
+test_case = "pytest-plugin-demo"
 
 [tool.sift.pytest.report.metadata]
 # Free-form key/value metadata stamped on every report. Values keep their TOML

--- a/python/lib/sift_client/_internal/low_level_wrappers/_test_results_log.py
+++ b/python/lib/sift_client/_internal/low_level_wrappers/_test_results_log.py
@@ -40,6 +40,7 @@ Ad-hoc writers to the same path are not protected.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 from dataclasses import dataclass, field
@@ -49,8 +50,12 @@ from typing import TYPE_CHECKING, Any, Generator
 from filelock import FileLock
 from google.protobuf import json_format
 
+from sift_client._internal.pytest_plugin.audit_log import log_event
+
 if TYPE_CHECKING:
     from sift_client.sift_types.test_report import TestMeasurement, TestReport, TestStep
+
+logger = logging.getLogger(__name__)
 
 
 def _client_version() -> str:
@@ -219,6 +224,9 @@ def iter_log_data_lines(
             continue
         match = line_pattern.match(line)
         if not match:
+            log_event(
+                logger, logging.WARNING, "log.parse_error", line=data_line_count + 1, text=line
+            )
             raise ValueError(f"Invalid log line: {line}")
         data_line_count += 1
         if data_line_count <= start_line:

--- a/python/lib/sift_client/_internal/low_level_wrappers/test_results.py
+++ b/python/lib/sift_client/_internal/low_level_wrappers/test_results.py
@@ -48,6 +48,7 @@ from sift_client._internal.low_level_wrappers._test_results_log import (
     log_request_to_file,
 )
 from sift_client._internal.low_level_wrappers.base import DEFAULT_PAGE_SIZE, LowLevelClientBase
+from sift_client._internal.pytest_plugin.audit_log import log_event
 from sift_client.sift_types.test_report import (
     TestMeasurement,
     TestMeasurementCreate,
@@ -1214,17 +1215,44 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         for request_type, response_id, json_str in iter_log_data_lines(
             log_path, start_line=tracking.last_uploaded_line
         ):
-            await self._import_entry(
-                request_type,
-                response_id,
-                json_str,
-                simulate=False,
-                id_map=id_map,
-                state=state,
-            )
+            line_number = tracking.last_uploaded_line + 1
+            try:
+                await self._import_entry(
+                    request_type,
+                    response_id,
+                    json_str,
+                    simulate=False,
+                    id_map=id_map,
+                    state=state,
+                )
+            except Exception as exc:
+                # Surface which line/entity failed before the line is retried
+                # next tick (last_uploaded_line is not advanced on failure).
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    "replay.error",
+                    line=line_number,
+                    type=request_type,
+                    error=repr(exc),
+                )
+                raise
 
             tracking.last_uploaded_line += 1
             tracking.save(log_path)
+            # One line per uploaded entity: what was sent, the sim->real id
+            # mapping (creates only), and the sidecar cursor + id-map size after
+            # the save so a reader can follow exactly what reached the server.
+            log_event(
+                logger,
+                logging.DEBUG,
+                "replay.upload",
+                type=request_type,
+                line=tracking.last_uploaded_line,
+                sim_id=response_id or "-",
+                real_id=id_map.get(response_id, "-") if response_id else "-",
+                idmap=len(id_map),
+            )
 
         # On a resume tick the CreateTestReport line was consumed on an earlier
         # tick, so state.report is expected to be None; the report already exists

--- a/python/lib/sift_client/_internal/low_level_wrappers/test_results.py
+++ b/python/lib/sift_client/_internal/low_level_wrappers/test_results.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import uuid
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar, cast
 
 from google.protobuf import json_format
 from sift.test_reports.v1.test_reports_pb2 import (
@@ -70,6 +70,20 @@ logger = logging.getLogger(__name__)
 
 
 _EntityT = TypeVar("_EntityT", TestReport, TestStep, TestMeasurement)
+
+
+class _EntryIds(NamedTuple):
+    """The entity a replayed log entry acted on, for the audit trace.
+
+    ``sim_id`` is the simulated ID recorded in the log; ``real_id`` is the
+    server-assigned ID it resolved to. For a create both come from the new
+    entity; for an update both identify the target being mutated, so the
+    ``replay.upload`` line names which step/report/measurement it touched
+    instead of leaving the columns blank.
+    """
+
+    sim_id: str | None = None
+    real_id: str | None = None
 
 
 class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
@@ -951,13 +965,17 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         simulate: bool,
         id_map: dict[str, str],
         state: _ReplayState,
-    ) -> None:
+    ) -> _EntryIds:
         """Process a single log entry, updating *state* in place.
 
         When *simulate* is True the create/update methods return simulated
         responses (no network call).  When False they issue real gRPC calls.
         *id_map* is updated so that subsequent entries can remap IDs that
         were generated during the original simulation run.
+
+        Returns the ``(sim_id, real_id)`` the entry acted on so the caller can
+        record which entity reached the server; an unhandled type yields empty
+        IDs.
         """
         handlers = {
             "CreateTestReport": self._replay_create_report,
@@ -970,8 +988,8 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         }
         handler = handlers.get(request_type)
         if handler is None:
-            return
-        await handler(json_str, response_id, simulate=simulate, id_map=id_map, state=state)
+            return _EntryIds()
+        return await handler(json_str, response_id, simulate=simulate, id_map=id_map, state=state)
 
     @staticmethod
     def _map_id(id_map: dict[str, str], sid: str) -> str:
@@ -986,12 +1004,13 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         simulate: bool,
         id_map: dict[str, str],
         state: _ReplayState,
-    ) -> None:
+    ) -> _EntryIds:
         request = CreateTestReportRequest()
         json_format.Parse(json_str, request)
         state.report = await self.create_test_report(request=request, simulate=simulate)
         if response_id:
             id_map[response_id] = state.report._id_or_error
+        return _EntryIds(response_id, state.report._id_or_error)
 
     async def _replay_create_step(
         self,
@@ -1001,7 +1020,7 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         simulate: bool,
         id_map: dict[str, str],
         state: _ReplayState,
-    ) -> None:
+    ) -> _EntryIds:
         request = CreateTestStepRequest()
         json_format.Parse(json_str, request)
         request.test_step.test_report_id = self._map_id(id_map, request.test_step.test_report_id)
@@ -1014,6 +1033,7 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
             id_map[response_id] = step._id_or_error
         state.steps_by_id[step._id_or_error] = step
         state.steps_order.append(step._id_or_error)
+        return _EntryIds(response_id, step._id_or_error)
 
     async def _replay_create_measurement(
         self,
@@ -1023,7 +1043,7 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         simulate: bool,
         id_map: dict[str, str],
         state: _ReplayState,
-    ) -> None:
+    ) -> _EntryIds:
         request = CreateTestMeasurementRequest()
         json_format.Parse(json_str, request)
         request.test_measurement.test_step_id = self._map_id(
@@ -1034,6 +1054,7 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
             id_map[response_id] = measurement._id_or_error
         state.measurements_by_id[measurement._id_or_error] = measurement
         state.measurements_order.append(measurement._id_or_error)
+        return _EntryIds(response_id, measurement._id_or_error)
 
     async def _replay_create_measurements(
         self,
@@ -1043,12 +1064,13 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         simulate: bool,
         id_map: dict[str, str],
         state: _ReplayState,
-    ) -> None:
+    ) -> _EntryIds:
         request = CreateTestMeasurementsRequest()
         json_format.Parse(json_str, request)
         for tm in request.test_measurements:
             tm.test_step_id = self._map_id(id_map, tm.test_step_id)
         original_ids = response_id.split(",") if response_id else []
+        created_ids: list[str] = []
         if simulate:
             # Batch endpoint has no simulate path; fan out to per-measurement simulate calls.
             for i, tm_proto in enumerate(request.test_measurements):
@@ -1058,11 +1080,17 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
                     id_map[original_ids[i]] = meas._id_or_error
                 state.measurements_by_id[meas._id_or_error] = meas
                 state.measurements_order.append(meas._id_or_error)
+                created_ids.append(meas._id_or_error)
         else:
             _, real_ids = await self.create_test_measurements(request=request)
             for i, real_id in enumerate(real_ids):
                 if i < len(original_ids):
                     id_map[original_ids[i]] = real_id
+                created_ids.append(real_id)
+        # Batch line covers many measurements; comma-join both sides so the
+        # audit row still names every entity (fields are space-free, so commas
+        # keep it one token).
+        return _EntryIds(response_id, ",".join(created_ids) or None)
 
     async def _replay_update_report(
         self,
@@ -1072,12 +1100,12 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         simulate: bool,
         id_map: dict[str, str],
         state: _ReplayState,
-    ) -> None:
+    ) -> _EntryIds:
         request = UpdateTestReportRequest()
         json_format.Parse(json_str, request)
-        request.test_report.test_report_id = self._map_id(
-            id_map, request.test_report.test_report_id
-        )
+        orig_report_id = request.test_report.test_report_id
+        mapped_report_id = self._map_id(id_map, orig_report_id)
+        request.test_report.test_report_id = mapped_report_id
         # Batch/simulate replays the whole log in order, so a missing report means
         # the log is malformed. Incremental replay may have created the report on an
         # earlier tick (its real ID lives in id_map), so state.report is legitimately
@@ -1087,6 +1115,7 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         state.report = await self.update_test_report(
             request=request, simulate=simulate, existing=state.report
         )
+        return _EntryIds(orig_report_id or None, mapped_report_id or None)
 
     async def _replay_update_step(
         self,
@@ -1096,7 +1125,7 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         simulate: bool,
         id_map: dict[str, str],
         state: _ReplayState,
-    ) -> None:
+    ) -> _EntryIds:
         request = UpdateTestStepRequest()
         json_format.Parse(json_str, request)
         orig_step_id = request.test_step.test_step_id
@@ -1110,6 +1139,7 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         )
         if mapped_step_id in state.steps_by_id:
             state.steps_by_id[mapped_step_id] = updated_step
+        return _EntryIds(orig_step_id or None, mapped_step_id or None)
 
     async def _replay_update_measurement(
         self,
@@ -1119,7 +1149,7 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         simulate: bool,
         id_map: dict[str, str],
         state: _ReplayState,
-    ) -> None:
+    ) -> _EntryIds:
         request = UpdateTestMeasurementRequest()
         json_format.Parse(json_str, request)
         orig_meas_id = request.test_measurement.measurement_id
@@ -1133,6 +1163,7 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         )
         if mapped_meas_id in state.measurements_by_id:
             state.measurements_by_id[mapped_meas_id] = updated_meas
+        return _EntryIds(orig_meas_id or None, mapped_meas_id or None)
 
     # ------------------------------------------------------------------
     # Batch replay (default)
@@ -1217,7 +1248,7 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
         ):
             line_number = tracking.last_uploaded_line + 1
             try:
-                await self._import_entry(
+                entry_ids = await self._import_entry(
                     request_type,
                     response_id,
                     json_str,
@@ -1240,17 +1271,18 @@ class TestResultsLowLevelClient(LowLevelClientBase, WithGrpcClient):
 
             tracking.last_uploaded_line += 1
             tracking.save(log_path)
-            # One line per uploaded entity: what was sent, the sim->real id
-            # mapping (creates only), and the sidecar cursor + id-map size after
-            # the save so a reader can follow exactly what reached the server.
+            # One line per uploaded entity: what was sent, the sim->real id of
+            # the entity it acted on (the new entity for a create, the target
+            # for an update), and the sidecar cursor + id-map size after the
+            # save so a reader can follow exactly what reached the server.
             log_event(
                 logger,
                 logging.DEBUG,
                 "replay.upload",
                 type=request_type,
                 line=tracking.last_uploaded_line,
-                sim_id=response_id or "-",
-                real_id=id_map.get(response_id, "-") if response_id else "-",
+                sim_id=entry_ids.sim_id or "-",
+                real_id=entry_ids.real_id or "-",
                 idmap=len(id_map),
             )
 

--- a/python/lib/sift_client/_internal/pytest_plugin/audit_log.py
+++ b/python/lib/sift_client/_internal/pytest_plugin/audit_log.py
@@ -1,0 +1,237 @@
+"""DEBUG audit trace for the pytest plugin (file) plus WARNING echo (stdout).
+
+On by default: every session attaches two handlers to the ``sift_client`` root
+logger so plugin-behavior modules AND high-value SDK call sites land in one file
+(a temp file unless ``--sift-audit-log=<path>`` pins one), with warnings also
+echoed to stdout. Pass ``--sift-audit-log=false`` (or set ``sift_audit_log =
+"false"``) to turn it off. The replay subprocess gets its own sibling file via
+``replay_audit_path``.
+
+Handlers are removed at session end (``pytest_unconfigure`` ->
+``detach_audit_handlers``) so a process that runs many pytest sessions — the
+plugin's own test suite drives nested in-process sessions — doesn't accumulate
+handlers or leak one session's file into the next.
+
+TODO: levels are fixed (DEBUG file / WARNING stdout) and output is plain text.
+A configurable level, JSON lines, or rotation are follow-ups gated on real need.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import pytest
+
+ROOT_LOGGER = "sift_client"
+# Columnar line for easy parsing: fixed-width timestamp, level, and namespace
+# columns, then the message — which every plugin call starts with a
+# left-justified ``EVENT_WIDTH`` event token followed by space-separated
+# key=value fields (incl. the full test ``path=``). Fields never contain spaces
+# (lists are ``/``-joined, free text is quoted), so the line tokenizes cleanly
+# on whitespace then ``=``.
+FILE_FORMAT = "%(asctime)s %(levelname)-7s %(namespace)-34s %(message)s"
+STDOUT_FORMAT = "Sift audit %(levelname)s: %(message)s"
+# Width the leading event token is padded to, so the key=value columns align.
+EVENT_WIDTH = 16
+# Tag so a re-entered pytest_configure (or both processes) doesn't double-attach.
+HANDLER_TAG = "sift_audit"
+
+
+def _fmt_value(value: object) -> str:
+    """Render one field value: bare when safe, quoted when it would break tokenizing."""
+    if isinstance(value, str):
+        return repr(value) if value == "" or any(c in value for c in " \t=") else value
+    return str(value)
+
+
+def log_event(logger: logging.Logger, level: int, event: str, **fields: object) -> None:
+    """Emit one columnar audit line: ``<event padded> key=value key=value``.
+
+    Centralizes the event-token padding and value quoting so call sites read as
+    ``log_event(logger, logging.DEBUG, "step.open", name=…, path=…)``. Guarded by
+    ``isEnabledFor`` so nothing is formatted when audit logging is off.
+    """
+    if not logger.isEnabledFor(level):
+        return
+    body = " ".join(f"{key}={_fmt_value(value)}" for key, value in fields.items())
+    logger.log(level, "%-*s %s", EVENT_WIDTH, event, body)
+
+
+class ColumnFormatter(logging.Formatter):
+    """Formatter for the columnar file log.
+
+    Adds a ``namespace`` field (the logger name with the redundant
+    ``sift_client.`` prefix trimmed) as its own aligned column, without mutating
+    ``record.name`` — other handlers (e.g. pytest's log capture) see the record
+    unchanged.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        name = record.name
+        record.namespace = name[len("sift_client.") :] if name.startswith("sift_client.") else name
+        return super().format(record)
+
+
+def replay_audit_path(main_path: Path) -> Path:
+    """Sibling path for the replay subprocess: ``foo.log`` -> ``foo.replay.log``."""
+    return main_path.with_suffix(".replay" + main_path.suffix)
+
+
+def audit_disabled(value: object) -> bool:
+    """Whether audit logging is explicitly turned off.
+
+    Default on: only ``False`` / ``"false"`` / ``"none"`` disables. Anything
+    else — unset, ``"true"``, or a path — leaves it enabled.
+    """
+    if value is False:
+        return True
+    return isinstance(value, str) and value.strip().lower() in ("false", "none")
+
+
+def explicit_audit_path(value: object) -> Path | None:
+    """The file path the user pinned, or ``None`` to use a temp default.
+
+    ``"true"`` / ``"1"`` / unset all mean "enabled, no specific path", so the
+    caller falls back to :func:`default_audit_path`.
+    """
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if text.lower() in ("", "true", "1", "false", "none"):
+        return None
+    return Path(text)
+
+
+def default_audit_path() -> Path:
+    """A unique temp file for the default-on trace (mirrors the JSONL log default)."""
+    tmp = tempfile.NamedTemporaryFile(prefix="sift-audit-", suffix=".log", delete=False)
+    tmp.close()
+    return Path(tmp.name)
+
+
+def attach_file_handler(path: Path, *, root: str = ROOT_LOGGER) -> None:
+    """Attach an idempotent DEBUG FileHandler to ``root``. Shared by both processes."""
+    logger = logging.getLogger(root)
+    if any(
+        getattr(h, HANDLER_TAG, False) and isinstance(h, logging.FileHandler)
+        for h in logger.handlers
+    ):
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handler = logging.FileHandler(path, mode="w")
+    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(ColumnFormatter(FILE_FORMAT))
+    setattr(handler, HANDLER_TAG, True)
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    # Stop records bubbling to the root logger so pytest's log capture (caplog,
+    # "Captured log" sections, --log-cli) doesn't surface the plugin's own audit
+    # trace. Our handlers are attached directly here, so they still fire.
+    logger.propagate = False
+
+
+def configure_audit_logging(config: pytest.Config) -> Path | None:
+    """Set up audit logging for the main pytest process. On by default.
+
+    Returns the resolved file path (so the caller can thread the ``.replay``
+    sibling to the subprocess and surface paths in the terminal summary), or
+    ``None`` when audit logging is explicitly disabled.
+    """
+    from sift_client._internal.pytest_plugin.options import AUDIT_LOG_OPTION
+
+    raw = AUDIT_LOG_OPTION.resolve(config)
+    if audit_disabled(raw):
+        return None
+    path = explicit_audit_path(raw) or default_audit_path()
+    attach_file_handler(path)
+    logger = logging.getLogger(ROOT_LOGGER)
+    if not any(
+        getattr(h, HANDLER_TAG, False)
+        and isinstance(h, logging.StreamHandler)
+        and not isinstance(h, logging.FileHandler)
+        for h in logger.handlers
+    ):
+        # WARNING echo to stdout. Note: pytest captures stdout per-test, so
+        # mid-test warnings land in pytest's captured-output section;
+        # session-boundary warnings reach the terminal directly. The file is
+        # always the complete record.
+        stream = logging.StreamHandler(sys.stdout)
+        stream.setLevel(logging.WARNING)
+        stream.setFormatter(logging.Formatter(STDOUT_FORMAT))
+        setattr(stream, HANDLER_TAG, True)
+        logger.addHandler(stream)
+    return path
+
+
+def detach_audit_handlers(*, root: str = ROOT_LOGGER) -> None:
+    """Remove and close the audit handlers; reset the logger level.
+
+    Called from ``pytest_unconfigure`` so handlers don't outlive the session
+    that created them — important when one process runs many sessions (the
+    plugin's own test suite drives nested in-process pytester runs).
+    """
+    logger = logging.getLogger(root)
+    for handler in [h for h in logger.handlers if getattr(h, HANDLER_TAG, False)]:
+        handler.close()
+        logger.removeHandler(handler)
+    logger.setLevel(logging.NOTSET)
+    logger.propagate = True
+
+
+# Width the status column is right-aligned to in the rendered tree.
+_TREE_WIDTH = 64
+
+
+def render_report_tree(created_steps: list[Any], *, mode: str) -> str:
+    """Render the final step tree with statuses — the end-state validation view.
+
+    Reconstructs the parent/child structure from each step's dotted numeric
+    ``step_path`` (``"1"`` -> ``"1.1"`` -> ``"1.1.2"``), preserving creation
+    order, and renders an ASCII tree with a dotted leader to the final status.
+    Failed/errored steps are annotated with the first line of their
+    ``error_info`` when present, so a reader sees what went wrong inline.
+    """
+    header = f"Sift report tree ({mode} mode):"
+    if not created_steps:
+        return f"{header}\n(no steps recorded)"
+
+    by_path = {s.step_path: s for s in created_steps}
+    children: dict[str, list[Any]] = {}
+    roots: list[Any] = []
+    for step in created_steps:
+        parent_path = step.step_path.rpartition(".")[0]
+        if parent_path and parent_path in by_path:
+            children.setdefault(parent_path, []).append(step)
+        else:
+            roots.append(step)
+
+    lines = [header]
+
+    def walk(step: Any, prefix: str, is_last: bool, is_root: bool) -> None:
+        status = step.status.name if step.status is not None else "?"
+        if is_root:
+            # Roots are the trunk: no branch connector, children start at col 0.
+            head = f"{step.name} "
+            child_prefix = ""
+        else:
+            connector = "`- " if is_last else "|- "
+            head = f"{prefix}{connector}{step.name} "
+            child_prefix = prefix + ("   " if is_last else "|  ")
+        leader = "." * max(3, _TREE_WIDTH - len(head))
+        line = f"{head}{leader} {status}"
+        error = getattr(step, "error_info", None)
+        if status in ("FAILED", "ERROR") and error is not None and error.error_message:
+            line += f"   <- {error.error_message.strip().splitlines()[0]}"
+        lines.append(line)
+        kids = children.get(step.step_path, [])
+        for index, kid in enumerate(kids):
+            walk(kid, child_prefix, index == len(kids) - 1, is_root=False)
+
+    for index, root in enumerate(roots):
+        walk(root, "", index == len(roots) - 1, is_root=True)
+    return "\n".join(lines)

--- a/python/lib/sift_client/_internal/pytest_plugin/audit_log.py
+++ b/python/lib/sift_client/_internal/pytest_plugin/audit_log.py
@@ -107,8 +107,28 @@ def explicit_audit_path(value: object) -> Path | None:
     return Path(text)
 
 
-def default_audit_path() -> Path:
-    """A unique temp file for the default-on trace (mirrors the JSONL log default)."""
+def _make_session_dir() -> Path:
+    """Create and return ``<tmpdir>/sift_test_results/<random>/``.
+
+    All per-session temp artifacts (JSONL log, tracking sidecar, audit log,
+    replay audit log) land inside this directory so they're easy to locate and
+    clean up together. The random component comes from ``tempfile.mkdtemp`` —
+    the same OS-backed source used by ``NamedTemporaryFile``.
+    """
+    parent = Path(tempfile.gettempdir()) / "sift_test_results"
+    parent.mkdir(exist_ok=True)
+    return Path(tempfile.mkdtemp(dir=parent, prefix=""))
+
+
+def default_audit_path(session_dir: Path | None = None) -> Path:
+    """A unique temp file for the default-on trace.
+
+    When ``session_dir`` is provided the audit log is placed inside it as
+    ``<session_dir.name>-audit.log`` so all session artifacts share one dir.
+    Without it a standalone temp file is created (legacy / no-session-dir path).
+    """
+    if session_dir is not None:
+        return session_dir / f"{session_dir.name}-audit.log"
     tmp = tempfile.NamedTemporaryFile(prefix="sift-audit-", suffix=".log", delete=False)
     tmp.close()
     return Path(tmp.name)
@@ -135,19 +155,25 @@ def attach_file_handler(path: Path, *, root: str = ROOT_LOGGER) -> None:
     logger.propagate = False
 
 
-def configure_audit_logging(config: pytest.Config) -> Path | None:
+def configure_audit_logging(
+    config: pytest.Config, *, session_dir: Path | None = None
+) -> Path | None:
     """Set up audit logging for the main pytest process. On by default.
 
     Returns the resolved file path (so the caller can thread the ``.replay``
     sibling to the subprocess and surface paths in the terminal summary), or
     ``None`` when audit logging is explicitly disabled.
+
+    When ``session_dir`` is provided and the audit path is at its default
+    (not explicitly set by the user), the audit log is placed inside the
+    session dir so all temp artifacts land together.
     """
     from sift_client._internal.pytest_plugin.options import AUDIT_LOG_OPTION
 
     raw = AUDIT_LOG_OPTION.resolve(config)
     if audit_disabled(raw):
         return None
-    path = explicit_audit_path(raw) or default_audit_path()
+    path = explicit_audit_path(raw) or default_audit_path(session_dir=session_dir)
     attach_file_handler(path)
     logger = logging.getLogger(ROOT_LOGGER)
     if not any(

--- a/python/lib/sift_client/_internal/pytest_plugin/options.py
+++ b/python/lib/sift_client/_internal/pytest_plugin/options.py
@@ -398,7 +398,7 @@ METADATA_OPTION = Option(
     name="metadata",
     category=CAT_REPORT,
     help="Free-form report metadata, as a TOML table of scalar values. For "
-    "dynamic per-run keys, attach them in conftest via the report_context fixture.",
+    "dynamic per-run keys, override the sift_report_metadata fixture in conftest.",
     toml=("pytest", "report", "metadata"),
     merge=True,
 )

--- a/python/lib/sift_client/_internal/pytest_plugin/options.py
+++ b/python/lib/sift_client/_internal/pytest_plugin/options.py
@@ -8,12 +8,17 @@ setting is added or changed in one place instead of wired up across several.
 
 from __future__ import annotations
 
+import logging
 import os
 import warnings
 from dataclasses import dataclass
 from typing import Any
 
 import pytest
+
+from sift_client._internal.pytest_plugin.audit_log import log_event
+
+logger = logging.getLogger(__name__)
 
 from sift_client._internal.pyproject_config import load_tool_sift
 
@@ -114,32 +119,41 @@ class Option:
         only returns ini values for booleans (always meaningful), non-empty
         strings, and non-empty lists.
         """
+        return self.resolve_with_source(config)[0]
+
+    def resolve_with_source(self, config: pytest.Config | None) -> tuple[Any, str]:
+        """Like :meth:`resolve`, but also reports which surface set the value.
+
+        Returns ``(value, source)`` where ``source`` is one of
+        ``env``/``cli``/``ini``/``toml``, or ``default`` when nothing set it
+        (``value`` is then ``None``). Used by the audit log's settings snapshot.
+        """
         if self.env:
             env_value = os.getenv(self.env)
             if env_value not in (None, ""):
-                return env_value
+                return env_value, "env"
         if config is None:
-            return None
+            return None, "default"
         if self.cli:
             cli_value = config.getoption(self.cli_dest, default=None)
             if cli_value is not None:
-                return cli_value
+                return cli_value, "cli"
         if self.ini:
             try:
                 ini_value = config.getini(self.ini)
             except (KeyError, ValueError):
                 ini_value = None
             if isinstance(ini_value, bool):
-                return ini_value
+                return ini_value, "ini"
             if isinstance(ini_value, str) and ini_value:
-                return ini_value
+                return ini_value, "ini"
             if isinstance(ini_value, list) and ini_value:
-                return ini_value
+                return ini_value, "ini"
         if self.toml:
             toml_value = _walk_toml(tool_sift(config), self.toml)
             if toml_value not in (None, ""):
-                return toml_value
-        return None
+                return toml_value, "toml"
+        return None, "default"
 
     def resolve_merged(self, config: pytest.Config | None) -> dict[str, str | float | bool]:
         """For ``merge=True`` dict-shape settings: the free-form TOML table.
@@ -210,6 +224,15 @@ LOG_FILE_OPTION = Option(
     help="Path to the JSONL log of create/update calls (path | true | false | none).",
     cli="--sift-log-file",
     ini="sift_log_file",
+)
+AUDIT_LOG_OPTION = Option(
+    name="audit_log",
+    category=CAT_BEHAVIOR,
+    help="DEBUG-level audit trace of plugin behavior (path | true | false). On by "
+    "default to a temp file, with warnings echoed to stdout; set a path to pin the "
+    "file, or false to disable.",
+    cli="--sift-audit-log",
+    ini="sift_audit_log",
 )
 GIT_METADATA_OPTION = Option(
     name="git_metadata",
@@ -382,6 +405,7 @@ METADATA_OPTION = Option(
 
 PLUGIN_OPTIONS: tuple[Option, ...] = (
     LOG_FILE_OPTION,
+    AUDIT_LOG_OPTION,
     GIT_METADATA_OPTION,
     OFFLINE_OPTION,
     DISABLED_OPTION,
@@ -403,6 +427,21 @@ PLUGIN_OPTIONS: tuple[Option, ...] = (
     PART_NUMBER_OPTION,
     METADATA_OPTION,
 )
+
+
+def resolved_settings(config: pytest.Config | None) -> list[tuple[str, Any, str]]:
+    """Every option's resolved ``(name, value, source)`` for the audit snapshot.
+
+    The API key is the only secret in the registry; its value is redacted to
+    ``"***"`` so the snapshot is safe to write to the log file.
+    """
+    rows: list[tuple[str, Any, str]] = []
+    for opt in PLUGIN_OPTIONS:
+        value, source = opt.resolve_with_source(config)
+        if opt.name == "api_key" and value:
+            value = "***"
+        rows.append((opt.name, value, source))
+    return rows
 
 
 def register_options(parser: pytest.Parser) -> None:
@@ -521,6 +560,14 @@ def warn_on_unknown_env_vars() -> None:
             continue
         close = difflib.get_close_matches(name, suggestion_pool, n=1, cutoff=0.6)
         hint = f" (did you mean `{close[0]}`?)" if close else ""
+        log_event(
+            logger,
+            logging.WARNING,
+            "config.unknown",
+            kind="env",
+            name=name,
+            suggestion=close[0] if close else "-",
+        )
         warnings.warn(
             f"Unknown SIFT_* env var `{name}`{hint}; ignored.",
             SiftPytestPluginWarning,
@@ -570,6 +617,14 @@ def warn_on_unknown_toml_keys(config: pytest.Config) -> None:
             ]
             close = difflib.get_close_matches(".".join(path), same_depth, n=1, cutoff=0.6)
             hint = f" (did you mean `tool.sift.{close[0]}`?)" if close else ""
+            log_event(
+                logger,
+                logging.WARNING,
+                "config.unknown",
+                kind="toml",
+                name=full_name,
+                suggestion=f"tool.sift.{close[0]}" if close else "-",
+            )
             warnings.warn(
                 f"Unknown sift config key `{full_name}`{hint}; ignored.",
                 SiftPytestPluginWarning,

--- a/python/lib/sift_client/_internal/pytest_plugin/report.py
+++ b/python/lib/sift_client/_internal/pytest_plugin/report.py
@@ -9,6 +9,7 @@ plugin's ``report_context`` fixture owns the module-level ``REPORT_CONTEXT``.
 
 from __future__ import annotations
 
+import logging
 import os
 import warnings
 from datetime import datetime, timezone
@@ -18,6 +19,7 @@ from typing import TYPE_CHECKING, Any, Generator
 import pytest
 
 from sift_client import SiftClient, SiftConnectionConfig
+from sift_client._internal.pytest_plugin.audit_log import log_event
 from sift_client._internal.pytest_plugin.modes import is_offline
 from sift_client._internal.pytest_plugin.options import (
     GIT_METADATA_OPTION,
@@ -46,6 +48,8 @@ from sift_client.util.test_results.context_manager import (
 
 if TYPE_CHECKING:
     from sift_client.util.test_results.context_manager import NewStep
+
+logger = logging.getLogger(__name__)
 
 
 def resolve_real_report_id(context: Any) -> str | None:
@@ -205,6 +209,40 @@ def resolve_initial_status(new_step: NewStep, item: pytest.Item) -> None:
     new_step._sift_managed_externally = True
 
 
+def describe_step_failure(new_step: NewStep) -> str:
+    """A short, human reason a step failed, for the audit log. Empty when none.
+
+    Prefers a named out-of-bounds measurement (the common test-failure cause),
+    then falls back to the first line of the step's ``error_info``.
+    """
+    failed = getattr(new_step, "_failed_measurements", [])
+    if failed:
+        extra = f" (and {len(failed) - 1} more)" if len(failed) > 1 else ""
+        return f"{failed[0]}{extra}"
+    step = new_step.current_step
+    if step is not None and step.error_info is not None and step.error_info.error_message:
+        return step.error_info.error_message.strip().splitlines()[0]
+    return ""
+
+
+def skip_or_xfail_reason(phase: Any) -> str:
+    """The skip/xfail reason text from a pytest phase, or empty when none.
+
+    xfail reasons ride on ``report.wasxfail``; plain skips store
+    ``(path, lineno, "Skipped: <reason>")`` in ``report.longrepr``.
+    """
+    if phase is None:
+        return ""
+    report = phase.report
+    wasxfail = getattr(report, "wasxfail", None)
+    if wasxfail:
+        return f"xfail: {wasxfail}"
+    longrepr = getattr(report, "longrepr", None)
+    if isinstance(longrepr, tuple) and len(longrepr) == 3:
+        return str(longrepr[2])
+    return ""
+
+
 def finalize_after_teardown(item: pytest.Item, teardown_report: pytest.TestReport) -> None:
     """Upgrade a closed step to FAILED when the teardown phase failed.
 
@@ -219,6 +257,14 @@ def finalize_after_teardown(item: pytest.Item, teardown_report: pytest.TestRepor
     if current_step is None:
         return
     if teardown_report.outcome == "failed" and current_step.status == TestStatus.PASSED:
+        log_event(
+            logger,
+            logging.WARNING,
+            "status",
+            path=item.nodeid,
+            pytest="teardown_failed",
+            sift="PASSED->FAILED",
+        )
         current_step.update({"status": TestStatus.FAILED})
         step.report_context.mark_step_failed_after_close(current_step)
 
@@ -314,6 +360,15 @@ def format_template(
     try:
         return template.format(**fields)
     except (KeyError, IndexError, ValueError) as exc:
+        log_event(
+            logger,
+            logging.WARNING,
+            "template.invalid",
+            option=option_label,
+            template=template,
+            error=repr(exc),
+            fallback=fallback,
+        )
         warnings.warn(
             f"Invalid {option_label} template {template!r} ({exc}); using fallback.",
             SiftPytestPluginWarning,
@@ -372,6 +427,9 @@ def report_context_impl(
     target = derive_target(request, args)
     command = "pytest " + " ".join(args) if args else "pytest"
     fields = build_template_fields(target, command, args, request)
+    # What each report_name / test_case ``{placeholder}`` resolved to; the
+    # resolved name/test_case themselves show on the ``report`` line.
+    log_event(logger, logging.DEBUG, "template", **fields)
     name_template = REPORT_NAME_OPTION.resolve(pytestconfig) or "{target} {timestamp}"
     name = format_template(
         name_template,
@@ -405,6 +463,12 @@ def report_context_impl(
     offline = False if disabled else is_offline(pytestconfig)
     log_file: str | Path | bool | None = False if disabled else resolve_log_file(pytestconfig)
     include_git_metadata = bool(GIT_METADATA_OPTION.resolve(pytestconfig))
+    # Local import avoids a circular import (pytest_plugin imports this module).
+    audit_log = None
+    if pytestconfig is not None:
+        from sift_client.pytest_plugin import SIFT_AUDIT_LOG_STASH_KEY
+
+        audit_log = pytestconfig.stash.get(SIFT_AUDIT_LOG_STASH_KEY, None)
     with ReportContext(
         sift_client,
         name=name,
@@ -417,7 +481,33 @@ def report_context_impl(
         include_git_metadata=include_git_metadata,
         replay_log_file=not (disabled or offline),
         metadata=report_metadata,
+        audit_log=audit_log,
     ) as context:
+        report = context.report
+        meta_kv = ",".join(f"{k}={v}" for k, v in (report.metadata or {}).items()) or "-"
+        log_event(
+            logger,
+            logging.INFO,
+            "report",
+            name=report.name,
+            test_case=report.test_case,
+            id=report.id_ or "-",
+            system=report.test_system_name or "-",
+            operator=report.system_operator or "-",
+            serial=report.serial_number or "-",
+            part=report.part_number or "-",
+            metadata=meta_kv,
+        )
+        # What actually happens with the JSONL log, not the raw setting: the
+        # effective path (temp or pinned), or "disabled", plus whether the
+        # background replay worker runs.
+        log_event(
+            logger,
+            logging.INFO,
+            "log_file",
+            path=context.log_file or "disabled",
+            replay=not (disabled or offline),
+        )
         try:
             yield context
         finally:
@@ -493,7 +583,37 @@ def step_impl(
         assertion_as_fail_not_error=False,
         parent=parent_step,
         push=True,
+        origin="step_impl",
+        source_path=node.nodeid,
     ) as new_step:
         node._sift_step = new_step
         yield new_step
         resolve_initial_status(new_step, node)
+    # One readable line per test, logged after __exit__ resolves the passing
+    # path (incl. pytest-passed-but-step-failed via a bad measurement), pairing
+    # the pytest outcome with the final Sift status and naming the cause on
+    # failure so a reader sees what went wrong.
+    call_phase = getattr(node, "_sift_phase_call", None)
+    setup_phase = getattr(node, "_sift_phase_setup", None)
+    phase = call_phase or setup_phase
+    final_step = new_step.current_step
+    status_name = final_step.status.name if final_step is not None else "IN_PROGRESS"
+    if call_phase is not None:
+        pytest_outcome = call_phase.report.outcome
+    elif setup_phase is not None:
+        pytest_outcome = setup_phase.report.outcome
+    else:
+        pytest_outcome = "not run"
+    duration = getattr(phase.report, "duration", None) if phase is not None else None
+    dur_ms = int(duration * 1000) if duration is not None else 0
+    failed = status_name in ("FAILED", "ERROR")
+    reason = describe_step_failure(new_step) if failed else skip_or_xfail_reason(phase)
+    fields: dict[str, object] = {
+        "path": node.nodeid,
+        "pytest": pytest_outcome,
+        "sift": status_name,
+        "dur": f"{dur_ms}ms",
+    }
+    if reason:
+        fields["reason"] = reason
+    log_event(logger, logging.DEBUG, "status", **fields)

--- a/python/lib/sift_client/_internal/pytest_plugin/report.py
+++ b/python/lib/sift_client/_internal/pytest_plugin/report.py
@@ -448,11 +448,13 @@ def report_context_impl(
         if test_case_template
         else target
     )
-    # Metadata starts from the [tool.sift.pytest.report.metadata] TOML table, and
-    # the auto-recorded pytest_command layers in last so the user can't
-    # accidentally overwrite it.
+    # Metadata starts from the [tool.sift.pytest.report.metadata] TOML table, then
+    # the sift_report_metadata fixture layers over it (runtime values the static
+    # table can't express), and the auto-recorded pytest_command layers in last so
+    # neither can overwrite it.
     report_metadata: dict[str, str | float | bool] = {
         **METADATA_OPTION.resolve_merged(pytestconfig),
+        **request.getfixturevalue("sift_report_metadata"),
         "pytest_command": command,
     }
     # Mode → ReportContext flags:

--- a/python/lib/sift_client/_internal/pytest_plugin/report.py
+++ b/python/lib/sift_client/_internal/pytest_plugin/report.py
@@ -462,6 +462,15 @@ def report_context_impl(
     disabled = sift_client._simulate
     offline = False if disabled else is_offline(pytestconfig)
     log_file: str | Path | bool | None = False if disabled else resolve_log_file(pytestconfig)
+    # When the log would use a default temp file and the plugin already created
+    # a session dir, pin the JSONL inside that dir so it lands alongside the
+    # audit log rather than having ReportContext mint a separate session dir.
+    if log_file is True and pytestconfig is not None:
+        from sift_client.pytest_plugin import SIFT_SESSION_DIR_STASH_KEY
+
+        plugin_session_dir = pytestconfig.stash.get(SIFT_SESSION_DIR_STASH_KEY, None)
+        if plugin_session_dir is not None:
+            log_file = plugin_session_dir / f"{plugin_session_dir.name}.jsonl"
     include_git_metadata = bool(GIT_METADATA_OPTION.resolve(pytestconfig))
     # Local import avoids a circular import (pytest_plugin imports this module).
     audit_log = None

--- a/python/lib/sift_client/_internal/pytest_plugin/steps.py
+++ b/python/lib/sift_client/_internal/pytest_plugin/steps.py
@@ -11,11 +11,13 @@ backstop for anything still open.
 
 from __future__ import annotations
 
+import logging
 import warnings
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
 import pytest
 
+from sift_client._internal.pytest_plugin.audit_log import log_event
 from sift_client._internal.pytest_plugin.modes import gate_enabled
 from sift_client._internal.pytest_plugin.options import (
     CLASS_STEP_OPTION,
@@ -23,6 +25,8 @@ from sift_client._internal.pytest_plugin.options import (
     PACKAGE_STEP_OPTION,
     PARAMETRIZE_NESTING_OPTION,
 )
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from typing import Callable

--- a/python/lib/sift_client/_internal/pytest_plugin/steps.py
+++ b/python/lib/sift_client/_internal/pytest_plugin/steps.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
 import pytest
 
-from sift_client._internal.pytest_plugin.audit_log import log_event
 from sift_client._internal.pytest_plugin.modes import gate_enabled
 from sift_client._internal.pytest_plugin.options import (
     CLASS_STEP_OPTION,

--- a/python/lib/sift_client/_internal/pytest_plugin/terminal.py
+++ b/python/lib/sift_client/_internal/pytest_plugin/terminal.py
@@ -202,30 +202,40 @@ def write_report_summary(
         if log_file is not None:
             terminalreporter.write_sep("-", "to upload to Sift")
             terminalreporter.write_line(f"  >> import-test-result-log {log_file}", cyan=True)
-        return
-
-    if not report_id:
-        # Incremental upload never mapped the report (the worker died before
-        # replaying the create), so there's no real report to link.
-        sift_kv(
-            terminalreporter,
-            "Report",
-            f"not uploaded — replay with: import-test-result-log {log_file}",
-            yellow=True,
-        )
-    elif report_url is not None:
-        sift_kv(terminalreporter, "Report", report_url, cyan=True)
     else:
-        sift_kv(
-            terminalreporter,
-            "Report",
-            f"id {report_id}  (set sift_app_url for a clickable link)",
-        )
+        if not report_id:
+            # Incremental upload never mapped the report (the worker died before
+            # replaying the create), so there's no real report to link.
+            sift_kv(
+                terminalreporter,
+                "Report",
+                f"not uploaded — replay with: import-test-result-log {log_file}",
+                yellow=True,
+            )
+        elif report_url is not None:
+            sift_kv(terminalreporter, "Report", report_url, cyan=True)
+        else:
+            sift_kv(
+                terminalreporter,
+                "Report",
+                f"id {report_id}  (set sift_app_url for a clickable link)",
+            )
 
-    if report_id and getattr(context, "replay_incomplete", False) and log_file is not None:
-        sift_kv(
-            terminalreporter,
-            "",
-            f"may be incomplete — finish with: import-test-result-log {log_file}",
-            yellow=True,
-        )
+        if report_id and getattr(context, "replay_incomplete", False) and log_file is not None:
+            sift_kv(
+                terminalreporter,
+                "",
+                f"may be incomplete — finish with: import-test-result-log {log_file}",
+                yellow=True,
+            )
+
+    # Audit log: its own section after the upload/report block. The main-process
+    # trace plus, online, the replay worker's sibling file.
+    audit_log = getattr(context, "audit_log", None)
+    if audit_log is not None:
+        from sift_client._internal.pytest_plugin.audit_log import replay_audit_path
+
+        terminalreporter.write_sep("-", "audit log")
+        sift_kv(terminalreporter, "File", str(audit_log))
+        if not offline:
+            sift_kv(terminalreporter, "Replay", str(replay_audit_path(audit_log)))

--- a/python/lib/sift_client/_tests/_internal/low_level_wrappers/test_incremental_replay.py
+++ b/python/lib/sift_client/_tests/_internal/low_level_wrappers/test_incremental_replay.py
@@ -10,6 +10,7 @@ offline -- unlike the end-to-end resume test, which needs the integration server
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
@@ -28,6 +29,10 @@ from sift_client.sift_types.test_report import (
     TestStep,
     TestStepCreate,
     TestStepType,
+)
+from sift_client.sift_types.test_report import (
+    # Aliased so pytest doesn't try to collect the `Test`-prefixed update model.
+    TestStepUpdate as StepUpdate,
 )
 
 T0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
@@ -141,3 +146,150 @@ async def test_resume_with_only_steps_does_not_require_report(tmp_path):
     # The report was created on the earlier tick, so this resume tick has no report.
     assert result.report is None
     assert len(result.steps) == 1
+
+
+@pytest.mark.asyncio
+async def test_replay_upload_log_names_update_target(tmp_path):
+    """The ``replay.upload`` line for an update carries the step it acted on.
+
+    Updates mint no new entity, so the audit line used to leave sim_id/real_id
+    blank. It now reports the target's simulated and remapped real IDs so a
+    reader can tell which step each update touched.
+    """
+    log_file = tmp_path / "upload_log.jsonl"
+    client = ResultsLowLevelClient(grpc_client=MagicMock())
+
+    # Build the log offline: create a report + step, then update the step.
+    report = await client.create_test_report(test_report=_report_create(), log_file=log_file)
+    step = await client.create_test_step(
+        test_step=TestStepCreate(
+            test_report_id=report.id_,
+            name="s1",
+            step_type=TestStepType.ACTION,
+            step_path="1",
+            status=TestStatus.IN_PROGRESS,
+            start_time=T0,
+            end_time=T0,
+        ),
+        log_file=log_file,
+    )
+    step_update = StepUpdate(status=TestStatus.PASSED)
+    step_update.resource_id = step.id_
+    await client.update_test_step(update=step_update, log_file=log_file)
+
+    # Full replay from line 0; stub the real RPCs the replay issues.
+    client.create_test_report = AsyncMock(return_value=_make_report("real-report"))
+    client.create_test_step = AsyncMock(return_value=_make_step("real-step"))
+    client.update_test_step = AsyncMock(return_value=_make_step("real-step"))
+
+    # Capture directly on the module logger: the Sift plugin sets propagate=False
+    # on the sift_client logger, so caplog's root handler wouldn't see the records.
+    module_logger = logging.getLogger("sift_client._internal.low_level_wrappers.test_results")
+    messages: list[str] = []
+    handler = logging.Handler()
+    handler.emit = lambda record: messages.append(record.getMessage())  # type: ignore[method-assign]
+    prior_level = module_logger.level
+    module_logger.addHandler(handler)
+    module_logger.setLevel(logging.DEBUG)
+    try:
+        await client.import_log_file(log_file, incremental=True)
+    finally:
+        module_logger.removeHandler(handler)
+        module_logger.setLevel(prior_level)
+
+    upload_lines = [m for m in messages if m.startswith("replay.upload")]
+    update_line = next(line for line in upload_lines if "type=UpdateTestStep" in line)
+    # Pre-fix this line read ``sim_id=- real_id=-``; now it names the target.
+    assert f"sim_id={step.id_}" in update_line
+    assert "real_id=real-step" in update_line
+
+
+# ---------------------------------------------------------------------------
+# Session directory grouping
+# ---------------------------------------------------------------------------
+
+
+def test_make_session_dir_layout(tmp_path, monkeypatch):
+    """``_make_session_dir`` creates ``<tmpdir>/sift_test_results/<random>/``.
+
+    The dir name is used as the shared prefix for all session artifacts.
+    """
+    import tempfile
+
+    from sift_client._internal.pytest_plugin.audit_log import _make_session_dir
+
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+    session_dir = _make_session_dir()
+    assert session_dir.parent == tmp_path / "sift_test_results"
+    assert session_dir.is_dir()
+    # Name is a non-empty random token from mkdtemp.
+    assert session_dir.name
+
+
+def test_make_session_dir_concurrent_calls_unique(tmp_path, monkeypatch):
+    """Each ``_make_session_dir`` call produces a distinct directory."""
+    import tempfile
+
+    from sift_client._internal.pytest_plugin.audit_log import _make_session_dir
+
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+    dirs = {_make_session_dir() for _ in range(5)}
+    assert len(dirs) == 5
+
+
+def test_cleanup_temp_log_removes_session_dir(tmp_path, monkeypatch):
+    """``_cleanup_temp_log`` removes the whole session dir when audit is off.
+
+    Session dir layout: ``<tmpdir>/sift_test_results/<random>/``. The JSONL,
+    its tracking sidecar, and any audit files in the dir are all removed.
+    """
+    import tempfile
+
+    from sift_client.scripts.import_test_result_log import _cleanup_temp_log
+
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+    session_dir = tmp_path / "sift_test_results" / "abc123"
+    session_dir.mkdir(parents=True)
+    log = session_dir / "abc123.jsonl"
+    tracking = session_dir / "abc123.jsonl.tracking"
+    audit = session_dir / "abc123-audit.log"
+    for f in (log, tracking, audit):
+        f.write_text("{}")
+
+    _cleanup_temp_log(str(log))
+
+    assert not session_dir.exists()
+
+
+def test_cleanup_temp_log_ignores_explicit_path(tmp_path, monkeypatch):
+    """``_cleanup_temp_log`` does not touch a log outside the temp dir."""
+    import tempfile
+
+    from sift_client.scripts.import_test_result_log import _cleanup_temp_log
+
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+    explicit_log = tmp_path.parent / "my_project_log.jsonl"
+    explicit_log.write_text("{}")
+    _cleanup_temp_log(str(explicit_log))
+    assert explicit_log.exists()
+    explicit_log.unlink()
+
+
+def test_cleanup_temp_log_legacy_flat_layout(tmp_path, monkeypatch):
+    """Legacy flat-temp layout: only the JSONL and its tracking sidecar are removed."""
+    import tempfile
+
+    from sift_client.scripts.import_test_result_log import _cleanup_temp_log
+
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+    log = tmp_path / "tmp12345.jsonl"
+    tracking = tmp_path / "tmp12345.jsonl.tracking"
+    other = tmp_path / "other_file.txt"
+    for f in (log, tracking, other):
+        f.write_text("{}")
+
+    _cleanup_temp_log(str(log))
+
+    assert not log.exists()
+    assert not tracking.exists()
+    assert other.exists()

--- a/python/lib/sift_client/_tests/pytest_plugin/test_configuration.py
+++ b/python/lib/sift_client/_tests/pytest_plugin/test_configuration.py
@@ -11,10 +11,39 @@ from __future__ import annotations
 import textwrap
 from typing import TYPE_CHECKING, Callable
 
+from sift_client._internal.pytest_plugin.options import (
+    GRPC_URI_OPTION,
+    resolved_settings,
+)
+
 if TYPE_CHECKING:
     from pathlib import Path
 
     import pytest
+
+
+class TestResolvedSettings:
+    """The audit snapshot helpers report value + source and redact the API key."""
+
+    def test_resolve_with_source_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SIFT_GRPC_URI", "grpc.example:443")
+        assert GRPC_URI_OPTION.resolve_with_source(None) == ("grpc.example:443", "env")
+
+    def test_unset_resolves_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SIFT_GRPC_URI", raising=False)
+        assert GRPC_URI_OPTION.resolve_with_source(None) == (None, "default")
+
+    def test_resolved_settings_redacts_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SIFT_API_KEY", "super-secret")
+        rows = {name: (value, source) for name, value, source in resolved_settings(None)}
+        assert rows["api_key"] == ("***", "env")
+
+    def test_resolved_settings_unset_api_key_is_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("SIFT_API_KEY", raising=False)
+        rows = {name: (value, source) for name, value, source in resolved_settings(None)}
+        assert rows["api_key"] == (None, "default")
 
 
 class TestIniConfiguration:

--- a/python/lib/sift_client/_tests/util/conftest.py
+++ b/python/lib/sift_client/_tests/util/conftest.py
@@ -1,3 +1,6 @@
+import os
+import platform
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 import pytest
@@ -8,6 +11,35 @@ _HERE = Path(__file__).parent
 def pytest_configure(config: pytest.Config) -> None:
     """Configure the pytest configuration to disable the Sift test results log file."""
     config.option.sift_log_file = False
+
+
+@pytest.fixture(scope="session", autouse=True)
+def stamp_run_metadata(request: pytest.FixtureRequest) -> None:
+    """Stamp run-wide metadata on the report: where it ran plus SDK/Python versions.
+
+    ``environment`` is ``ci`` when a CI provider sets ``CI=true``, else ``local``.
+    ``sdk_version``/``python_version`` record what produced the report. Stamped
+    once per session, spreading the existing metadata first since ``update``
+    replaces the map wholesale. Skipped under ``--sift-disabled`` (unit runs) so
+    no report is created just to carry it.
+    """
+    if request.config.option.sift_disabled:
+        return
+    try:
+        sdk_version = version("sift_stack_py")
+    except PackageNotFoundError:
+        sdk_version = "unknown"
+    report_context = request.getfixturevalue("report_context")
+    report_context.report.update(
+        {
+            "metadata": {
+                **report_context.report.metadata,
+                "environment": "ci" if os.environ.get("CI") else "local",
+                "sdk_version": sdk_version,
+                "python_version": platform.python_version(),
+            }
+        }
+    )
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: "list[pytest.Item]") -> None:

--- a/python/lib/sift_client/_tests/util/conftest.py
+++ b/python/lib/sift_client/_tests/util/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import platform
 from importlib.metadata import PackageNotFoundError, version
@@ -13,36 +15,29 @@ def pytest_configure(config: pytest.Config) -> None:
     config.option.sift_log_file = False
 
 
-@pytest.fixture(scope="session", autouse=True)
-def stamp_run_metadata(request: pytest.FixtureRequest) -> None:
+@pytest.fixture(scope="session")
+def sift_report_metadata() -> dict[str, str | float | bool]:
     """Stamp run-wide metadata on the report: where it ran plus SDK/Python versions.
 
-    ``environment`` is ``ci`` when a CI provider sets ``CI=true``, else ``local``.
-    ``sdk_version``/``python_version`` record what produced the report. Stamped
-    once per session, spreading the existing metadata first since ``update``
-    replaces the map wholesale. Skipped under ``--sift-disabled`` (unit runs) so
-    no report is created just to carry it.
+    Overrides the plugin's default (empty) fixture, so these layer over the
+    ``[tool.sift.pytest.report.metadata]`` TOML table. ``environment`` is ``ci``
+    when a CI provider sets ``CI=true``, else ``local``; ``sdk_version`` and
+    ``python_version`` record what produced the report. The plugin resolves this
+    only while building the report, so a unit run that creates no report never
+    calls it.
     """
-    if request.config.option.sift_disabled:
-        return
     try:
         sdk_version = version("sift_stack_py")
     except PackageNotFoundError:
         sdk_version = "unknown"
-    report_context = request.getfixturevalue("report_context")
-    report_context.report.update(
-        {
-            "metadata": {
-                **report_context.report.metadata,
-                "environment": "ci" if os.environ.get("CI") else "local",
-                "sdk_version": sdk_version,
-                "python_version": platform.python_version(),
-            }
-        }
-    )
+    return {
+        "environment": "ci" if os.environ.get("CI") else "local",
+        "sdk_version": sdk_version,
+        "python_version": platform.python_version(),
+    }
 
 
-def pytest_collection_modifyitems(config: pytest.Config, items: "list[pytest.Item]") -> None:
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     """Bulk-apply ``@pytest.mark.sift_include`` to integration tests under util/.
 
     The project-wide default in ``pyproject.toml`` is ``sift_autouse

--- a/python/lib/sift_client/pytest_plugin.py
+++ b/python/lib/sift_client/pytest_plugin.py
@@ -13,12 +13,23 @@ lives under ``sift_client._internal.pytest_plugin``.
 
 from __future__ import annotations
 
+import logging
+import platform
+import sys
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Generator
 
 import pytest
 
 from sift_client import SiftClient, SiftConnectionConfig
+from sift_client._internal.pytest_plugin.audit_log import (
+    configure_audit_logging,
+    detach_audit_handlers,
+    log_event,
+    render_report_tree,
+    replay_audit_path,
+)
 from sift_client._internal.pytest_plugin.modes import (
     gate_enabled,
     is_disabled,
@@ -33,6 +44,7 @@ from sift_client._internal.pytest_plugin.options import (
     OPEN_OPTION,
     REST_URI_OPTION,
     register_options,
+    resolved_settings,
     warn_on_unknown_env_vars,
     warn_on_unknown_toml_keys,
 )
@@ -64,6 +76,8 @@ from sift_client.errors import SiftWarning
 from sift_client.sift_types.test_report import TestStatus
 from sift_client.util.test_results import ReportContext
 from sift_client.util.test_results.context_manager import NewStep
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "REPORT_CONTEXT",
@@ -110,6 +124,11 @@ REPORT_CONTEXT: Any = None
 SIFT_REPORT_ID_STASH_KEY = pytest.StashKey[str]()
 SIFT_REPORT_URL_STASH_KEY = pytest.StashKey[str]()
 
+# Set in ``pytest_configure`` when ``--sift-audit-log`` is on; the resolved audit
+# file path. Read by ``report_context`` to thread the replay sibling to the
+# subprocess and by the terminal summary to surface the paths.
+SIFT_AUDIT_LOG_STASH_KEY = pytest.StashKey[Path]()
+
 
 # ---------------------------------------------------------------------------
 # Fixtures.
@@ -148,6 +167,7 @@ def sift_client(pytestconfig: pytest.Config) -> SiftClient:
     }
     missing = [env for env, value in resolved.items() if not value]
     if missing and not is_offline(pytestconfig):
+        log_event(logger, logging.ERROR, "credentials", missing=",".join(missing))
         raise pytest.UsageError(
             "Sift credentials missing: "
             + ", ".join(missing)
@@ -247,19 +267,22 @@ def report_context(
         return
     sift_client = request.getfixturevalue("sift_client")
     if not is_offline(pytestconfig):
+        grpc_config = getattr(getattr(sift_client, "grpc_client", None), "_config", None)
+        grpc_url = getattr(grpc_config, "uri", "<unknown>")
+        log_event(logger, logging.INFO, "connect.ping", target=grpc_url)
         try:
             request.getfixturevalue("client_has_connection")
         except pytest.UsageError:
             raise
         except Exception as exc:
-            grpc_config = getattr(getattr(sift_client, "grpc_client", None), "_config", None)
-            grpc_url = getattr(grpc_config, "uri", "<unknown>")
+            log_event(logger, logging.ERROR, "connect.failed", target=grpc_url, error=repr(exc))
             pytest.exit(
                 f"Sift ping failed against {grpc_url}: {exc}. "
                 "Pass --sift-offline to run without contacting Sift, or "
                 "--sift-disabled to skip Sift entirely.",
                 returncode=4,
             )
+        log_event(logger, logging.INFO, "connect.ok", target=grpc_url)
     yield from _set_report_context(
         report_context_impl(sift_client, request, pytestconfig=pytestconfig)
     )
@@ -314,6 +337,43 @@ def _sift_parents(
 # ---------------------------------------------------------------------------
 
 
+def _log_settings_and_provenance(config: pytest.Config) -> None:
+    """Write the resolved-settings snapshot and the run-provenance lines.
+
+    Called from ``pytest_configure`` only when audit logging is on. Every
+    record is a no-op unless a handler is attached, so this is gated by the
+    caller rather than re-checking here.
+    """
+    from sift_client.util.test_results.context_manager import _git_metadata
+
+    for name, value, source in resolved_settings(config):
+        log_event(logger, logging.DEBUG, "settings", name=name, value=value, source=source)
+
+    args = config.invocation_params.args
+    command = "pytest " + " ".join(args) if args else "pytest"
+    log_event(
+        logger,
+        logging.INFO,
+        "env",
+        sdk=sdk_version(),
+        pytest=pytest.__version__,
+        python=platform.python_version(),
+        platform=sys.platform,
+        rootdir=config.rootpath,
+        command=command,
+    )
+    git = _git_metadata() or {}
+    if git:
+        log_event(
+            logger,
+            logging.INFO,
+            "env",
+            git_repo=git.get("git_repo", "-"),
+            git_branch=git.get("git_branch", "-"),
+            git_commit=git.get("git_commit", "-"),
+        )
+
+
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Register every CLI flag and pytest ini key declared in ``PLUGIN_OPTIONS``."""
     register_options(parser)
@@ -331,6 +391,22 @@ def pytest_configure(config: pytest.Config) -> None:
         "sift_exclude: force the Sift autouse fixtures to skip this test "
         "regardless of the `sift_autouse` ini default.",
     )
+    # Audit trace (on by default): attaches DEBUG file + WARNING stdout handlers
+    # to the sift_client root logger. Returns None only when audit logging is
+    # explicitly disabled via --sift-audit-log=false. Done first so the typo
+    # warnings below are captured in the audit file.
+    audit_path = configure_audit_logging(config)
+    if audit_path is not None:
+        config.stash[SIFT_AUDIT_LOG_STASH_KEY] = audit_path
+        log_event(
+            logger,
+            logging.INFO,
+            "session",
+            mode=mode_label(config),
+            audit_log=audit_path,
+            replay_log=replay_audit_path(audit_path),
+        )
+        _log_settings_and_provenance(config)
     # Surface typos in env vars and [tool.sift...] keys at session start so a
     # silent no-op (env var that doesn't match anything, table key the loader
     # ignores) becomes visible. The registry is the source of truth for what's
@@ -354,8 +430,21 @@ def pytest_itemcollected(item: pytest.Item) -> None:
     on-demand recompute fallback, so an item a later hook injects without going
     through this hook still resolves correctly.
     """
-    item.stash[hierarchy_key] = build_hierarchy_chain(item, item.config)
-    item.stash[parametrize_path_key] = build_parametrize_path(item)
+    chain = build_hierarchy_chain(item, item.config)
+    parametrize_path = build_parametrize_path(item)
+    item.stash[hierarchy_key] = chain
+    item.stash[parametrize_path_key] = parametrize_path
+    gated = gate_enabled(item, item.config)
+    rendered_hierarchy = "/".join(name for _id, name, _doc, rendered in chain if rendered)
+    log_event(
+        logger,
+        logging.DEBUG,
+        "collection.item",
+        path=item.nodeid,
+        gated=gated,
+        hierarchy=rendered_hierarchy or "-",
+        parametrize="/".join(parametrize_path) or "-",
+    )
 
 
 def pytest_collection_finish(session: pytest.Session) -> None:
@@ -365,6 +454,14 @@ def pytest_collection_finish(session: pytest.Session) -> None:
     reflect only the selected, gated-in items. See ``release_finished_leaf``.
     """
     tally_expected_parents(session)
+    items = session.items
+    excluded_count = sum(1 for i in items if not gate_enabled(i, session.config))
+    collection_fields: dict[str, object] = {
+        "collected": len(items),
+        "will_run": len(items) - excluded_count,
+        "excluded": excluded_count,
+    }
+    log_event(logger, logging.INFO, "collection", **collection_fields)
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
@@ -398,7 +495,12 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[Any]):
         # report root instead of under its module/class.
         parent_ns = resolve_parent_chain_in_context(item, item.config, REPORT_CONTEXT)
         parent_step = parent_ns.current_step if parent_ns is not None else None
-        with REPORT_CONTEXT.new_step(name=item.name, parent=parent_step) as inline_step:
+        with REPORT_CONTEXT.new_step(
+            name=item.name,
+            parent=parent_step,
+            origin="pytest_runtest_makereport",
+            source_path=item.nodeid,
+        ) as inline_step:
             inline_step.current_step.update({"status": TestStatus.SKIPPED})
 
     if report.when == "teardown":
@@ -448,6 +550,16 @@ def pytest_terminal_summary(terminalreporter: Any, exitstatus: int, config: pyte
     """
     quiet = config.get_verbosity() < 0
 
+    # End-state validation view: the final step tree with statuses, written to
+    # the audit log (not the terminal) in every mode. created_steps are retained
+    # after the context closes, so this reflects final statuses (incl. teardown
+    # upgrades). Logged regardless of -q since it's a file artifact.
+    if SIFT_AUDIT_LOG_STASH_KEY in config.stash and REPORT_CONTEXT is not None:
+        logger.debug(
+            "%s",
+            render_report_tree(REPORT_CONTEXT.created_steps, mode=mode_label(config)),
+        )
+
     if is_disabled(config):
         if not quiet:
             write_disabled_summary(terminalreporter)
@@ -464,6 +576,7 @@ def pytest_terminal_summary(terminalreporter: Any, exitstatus: int, config: pyte
     report_id, report_url = resolve_report_link(context, offline)
     if report_id:
         config.stash[SIFT_REPORT_ID_STASH_KEY] = report_id
+        log_event(logger, logging.INFO, "report", id=report_id, url=report_url or "-")
     if report_url is not None:
         config.stash[SIFT_REPORT_URL_STASH_KEY] = report_url
         if OPEN_OPTION.resolve(config):
@@ -473,3 +586,11 @@ def pytest_terminal_summary(terminalreporter: Any, exitstatus: int, config: pyte
         return
 
     write_report_summary(terminalreporter, context, config, report_id, report_url, offline)
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    """Tear down the audit-log handlers so they don't outlive the session.
+
+    A no-op when audit logging was disabled (no handlers were attached).
+    """
+    detach_audit_handlers()

--- a/python/lib/sift_client/pytest_plugin.py
+++ b/python/lib/sift_client/pytest_plugin.py
@@ -223,6 +223,23 @@ def client_has_connection(pytestconfig: pytest.Config, request: pytest.FixtureRe
     return True
 
 
+@pytest.fixture(scope="session")
+def sift_report_metadata() -> dict[str, str | float | bool]:
+    """Extra report metadata, merged on top of the ``[tool.sift.pytest.report.metadata]``
+    TOML table.
+
+    Returns ``{}`` by default. Override this fixture in your conftest to add
+    metadata computed at runtime (SDK/Python version, CI provider, build id),
+    which the static TOML table can't express. It's resolved while the report is
+    built, so it never forces a report to be created on its own: a run that
+    creates no report (e.g. a unit suite with the Sift gate off) never calls it.
+
+    Keys here layer over matching TOML keys; ``pytest_command`` is reserved and
+    always wins.
+    """
+    return {}
+
+
 def _set_report_context(
     contexts: Generator[ReportContext, None, None],
 ) -> Generator[ReportContext, None, None]:

--- a/python/lib/sift_client/pytest_plugin.py
+++ b/python/lib/sift_client/pytest_plugin.py
@@ -24,8 +24,11 @@ import pytest
 
 from sift_client import SiftClient, SiftConnectionConfig
 from sift_client._internal.pytest_plugin.audit_log import (
+    _make_session_dir,
+    audit_disabled,
     configure_audit_logging,
     detach_audit_handlers,
+    explicit_audit_path,
     log_event,
     render_report_tree,
     replay_audit_path,
@@ -40,6 +43,7 @@ from sift_client._internal.pytest_plugin.modes import (
 from sift_client._internal.pytest_plugin.options import (
     API_KEY_OPTION,
     APP_URL_OPTION,
+    AUDIT_LOG_OPTION,
     GRPC_URI_OPTION,
     OPEN_OPTION,
     REST_URI_OPTION,
@@ -81,8 +85,10 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "REPORT_CONTEXT",
+    "SIFT_AUDIT_LOG_STASH_KEY",
     "SIFT_REPORT_ID_STASH_KEY",
     "SIFT_REPORT_URL_STASH_KEY",
+    "SIFT_SESSION_DIR_STASH_KEY",
     "NewStep",
     "ReportContext",
     "SiftPytestPluginWarning",
@@ -128,6 +134,12 @@ SIFT_REPORT_URL_STASH_KEY = pytest.StashKey[str]()
 # file path. Read by ``report_context`` to thread the replay sibling to the
 # subprocess and by the terminal summary to surface the paths.
 SIFT_AUDIT_LOG_STASH_KEY = pytest.StashKey[Path]()
+
+# Set in ``pytest_configure`` when both audit log and JSONL log use their
+# default temp paths. Groups all session artifacts under one directory:
+# ``<tmpdir>/sift_test_results/<random>/``. Read by ``report_context_impl``
+# to place the JSONL log alongside the audit log.
+SIFT_SESSION_DIR_STASH_KEY = pytest.StashKey[Path]()
 
 
 # ---------------------------------------------------------------------------
@@ -391,11 +403,21 @@ def pytest_configure(config: pytest.Config) -> None:
         "sift_exclude: force the Sift autouse fixtures to skip this test "
         "regardless of the `sift_autouse` ini default.",
     )
+    # Create a session dir when audit logging is enabled and at its default path
+    # (not explicitly set by the user). This groups all temp artifacts —
+    # JSONL log, tracking sidecar, audit log, replay audit log — under one
+    # directory: ``<tmpdir>/sift_test_results/<random>/``.
+    raw_audit = AUDIT_LOG_OPTION.resolve(config)
+    session_dir: Path | None = None
+    if not audit_disabled(raw_audit) and explicit_audit_path(raw_audit) is None:
+        session_dir = _make_session_dir()
+        config.stash[SIFT_SESSION_DIR_STASH_KEY] = session_dir
+
     # Audit trace (on by default): attaches DEBUG file + WARNING stdout handlers
     # to the sift_client root logger. Returns None only when audit logging is
     # explicitly disabled via --sift-audit-log=false. Done first so the typo
     # warnings below are captured in the audit file.
-    audit_path = configure_audit_logging(config)
+    audit_path = configure_audit_logging(config, session_dir=session_dir)
     if audit_path is not None:
         config.stash[SIFT_AUDIT_LOG_STASH_KEY] = audit_path
         log_event(

--- a/python/lib/sift_client/scripts/import_test_result_log.py
+++ b/python/lib/sift_client/scripts/import_test_result_log.py
@@ -6,6 +6,7 @@ import argparse
 import logging
 import os
 import select
+import shutil
 import sys
 import tempfile
 from pathlib import Path
@@ -32,12 +33,45 @@ def _print_result(result: ReplayResult) -> None:
         print(f"  - {m.name}: passed={m.passed}")
 
 
-def _incremental_import_loop(client: SiftClient, log_file: str) -> ReplayResult | None:
+def _cleanup_temp_log(log_file: str) -> None:
+    """Remove temp artifacts after a successful upload when audit logging is off.
+
+    Called only when audit logging is off: without an audit trail there's no
+    reason to retain the buffer, so default temp artifacts are reclaimed
+    immediately. An explicit ``--sift-log-file`` (not under the temp dir) is
+    the user's to keep and is never touched.
+
+    Session-dir layout (``<tmpdir>/sift_test_results/<random>/``): the whole
+    directory is removed, cleaning up the JSONL, tracking sidecar, lock, and
+    any audit files in one shot.
+
+    Legacy flat-temp layout (file directly in tmpdir): only the JSONL and its
+    tracking sidecar are removed individually.
+    """
+    fp = Path(log_file).absolute()
+    if not str(fp).startswith(tempfile.gettempdir()):
+        return
+    session_dir = fp.parent
+    if session_dir.parent == Path(tempfile.gettempdir()) / "sift_test_results":
+        shutil.rmtree(session_dir, ignore_errors=True)
+        log_event(logger, logging.DEBUG, "replay.cleanup", log=str(fp), dir=str(session_dir))
+        return
+    fp.unlink(missing_ok=True)
+    fp.with_name(fp.name + ".tracking").unlink(missing_ok=True)
+    log_event(logger, logging.DEBUG, "replay.cleanup", log=str(fp))
+
+
+def _incremental_import_loop(
+    client: SiftClient, log_file: str, *, keep_log: bool
+) -> ReplayResult | None:
     """Replay incrementally in a loop until stdin is closed (EOF).
 
     Per-entity upload detail and sidecar advances are logged inside the
     incremental importer (``replay.upload`` / ``replay.error``); idle ticks
     that upload nothing are silent on purpose.
+
+    When ``keep_log`` is False (audit logging off) the temp log is deleted on a
+    clean finish; with audit logging on it's retained alongside the audit trail.
     """
     result = None
     while True:
@@ -46,9 +80,8 @@ def _incremental_import_loop(client: SiftClient, log_file: str) -> ReplayResult 
         if received_signal:
             break
     log_event(logger, logging.INFO, "replay.complete", log=log_file)
-    fp = os.path.abspath(log_file)
-    if fp.startswith(tempfile.gettempdir()):
-        os.remove(fp)
+    if not keep_log:
+        _cleanup_temp_log(log_file)
     return result
 
 
@@ -88,14 +121,16 @@ def main() -> None:
         )
     )
 
+    # The worker is spawned with --audit-log only when audit logging is on, so
+    # its presence is the signal to retain the buffer after a clean upload.
+    keep_log = bool(args.audit_log)
     try:
         if args.incremental:
-            result = _incremental_import_loop(client, args.log_file)
+            result = _incremental_import_loop(client, args.log_file, keep_log=keep_log)
         else:
             result = client.test_results.import_log_file(args.log_file)
-            fp = os.path.abspath(args.log_file)
-            if fp.startswith(tempfile.gettempdir()):
-                os.remove(fp)
+            if not keep_log:
+                _cleanup_temp_log(args.log_file)
     except Exception as e:
         log_event(logger, logging.ERROR, "replay.failed", error=repr(e))
         log_replay_instructions(args.log_file)

--- a/python/lib/sift_client/scripts/import_test_result_log.py
+++ b/python/lib/sift_client/scripts/import_test_result_log.py
@@ -8,9 +8,11 @@ import os
 import select
 import sys
 import tempfile
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from sift_client import SiftClient, SiftConnectionConfig
+from sift_client._internal.pytest_plugin.audit_log import log_event
 from sift_client.util.test_results.context_manager import log_replay_instructions
 
 if TYPE_CHECKING:
@@ -31,14 +33,19 @@ def _print_result(result: ReplayResult) -> None:
 
 
 def _incremental_import_loop(client: SiftClient, log_file: str) -> ReplayResult | None:
-    """Replay incrementally in a loop until stdin is closed (EOF)."""
+    """Replay incrementally in a loop until stdin is closed (EOF).
+
+    Per-entity upload detail and sidecar advances are logged inside the
+    incremental importer (``replay.upload`` / ``replay.error``); idle ticks
+    that upload nothing are silent on purpose.
+    """
     result = None
     while True:
         received_signal, _, _ = select.select([sys.stdin], [], [], 1.0)
         result = client.test_results.import_log_file(log_file, incremental=True)
         if received_signal:
             break
-    logger.info(f"Replay completed: {result}")
+    log_event(logger, logging.INFO, "replay.complete", log=log_file)
     fp = os.path.abspath(log_file)
     if fp.startswith(tempfile.gettempdir()):
         os.remove(fp)
@@ -57,7 +64,15 @@ def main() -> None:
     parser.add_argument(
         "--incremental", action="store_true", help="Import the log file incrementally."
     )
+    parser.add_argument(
+        "--audit-log", default=None, help="Path to the replay worker's DEBUG audit log."
+    )
     args = parser.parse_args()
+
+    if args.audit_log:
+        from sift_client._internal.pytest_plugin.audit_log import attach_file_handler
+
+        attach_file_handler(Path(args.audit_log))
 
     if not args.grpc_url or not args.rest_url or not args.api_key:
         raise ValueError("SIFT_GRPC_URI, SIFT_REST_URI, and SIFT_API_KEY must be set")
@@ -82,7 +97,7 @@ def main() -> None:
             if fp.startswith(tempfile.gettempdir()):
                 os.remove(fp)
     except Exception as e:
-        logger.error(e)
+        log_event(logger, logging.ERROR, "replay.failed", error=repr(e))
         log_replay_instructions(args.log_file)
         raise
 

--- a/python/lib/sift_client/util/test_results/context_manager.py
+++ b/python/lib/sift_client/util/test_results/context_manager.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from sift_client._internal.pytest_plugin.audit_log import log_event
 from sift_client.errors import SiftWarning
 from sift_client.sift_types.test_report import (
     ErrorInfo,
@@ -172,6 +173,9 @@ class ReportContext(AbstractContextManager):
     # exited non-zero, so callers (e.g. the pytest plugin footer) can flag that
     # the uploaded report may be missing entries.
     replay_incomplete: bool = False
+    # When set, the path of the DEBUG audit log. The replay worker is spawned
+    # with ``--audit-log <sibling>`` so its activity is traced too.
+    audit_log: Path | None = None
     _import_proc: subprocess.Popen | None = None
     # Seconds to wait for the import worker subprocess to finish uploading
     # the JSONL backlog at session end before killing it. Tests substitute
@@ -192,6 +196,7 @@ class ReportContext(AbstractContextManager):
         include_git_metadata: bool = False,
         replay_log_file: bool = True,
         metadata: dict[str, str | float | bool] | None = None,
+        audit_log: str | Path | None = None,
     ):
         """Initialize a new report context.
 
@@ -216,9 +221,13 @@ class ReportContext(AbstractContextManager):
                 False, the log file is just a record and no worker is spawned.
                 Replay happens later via ``replay-test-result-log <path>``.
                 Has no effect when ``log_file`` is None.
+            audit_log: When set, the path of a DEBUG audit log. The replay worker
+                is spawned with ``--audit-log <sibling>`` so its activity is
+                traced to ``<path>.replay.log``.
         """
         self.client = client
         self.replay_log_file = replay_log_file
+        self.audit_log = Path(audit_log) if audit_log is not None else None
         self.step_is_open = False
         self.step_stack = []
         self.child_counts = {}
@@ -232,7 +241,7 @@ class ReportContext(AbstractContextManager):
         if log_file is True:
             tmp = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
             self.log_file = Path(tmp.name)
-            logger.info(f"Created temporary log file: {self.log_file}")
+            log_event(logger, logging.INFO, "log_file.create", path=self.log_file, source="temp")
         elif log_file:
             self.log_file = Path(log_file)
         else:
@@ -267,7 +276,7 @@ class ReportContext(AbstractContextManager):
         with controlled returncodes / stderr to exercise the ``__exit__``
         branches without depending on the real replay binary.
         """
-        return [
+        cmd = [
             "import-test-result-log",
             "--incremental",
             str(self.log_file),
@@ -278,6 +287,11 @@ class ReportContext(AbstractContextManager):
             "--api-key",
             self.client.grpc_client._config.api_key,
         ]
+        if self.audit_log is not None:
+            from sift_client._internal.pytest_plugin.audit_log import replay_audit_path
+
+            cmd += ["--audit-log", str(replay_audit_path(self.audit_log))]
+        return cmd
 
     def _open_import_proc(self):
         """Open a subprocess to import the log file.
@@ -285,13 +299,26 @@ class ReportContext(AbstractContextManager):
         ``stderr`` is captured so a worker crash mid-session can surface its
         error at session end via ``__exit__`` rather than failing silently.
         """
-        with _quiet_fork_stderr():
-            self._import_proc = subprocess.Popen(
-                self._build_replay_command(),
-                stdin=subprocess.PIPE,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.PIPE,
+        # Redact the API key before logging — never log the raw argv.
+        api_key = self.client.grpc_client._config.api_key
+        safe = ["***" if a == api_key else a for a in self._build_replay_command()]
+        log_event(logger, logging.INFO, "replay.start", log=self.log_file)
+        log_event(logger, logging.DEBUG, "replay.cmd", argv=" ".join(safe))
+        try:
+            with _quiet_fork_stderr():
+                self._import_proc = subprocess.Popen(
+                    self._build_replay_command(),
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.PIPE,
+                )
+        except OSError as exc:
+            # e.g. the ``import-test-result-log`` entry point isn't on PATH.
+            # Surface it; the JSONL log is still on disk for a manual replay.
+            log_event(
+                logger, logging.WARNING, "replay.spawn_failed", error=repr(exc), log=self.log_file
             )
+            raise
 
     def __enter__(self):
         if self.log_file and self.replay_log_file:
@@ -330,6 +357,13 @@ class ReportContext(AbstractContextManager):
                 self._import_proc.kill()
                 self._import_proc.wait()
                 self.replay_incomplete = True
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    "replay.timeout",
+                    secs=self._import_proc_timeout,
+                    log=self.log_file,
+                )
                 warnings.warn(
                     f"Sift import worker did not exit in "
                     f"{self._import_proc_timeout}s; killing it. "
@@ -344,6 +378,14 @@ class ReportContext(AbstractContextManager):
                 stderr_text = (
                     stderr_bytes.decode("utf-8", errors="replace").strip() if stderr_bytes else ""
                 )
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    "replay.error",
+                    code=self._import_proc.returncode,
+                    log=self.log_file,
+                    stderr=stderr_text or "",
+                )
                 warnings.warn(
                     f"Sift import worker exited with code "
                     f"{self._import_proc.returncode}. stderr: {stderr_text or '<empty>'}",
@@ -351,6 +393,8 @@ class ReportContext(AbstractContextManager):
                     stacklevel=2,
                 )
                 log_replay_instructions(self.log_file)
+            else:
+                log_event(logger, logging.INFO, "replay.done")
 
         return True
 
@@ -389,6 +433,8 @@ class ReportContext(AbstractContextManager):
         *,
         parent: TestStep | None | object = _USE_STACK_TOP,
         push: bool = True,
+        origin: str = "step",
+        source_path: str | None = None,
     ) -> NewStep:
         """Alias to return a new step context manager from this report context. Use create_step for actually creating a TestStep in the current context.
 
@@ -396,6 +442,10 @@ class ReportContext(AbstractContextManager):
         by everyday callers. The pytest plugin passes an explicit ``parent`` with
         ``push=False`` to open report-tree parents that persist outside the stack;
         see :meth:`create_step`.
+
+        ``origin`` (e.g. ``hierarchy``/``parametrize``/``test``/``substep``) and
+        ``source_path`` (the pytest nodeid the step was created for) are
+        audit-log labels only; they do not affect step creation.
         """
         return NewStep(
             self,
@@ -405,6 +455,8 @@ class ReportContext(AbstractContextManager):
             metadata=metadata,
             parent=parent,
             push=push,
+            origin=origin,
+            source_path=source_path,
         )
 
     def _resolve_parent(self, parent: TestStep | None | object) -> TestStep | None:
@@ -588,6 +640,8 @@ class NewStep(AbstractContextManager):
         *,
         parent: TestStep | None | object = _USE_STACK_TOP,
         push: bool = True,
+        origin: str = "step",
+        source_path: str | None = None,
     ):
         """Initialize a new step context.
 
@@ -599,6 +653,10 @@ class NewStep(AbstractContextManager):
             metadata: [Optional] Structured key/value metadata to attach to the step.
             parent: Parent step to nest under; see :meth:`ReportContext.create_step`.
             push: Whether the step joins the step stack; see :meth:`ReportContext.create_step`.
+            origin: Audit-log label for where the step came from (hierarchy,
+                parametrize, test, substep); does not affect behavior.
+            source_path: Audit-log label: the pytest nodeid this step was created
+                for; does not affect behavior.
         """
         self.report_context = report_context
         self.client = report_context.client
@@ -606,6 +664,8 @@ class NewStep(AbstractContextManager):
             name, description, metadata=metadata, parent=parent, push=push
         )
         self.assertion_as_fail_not_error = assertion_as_fail_not_error
+        self._origin = origin
+        self._source_path = source_path
         # Per-step measurement-failure count for ``measurements_passed``.
         # Tracks only direct ``measure*`` calls on this NewStep instance;
         # substep / ``report_outcome`` failures are intentionally not folded
@@ -614,6 +674,17 @@ class NewStep(AbstractContextManager):
         # Out-of-bounds measurements recorded on this step, retained so
         # ``pytest_fail_if_step_failed`` can name them in the failure message.
         self._failed_measurements: list[TestMeasurement] = []
+        parent_path = self.current_step.step_path.rpartition(".")[0] or "-"
+        log_event(
+            logger,
+            logging.DEBUG,
+            "step.open",
+            name=self.current_step.name,
+            path=source_path or "-",
+            step_path=self.current_step.step_path,
+            origin=origin,
+            parent=parent_path,
+        )
 
     def __enter__(self):
         """Enter the context manager to create a new step.
@@ -754,6 +825,30 @@ class NewStep(AbstractContextManager):
 
         return result
 
+    def _log_close(self, step: TestStep) -> None:
+        """Audit line for closing a step, with a per-step measurement summary.
+
+        Summarizes (not enumerates) the measurements recorded on this step:
+        passed/total, plus the out-of-bounds ones named so a reader sees what
+        failed. Omits the measurement field for steps with none.
+        """
+        measurements = [
+            m for m in self.report_context.created_measurements if m.test_step_id == str(step.id_)
+        ]
+        fields: dict[str, object] = {
+            "name": step.name,
+            "path": self._source_path or "-",
+            "step_path": step.step_path,
+            "origin": self._origin,
+        }
+        if measurements:
+            passed = sum(1 for m in measurements if m.passed)
+            fields["measurements"] = f"{passed}/{len(measurements)}"
+            failed = [m for m in measurements if not m.passed]
+            if failed:
+                fields["failed"] = "[" + ", ".join(str(m) for m in failed) + "]"
+        log_event(logger, logging.DEBUG, "step.close", **fields)
+
     def __exit__(self, exc, exc_value, tb):
         if getattr(self, "_sift_managed_externally", False):
             # The pytest fixture already resolved status from phase reports.
@@ -774,6 +869,7 @@ class NewStep(AbstractContextManager):
                 },
             )
             self.report_context.note_close(current_step)
+            self._log_close(current_step)
             self.report_context.exit_step(current_step)
             if hasattr(self, "force_result"):
                 result = self.force_result
@@ -784,6 +880,8 @@ class NewStep(AbstractContextManager):
         )
 
         # Now that the step is updated. Let the report context handle removing it from the stack and updating the report context.
+        if self.current_step is not None:
+            self._log_close(self.current_step)
         self.report_context.exit_step(self.current_step)
 
         # Test only attribute (hence not public class variable)
@@ -970,4 +1068,6 @@ class NewStep(AbstractContextManager):
             description=description,
             assertion_as_fail_not_error=self.assertion_as_fail_not_error,
             metadata=metadata,
+            origin="substep",
+            source_path=self._source_path,
         )

--- a/python/lib/sift_client/util/test_results/context_manager.py
+++ b/python/lib/sift_client/util/test_results/context_manager.py
@@ -5,7 +5,6 @@ import logging
 import os
 import socket
 import subprocess
-import tempfile
 import traceback
 import warnings
 from collections import Counter
@@ -16,7 +15,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from sift_client._internal.pytest_plugin.audit_log import log_event
+from sift_client._internal.pytest_plugin.audit_log import _make_session_dir, log_event
 from sift_client.errors import SiftWarning
 from sift_client.sift_types.test_report import (
     ErrorInfo,
@@ -239,8 +238,8 @@ class ReportContext(AbstractContextManager):
         self.replay_incomplete = False
 
         if log_file is True:
-            tmp = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
-            self.log_file = Path(tmp.name)
+            session_dir = _make_session_dir()
+            self.log_file = session_dir / f"{session_dir.name}.jsonl"
             log_event(logger, logging.INFO, "log_file.create", path=self.log_file, source="temp")
         elif log_file:
             self.log_file = Path(log_file)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -440,3 +440,7 @@ testpaths = [
 markers = [
     "integration: mark a test as an integration test (requires API)"
 ]
+
+[tool.sift.pytest.report]
+# Stable grouping key so integration reports query together across runs.
+test_case = "sift-client-integration"


### PR DESCRIPTION
Adds a DEBUG audit trace to the pytest plugin so field failures can be diagnosed from one file without a rerun.

- New `--sift-audit-log` / `sift_audit_log` option (`path | true | false`). On by default: DEBUG trace to a temp file, WARNINGs echoed to stdout. Set a path to pin the file, or `false` to disable.
- Columnar `key=value` lines trace config typos, credentials, connection, the resolved-settings snapshot (with `env`/`cli`/`ini`/`toml` provenance; API key redacted), status transitions, templates, step open/close, and the replay lifecycle.
- Per-session temp artifacts (JSONL log, tracking sidecar, audit log, replay sibling) now group under `<tmpdir>/sift_test_results/<random>/`; the replay subprocess gets its own `*.replay.log`. Temp logs are reclaimed on a clean finish only when audit logging is off.
- Terminal summary gains an `audit log` section; `render_report_tree` shows the final step tree with per-step status.
- Docs: a "Getting support" section in the plugin overview explains the trace, where to find it, and to zip the session directory when contacting Sift. `pyproject.toml` sets a stable `test_case` grouping key for integration runs.
- Tests added for configuration, incremental replay, and report context.
- Adds a fixture to assign report metadata that users can implement/override to have custom metadata handling

Example outputs:
[eyw4bltc-audit.replay.log](https://github.com/user-attachments/files/28814448/eyw4bltc-audit.replay.log)
[eyw4bltc-audit.log](https://github.com/user-attachments/files/28814449/eyw4bltc-audit.log)
