### PR TITLE
rust(chore): Bump rust crate to 0.10.1, sift_stream_bindings to 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 
 [workspace.package]
 authors = ["Sift Software Engineers <engineering@siftstack.com>"]
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 categories = ["aerospace", "science::robotics"]
 homepage = "https://github.com/sift-stack/sift"
@@ -83,15 +83,15 @@ tracing-test = { version = "0.2", features = ["no-env-filter"] }
 uuid = { version = "1.22", features = ["v4"] }
 zip = "8.2"
 
-sift_connect = { version = "0.10.0", path = "rust/crates/sift_connect" }
-sift_rs = { version = "0.10.0", path = "rust/crates/sift_rs" }
-sift_error = { version = "0.10.0", path = "rust/crates/sift_error" }
-sift_stream = { version = "0.10.0", path = "rust/crates/sift_stream" }
-sift_pbfs = { version = "0.10.0", path = "rust/crates/sift_pbfs" }
-sift_mcp = { version = "0.10.0", path = "rust/crates/sift_mcp" }
-sift_test_util = { version = "0.10.0", path = "rust/crates/sift_test_util" }
+sift_connect = { version = "0.10.1", path = "rust/crates/sift_connect" }
+sift_rs = { version = "0.10.1", path = "rust/crates/sift_rs" }
+sift_error = { version = "0.10.1", path = "rust/crates/sift_error" }
+sift_stream = { version = "0.10.1", path = "rust/crates/sift_stream" }
+sift_pbfs = { version = "0.10.1", path = "rust/crates/sift_pbfs" }
+sift_mcp = { version = "0.10.1", path = "rust/crates/sift_mcp" }
+sift_test_util = { version = "0.10.1", path = "rust/crates/sift_test_util" }
 
-sift_stream_bindings = { version = "0.4.0", path = "rust/crates/sift_stream_bindings" }
+sift_stream_bindings = { version = "0.4.1", path = "rust/crates/sift_stream_bindings" }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -3,6 +3,31 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v0.10.1] - June 10, 2026
+### What's New
+
+#### `AutoRegisterStream` trait for `SiftStreamAutoRegister` (PR [#629](https://github.com/sift-stack/sift/pull/629))
+
+`SiftStreamAutoRegister` now implements the new `AutoRegisterStream` trait, which exposes the same streaming surface — `send`, `finish`, `get_flow_descriptor`, `attach_run`, `detach_run`, and `run` — through a stable async trait. This makes it straightforward to swap in a mock implementation during testing without a live connection to Sift.
+
+```rust
+#[async_trait]
+pub trait AutoRegisterStream {
+    type SendError: std::error::Error + Send + Sync + 'static;
+
+    async fn send(&mut self, flow: Flow) -> Result<(), Self::SendError>;
+    async fn finish(self) -> Result<()> where Self: Sized;
+    fn get_flow_descriptor(&self, flow_name: &str) -> Result<FlowDescriptor<String>>;
+    async fn attach_run(&mut self, run_selector: RunSelector) -> Result<()>;
+    fn detach_run(&mut self);
+    fn run(&self) -> Option<&Run>;
+}
+```
+
+Note that `finish` carries a `where Self: Sized` bound and cannot be called through a `dyn AutoRegisterStream` object. Use generic bounds (`impl AutoRegisterStream` or `T: AutoRegisterStream`) in function signatures instead.
+
+---
+
 ## [v0.10.0] - June 9, 2026
 ### What's New
 

--- a/rust/crates/sift_stream_bindings/Cargo.toml
+++ b/rust/crates/sift_stream_bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sift-stream-bindings"
-version = "0.4.0"
+version = "0.4.1"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
Bumps Rust crate versions and sift-stream-bindings in order to release additional trait for improved testability of the `SiftStreamAutoRegister` struct.