### PR TITLE
python(feat): scope-aware parametrize support in the report tree

### DIFF
--- a/.github/workflows/python_ci.yaml
+++ b/.github/workflows/python_ci.yaml
@@ -140,18 +140,65 @@ jobs:
       #   run: |
       #     uv run --python ${{ matrix.python-version }} --no-project --with-editable '.[dev-all]' pytest -m "integration"
 
+  # Run the pytest-plugin test subset against pytest 7/8/9 to catch breakage
+  # from pytest internals the plugin reads (see the private-surface inventory in
+  # steps.py). The subset is self-contained (drives inner pytester sessions, no
+  # third-party-plugin imports), so each cell installs only the project + a
+  # target pytest + pytest-randomly — sidestepping the pinned plugin stack and
+  # the locked pytest==8.2.2 (we don't pull the dev extra). The full suite still
+  # runs on the locked pytest in `test-python`. pytest uses `~=` bounded to the
+  # major so new minors/patches are picked up automatically (early break
+  # detection); pytest-randomly is pinned per cell to its Python-floor-compatible
+  # release (it is kept so the suite runs under randomized order). Keep this
+  # subset free of third-party-plugin imports or the lean install breaks.
+  test-pytest-compat:
+    needs: [changes]
+    if: |
+      always() &&
+      (github.event_name != 'pull_request' || needs.changes.outputs.python == 'true')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python
+    strategy:
+      fail-fast: false
+      matrix:
+        # pytest line <-> compatible Python <-> compatible pytest-randomly pin
+        include:
+          - { python-version: "3.8",  pytest-spec: "~=7.4", randomly-version: "3.15.0" }
+          - { python-version: "3.9",  pytest-spec: "~=8.4", randomly-version: "3.16.0" }
+          - { python-version: "3.10", pytest-spec: "~=9.0", randomly-version: "4.1.0" }
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Plugin tests (Python ${{ matrix.python-version }}, pytest ${{ matrix.pytest-spec }})
+        run: |
+          uv run --python ${{ matrix.python-version }} --no-project --with-editable '.' \
+            --with "pytest${{ matrix.pytest-spec }}" \
+            --with "pytest-randomly==${{ matrix.randomly-version }}" \
+            pytest lib/sift_client/_tests/pytest_plugin -m "not integration"
+
   python-ci-status:
     if: always()
-    needs: [changes, static-checks, test-python]
+    needs: [changes, static-checks, test-python, test-pytest-compat]
     runs-on: ubuntu-latest
     steps:
       - name: Check result
         run: |
           static="${{ needs.static-checks.result }}"
           tests="${{ needs.test-python.result }}"
-          if [[ ("$static" == "success" || "$static" == "skipped") && ("$tests" == "success" || "$tests" == "skipped") ]]; then
-            echo "python-ci passed (static-checks: $static, test-python: $tests)"
+          compat="${{ needs.test-pytest-compat.result }}"
+          if [[ ("$static" == "success" || "$static" == "skipped") && ("$tests" == "success" || "$tests" == "skipped") && ("$compat" == "success" || "$compat" == "skipped") ]]; then
+            echo "python-ci passed (static-checks: $static, test-python: $tests, test-pytest-compat: $compat)"
           else
-            echo "python-ci failed (static-checks: $static, test-python: $tests)"
+            echo "python-ci failed (static-checks: $static, test-python: $tests, test-pytest-compat: $compat)"
             exit 1
           fi

--- a/.github/workflows/python_ci.yaml
+++ b/.github/workflows/python_ci.yaml
@@ -180,11 +180,16 @@ jobs:
           enable-cache: true
 
       - name: Plugin tests (Python ${{ matrix.python-version }}, pytest ${{ matrix.pytest-spec }})
+        # The plugin imports grpc, and runpytest_subprocess forks the session;
+        # fork support keeps grpc's epoll engine from aborting in the parent on
+        # CI Linux (see the suite's conftest).
+        env:
+          GRPC_ENABLE_FORK_SUPPORT: "1"
         run: |
           uv run --python ${{ matrix.python-version }} --no-project --with-editable '.' \
             --with "pytest${{ matrix.pytest-spec }}" \
             --with "pytest-randomly==${{ matrix.randomly-version }}" \
-            pytest lib/sift_client/_tests/pytest_plugin -m "not integration"
+            pytest lib/sift_client/_tests/pytest_plugin -m "plugin_compat"
 
   python-ci-status:
     if: always()

--- a/python/docs/examples/pytest_plugin_quickstart.md
+++ b/python/docs/examples/pytest_plugin_quickstart.md
@@ -142,18 +142,34 @@ TestReport (FAILED, since failures propagate up from leaves)
         ├── test_failed_measurement_marks_sift_step_failed           FAILED  (pytest PASSED)
         ├── test_pytest_fail_if_step_failed_at_end                                FAILED  (pytest FAILED)
         ├── test_report_level_metadata                               PASSED
-        └── TestClassStep
-            ├── test_parametrize
-            │   ├── axis_a='a1'
-            │   │   ├── axis_b='b1'                                  PASSED
-            │   │   └── axis_b='b2'                                  PASSED
-            │   └── axis_a='a2'
-            │       ├── axis_b='b1'                                  PASSED
-            │       └── axis_b='b2'                                  PASSED
-            └── TestNested
-                └── test_report_outcome
-                    └── check                                        PASSED
+        ├── TestClassStep
+        │   ├── test_parametrize
+        │   │   ├── axis_a='a1'
+        │   │   │   ├── axis_b='b1'                                  PASSED
+        │   │   │   └── axis_b='b2'                                  PASSED
+        │   │   └── axis_a='a2'
+        │   │       ├── axis_b='b1'                                  PASSED
+        │   │       └── axis_b='b2'                                  PASSED
+        │   └── TestNested
+        │       └── test_report_outcome
+        │           └── check                                        PASSED
+        └── TestScopedFixtureParam              ← class-scoped fixture param
+            ├── stable                          ← ids= label (else firmware='1.4.2')
+            │   ├── test_boots                                       PASSED
+            │   └── test_reports_version                             PASSED
+            └── beta
+                ├── test_boots                                       PASSED
+                └── test_reports_version                             PASSED
 ```
+
+`TestScopedFixtureParam` shows two things. Scope-based placement: the
+class-scoped `firmware` fixture's parameter lifts to wrap the class methods
+(each runs once per value), unlike the function-level `@pytest.mark.parametrize`
+in `TestClassStep`, whose axes nest under the test. Module- and session-scoped
+fixture params lift higher still (above the module, and to the report root). And
+human-readable labels: `firmware` declares `ids=["stable", "beta"]`, so the
+steps use those names instead of the default `firmware='1.4.2'` form (a list or
+a callable `ids=` factory both work, on parametrize axes as well as fixtures).
 
 The `pytest_only` module deliberately includes one failing, one skipped, and
 one erroring test so the demo shows every `TestStatus` mapping (`FAILED` for
@@ -169,7 +185,7 @@ call is the recommended pattern: it fails via `pytest.fail` (no assertion
 noise in `error_info`), and unlike asserting on an individual
 `step.measure(...)` call it does not short-circuit on the first failure and
 skip every measurement that follows. Expected
-pytest output is `16 passed, 3 failed, 1 skipped`.
+pytest output is `20 passed, 3 failed, 1 skipped`.
 
 Flip any of the `sift_*_step` / `sift_parametrize_nesting` flags in
 `pyproject.toml` to `false` to collapse a layer.

--- a/python/docs/guides/pytest_plugin/configuration.md
+++ b/python/docs/guides/pytest_plugin/configuration.md
@@ -153,7 +153,7 @@ suggestion, so typos like `SIFT_REPORT_SERIALNUM` surface immediately.
 | Disable Sift entirely (no API calls, no log file). Supersedes --sift-offline. | `--sift-disabled` | `sift_disabled` |
 | Open the resulting report in a browser at session end (online only; no-op when the report URL can't be resolved). | `--sift-open-report` | `sift_open_report` |
 | Default for the Sift autouse fixtures (report_context, step, hierarchy/parametrize parents). | — | `sift_autouse` |
-| Open a parent step for each Python package (a directory with `__init__.py`) in the test path. To drop a single unwanted one, delete that `__init__.py` (see [Report Structure](report_structure.md#modules-nested-under-a-package)). | — | `sift_package_step` |
+| Open a parent step for each Python package (a directory with an __init__.py) in the test path. To drop a single unwanted one, delete that __init__.py. | — | `sift_package_step` |
 | Open a parent step for each test module. | — | `sift_module_step` |
 | Open per-class parent steps, including nested classes. | — | `sift_class_step` |
 | Cluster parametrized tests under shared parent steps (e.g. test_a -> v=1, v=2). | — | `sift_parametrize_nesting` |

--- a/python/docs/guides/pytest_plugin/configuration.md
+++ b/python/docs/guides/pytest_plugin/configuration.md
@@ -153,7 +153,7 @@ suggestion, so typos like `SIFT_REPORT_SERIALNUM` surface immediately.
 | Disable Sift entirely (no API calls, no log file). Supersedes --sift-offline. | `--sift-disabled` | `sift_disabled` |
 | Open the resulting report in a browser at session end (online only; no-op when the report URL can't be resolved). | `--sift-open-report` | `sift_open_report` |
 | Default for the Sift autouse fixtures (report_context, step, hierarchy/parametrize parents). | — | `sift_autouse` |
-| Open a parent step for each Python package in the test path. | — | `sift_package_step` |
+| Open a parent step for each Python package (a directory with `__init__.py`) in the test path. To drop a single unwanted one, delete that `__init__.py` (see [Report Structure](report_structure.md#modules-nested-under-a-package)). | — | `sift_package_step` |
 | Open a parent step for each test module. | — | `sift_module_step` |
 | Open per-class parent steps, including nested classes. | — | `sift_class_step` |
 | Cluster parametrized tests under shared parent steps (e.g. test_a -> v=1, v=2). | — | `sift_parametrize_nesting` |

--- a/python/docs/guides/pytest_plugin/report_structure.md
+++ b/python/docs/guides/pytest_plugin/report_structure.md
@@ -171,6 +171,23 @@ TestReport
         └── test_load_temp
 ```
 
+!!! note "A package step appears for any directory with `__init__.py`"
+    The package step comes from pytest collecting a directory with an
+    `__init__.py` as a `pytest.Package`. A directory without one is a
+    `pytest.Dir`, which the plugin skips. So a `tests/__init__.py` adds a
+    `tests` step to every report, which is often not what you want.
+
+    To drop a single unwanted package step, delete that directory's
+    `__init__.py`. This is safe when you use `--import-mode=importlib` (which
+    needs no `__init__.py`) and your tests have no package-relative imports
+    (`from . import ...`). Under the default `prepend` import mode, removing
+    `__init__.py` can cause import collisions when test files share a basename
+    across directories, so keep it there.
+
+    To drop package steps everywhere, set `sift_package_step = false`. No pytest
+    setting (`testpaths`, `rootdir`, …) removes a package step on its own — the
+    step exists if and only if the directory has an `__init__.py`.
+
 ### Test classes (and nested classes)
 
 `class TestFoo:` and `class TestOuter: class TestInner:` produce class and

--- a/python/docs/guides/pytest_plugin/report_structure.md
+++ b/python/docs/guides/pytest_plugin/report_structure.md
@@ -257,6 +257,32 @@ TestReport
 Set `sift_parametrize_nesting = false` in `pytest.ini` to fall back to flat leaf
 names (`test_rail[3.3]`).
 
+**Human-readable labels.** Each axis defaults to a `name=value` label. Supply
+`ids=` to name it yourself — a list, or a callable factory pytest calls with
+each value. This works on `@pytest.mark.parametrize` and on parametrized
+fixtures alike:
+
+```python
+@pytest.mark.parametrize("voltage", [3.3, 5.0], ids=["nominal", "boosted"])
+def test_rail(step, voltage): ...
+```
+
+```text title="Sift report"
+TestReport
+└── test_module.py
+    └── test_rail
+        ├── nominal
+        └── boosted
+```
+
+**Scope-based placement.** The examples above use function-scoped parametrize,
+which nests under the test. A parametrized *fixture* is placed at its own scope
+instead: a class-scoped fixture param wraps the class's methods, a module-scoped
+one wraps the module's tests, and a session-scoped one sits at the report root.
+A `@pytest.mark.parametrize(..., scope="module")` follows the scope it names.
+This keeps the tree matching how pytest actually re-runs work — broader scope
+nests outside narrower.
+
 ### Helper functions
 
 Helpers called from a test do not auto-create a step. The plugin only sees

--- a/python/examples/pytest_plugin/README.md
+++ b/python/examples/pytest_plugin/README.md
@@ -2,8 +2,9 @@
 
 A self-contained pytest project that exercises every feature of
 `sift_client.pytest_plugin`: package / module / class / parametrize step
-nesting, nested classes, manual substeps, `step.measure(...)` against
-numeric / string / bool bounds, gate markers, and the ini opt-outs.
+nesting, nested classes, scope-based placement of parametrized-fixture params,
+manual substeps, `step.measure(...)` against numeric / string / bool bounds,
+gate markers, and the ini opt-outs.
 
 ```
 examples/pytest_plugin/
@@ -78,18 +79,35 @@ TestReport (FAILED, since failures propagate up from leaves)
         ├── test_failed_measurement_marks_sift_step_failed           FAILED  (pytest PASSED)
         ├── test_pytest_fail_if_step_failed_at_end                                FAILED  (pytest FAILED)
         ├── test_report_level_metadata                               PASSED
-        └── TestClassStep
-            ├── test_parametrize
-            │   ├── axis_a='a1'
-            │   │   ├── axis_b='b1'                                  PASSED
-            │   │   └── axis_b='b2'                                  PASSED
-            │   └── axis_a='a2'
-            │       ├── axis_b='b1'                                  PASSED
-            │       └── axis_b='b2'                                  PASSED
-            └── TestNested
-                └── test_report_outcome
-                    └── check                                        PASSED
+        ├── TestClassStep
+        │   ├── test_parametrize
+        │   │   ├── axis_a='a1'
+        │   │   │   ├── axis_b='b1'                                  PASSED
+        │   │   │   └── axis_b='b2'                                  PASSED
+        │   │   └── axis_a='a2'
+        │   │       ├── axis_b='b1'                                  PASSED
+        │   │       └── axis_b='b2'                                  PASSED
+        │   └── TestNested
+        │       └── test_report_outcome
+        │           └── check                                        PASSED
+        └── TestScopedFixtureParam              ← class-scoped fixture param
+            ├── stable                          ← ids= label (else firmware='1.4.2')
+            │   ├── test_boots                                       PASSED
+            │   └── test_reports_version                             PASSED
+            └── beta
+                ├── test_boots                                       PASSED
+                └── test_reports_version                             PASSED
 ```
+
+`TestScopedFixtureParam` shows two things. First, **scope-based placement**:
+`firmware` is class-scoped, so its parameter lifts to wrap the class methods
+(each runs once per value) instead of nesting under an individual test the way
+the function-level `@pytest.mark.parametrize` in `TestClassStep` does. Module-
+and session-scoped fixture params lift higher still (above the module, and to
+the report root, respectively). Second, **human-readable labels**: the fixture
+declares `ids=["stable", "beta"]`, so the steps use those names instead of the
+default `firmware='1.4.2'` form. A list or a callable `ids=` factory both work,
+on `@pytest.mark.parametrize` axes as well as fixtures.
 
 The `pytest_only` module deliberately includes one failing, one skipped, and
 one erroring test so the demo shows every `TestStatus` mapping (`FAILED` for
@@ -105,7 +123,7 @@ call is the recommended pattern: it fails via `pytest.fail` (no assertion
 noise in `error_info`), and unlike asserting on an individual
 `step.measure(...)` call it does not short-circuit on the first failure and
 skip every measurement that follows. Expected
-pytest output is `16 passed, 3 failed, 1 skipped`.
+pytest output is `20 passed, 3 failed, 1 skipped`.
 
 Toggle any of the `sift_*_step` / `sift_parametrize_nesting` flags in
 `pyproject.toml` to `false` to collapse a layer.
@@ -117,5 +135,5 @@ Toggle any of the `sift_*_step` / `sift_parametrize_nesting` flags in
 | `conftest.py` | Plugin registration via `pytest_plugins` (a single line) |
 | `pyproject.toml` | Pytest nesting/git-metadata knobs at their defaults; report `name`, `test_case`, and `metadata` under `[tool.sift.pytest.report]` |
 | `tests/pytest_only/test_pytest_only_demo.py` | Plain pytest tests with no Sift APIs. The plugin captures pass/fail automatically; covers functions, fixtures, parametrize, classes, plus one each of `AssertionError` (FAILED), `pytest.skip` (SKIPPED), and a raised `ValueError` (ERROR) |
-| `tests/with_sift/test_with_sift_demo.py` | `step.measure` (numeric/string/bool bounds, units, description, metadata, `channel_names`), `step.measure_avg` and `step.measure_all` for series, an out-of-bounds measurement (pytest PASSED, Sift step FAILED), the recommended `step.pytest_fail_if_step_failed()` end-of-test call that fails pytest while still recording every measurement, nested `step.substep` (with step-level `metadata=...`), `@pytest.mark.sift_exclude`, class step + class docstring → description, nested classes, stacked `@pytest.mark.parametrize`, `step.report_outcome`, and session-level metadata via `report_context.report.update({...})` |
+| `tests/with_sift/test_with_sift_demo.py` | `step.measure` (numeric/string/bool bounds, units, description, metadata, `channel_names`), `step.measure_avg` and `step.measure_all` for series, an out-of-bounds measurement (pytest PASSED, Sift step FAILED), the recommended `step.pytest_fail_if_step_failed()` end-of-test call that fails pytest while still recording every measurement, nested `step.substep` (with step-level `metadata=...`), `@pytest.mark.sift_exclude`, class step + class docstring → description, nested classes, stacked `@pytest.mark.parametrize`, a class-scoped parametrized fixture lifted above its methods by scope and given human-readable step labels via `ids=`, `step.report_outcome`, and session-level metadata via `report_context.report.update({...})` |
 | `tests/{pytest_only,with_sift}/__init__.py` | Each Python package (directory with `__init__.py`) becomes a parent step in the report tree |

--- a/python/examples/pytest_plugin/tests/with_sift/test_with_sift_demo.py
+++ b/python/examples/pytest_plugin/tests/with_sift/test_with_sift_demo.py
@@ -175,3 +175,45 @@ class TestClassStep:
         def test_report_outcome(self, step) -> None:
             """``step.report_outcome`` records a non-numeric pass/fail substep."""
             step.report_outcome(name="check", result=True, reason="value matched")
+
+
+@pytest.fixture(
+    scope="class",
+    params=["1.4.2", "2.0.0-rc1"],
+    ids=["stable", "beta"],
+)
+def firmware(request) -> str:
+    """A class-scoped parametrized fixture: each value re-runs the whole class.
+
+    ``ids=`` gives each value a human-readable label. The plugin uses that label
+    for the step (``stable`` / ``beta``) instead of the default ``name=value``
+    form (``firmware='1.4.2'``). A callable ``ids=`` factory works too — pytest
+    calls it with each value to build the label.
+    """
+    return request.param
+
+
+class TestScopedFixtureParam:
+    """Higher-scoped parametrized fixtures lift to their scope in the tree.
+
+    The ``firmware`` fixture is class-scoped, so pytest sets it up once per
+    value for the whole class. The plugin places its parameter at that scope:
+    just inside the class step, wrapping the methods, so each method runs once
+    per value. Contrast this with the function-level ``@pytest.mark.parametrize``
+    in ``TestClassStep.test_parametrize`` above, whose axes nest UNDER the test
+    rather than above its methods. The same rule scales the ladder: a
+    module-scoped fixture param lifts above the module's tests, a session-scoped
+    one to the report root, and a ``@pytest.mark.parametrize(..., scope=...)``
+    follows the scope it names.
+
+    The steps here are named ``stable`` / ``beta`` because ``firmware`` declares
+    ``ids=``; without it they would read ``firmware='1.4.2'`` / etc.
+    """
+
+    def test_boots(self, step, firmware: str) -> None:
+        """Runs once per firmware revision, under that revision's step."""
+        step.measure(name="boot_ok", value=True, bounds=True)
+
+    def test_reports_version(self, step, firmware: str) -> None:
+        """Also runs once per revision; both methods share each ``firmware`` step."""
+        step.measure(name="firmware_rev", value=firmware, bounds=firmware)

--- a/python/lib/sift_client/_internal/pytest_plugin/options.py
+++ b/python/lib/sift_client/_internal/pytest_plugin/options.py
@@ -289,7 +289,9 @@ AUTOUSE_OPTION = Option(
 PACKAGE_STEP_OPTION = Option(
     name="package_step",
     category=CAT_BEHAVIOR,
-    help="Open a parent step for each Python package in the test path.",
+    help="Open a parent step for each Python package (a directory with an "
+    "__init__.py) in the test path. To drop a single unwanted one, delete that "
+    "__init__.py.",
     ini="sift_package_step",
     ini_type="bool",
     ini_default=True,

--- a/python/lib/sift_client/_internal/pytest_plugin/report.py
+++ b/python/lib/sift_client/_internal/pytest_plugin/report.py
@@ -559,21 +559,30 @@ def build_disabled_client() -> SiftClient:
     return client
 
 
+def leaf_step_name(node: pytest.Item, config: pytest.Config) -> str:
+    """The display name for a test's leaf step.
+
+    Items get a parametrize path stashed in ``pytest_itemcollected``; the leaf
+    frame (``path[-1]``) is the test-specific display name with higher-scoped
+    params promoted out (e.g. ``v=1``, or the bare function name). When
+    parametrize-nesting is disabled, fall back to the bracket-mangled pytest
+    name (e.g. ``test_a[1]``) so the leaf stays uniquely identifiable. Shared by
+    the autouse ``step`` fixture and the collection-skip path so a skipped
+    parametrized item is named the same way a run one would be.
+    """
+    if PARAMETRIZE_NESTING_OPTION.resolve(config):
+        path = node.stash.get(parametrize_path_key, ())
+        return path[-1] if path else str(node.name)
+    return str(node.name)
+
+
 def step_impl(
     report_context: ReportContext, request: pytest.FixtureRequest
 ) -> Generator[NewStep, None, None]:
     node = request.node
-    # Items get a parametrize path stashed in ``pytest_itemcollected``;
-    # modules/other nodes fall back to their node name. The leaf frame
-    # (``path[-1]``) is the test-specific display name; parents are opened by
-    # ``_sift_parents``. When parametrize-nesting is disabled, fall back to the
-    # bracket-mangled pytest name (e.g. ``test_a[1]``) so the leaf remains
-    # uniquely identifiable.
-    if PARAMETRIZE_NESTING_OPTION.resolve(request.config):
-        path = node.stash.get(parametrize_path_key, ())
-        name = path[-1] if path else str(node.name)
-    else:
-        name = str(node.name)
+    # The leaf frame is the test-specific display name; parents are opened by
+    # ``_sift_parents``.
+    name = leaf_step_name(node, request.config)
     # ``node.obj`` may not exist (e.g., ``pytest.DoctestItem``) or may raise
     # when accessed; fall back to no description in those cases rather than
     # erroring out a perfectly valid test. ``getattr``'s default only

--- a/python/lib/sift_client/_internal/pytest_plugin/steps.py
+++ b/python/lib/sift_client/_internal/pytest_plugin/steps.py
@@ -70,6 +70,7 @@ def _signal_introspection_degraded(detail: str) -> None:
     )
     log_event(logger, logging.WARNING, "parametrize.introspection_degraded", detail=detail)
 
+
 if TYPE_CHECKING:
     from typing import Callable
 
@@ -151,11 +152,34 @@ expected_parametrize: dict[ParametrizeKey, int] = {}
 leaf_parents: dict[str, LeafParents] = {}
 
 
+# --- Private-pytest-API surface -------------------------------------------
+# Scope-aware parametrize placement reads a few pytest internals that have no
+# public equivalent. They are confined to the helpers below and each is guarded
+# so a pytest change degrades to flat (function-scoped) rendering with a single
+# warning, never a crash. The inventory, so it stays auditable in one place:
+#
+#   * ``session._fixturemanager.getfixturedefs`` — the only genuinely private
+#     access; obtaining a parametrized fixture's ``FixtureDef``. Wrapped in
+#     ``_fixturedefs`` (degrade + warn). The attributes read off the result
+#     (``.scope``, ``.baseid``, ``.ids``) are documented-stable public API.
+#   * ``item.callspec.params`` / ``.indices`` — semi-private but de-facto stable
+#     (every parametrize-aware plugin relies on it); read under try/except.
+#   * ``mark.args``/``mark.kwargs`` and ``node.parent``/``node.obj`` — public.
+#
+# pytest's own private scope dict (``callspec._arg2scope``) is deliberately NOT
+# read; ``_param_scope`` reconstructs the same result from public data.
+# CI exercises this surface against pytest 7/8/9 (see test-pytest-compat).
 def _fixturedefs(item: pytest.Item, name: str) -> Any:
     """The ``FixtureDef`` tuple for ``name``, or None when it is mark-based.
 
-    pytest 8 takes the node object; older versions take the nodeid string, so
-    fall back on ``TypeError`` to stay importable across the supported range.
+    The signature of ``getfixturedefs`` differs by pytest version: 8.x/9.x take
+    the node object, pytest 7.x takes the nodeid string. So we try the node
+    first and retry with the nodeid on failure. The retry trigger spans both
+    error shapes the wrong-type call raises: pytest 8.x/9.x raise ``TypeError``
+    when handed a nodeid where a node is expected, while pytest 7.x raises
+    ``AttributeError`` (it calls ``nodeid.find(...)`` on what is actually a
+    node, which has no ``.find``). Catching only ``TypeError`` would leave the
+    7.x path dead and silently degrade every parametrized test on pytest 7.
 
     A clean ``None`` means "no such fixture" (a mark-based param), which is
     normal and not a failure. Reaching the fixture manager at all is the part
@@ -169,7 +193,7 @@ def _fixturedefs(item: pytest.Item, name: str) -> Any:
         return None
     try:
         return manager.getfixturedefs(name, item)
-    except TypeError:
+    except (TypeError, AttributeError):
         try:
             return manager.getfixturedefs(name, item.nodeid)  # type: ignore[arg-type]
         except Exception as exc:
@@ -199,27 +223,32 @@ def _mark_argnames(mark: pytest.Mark) -> list[str]:
 def _param_scope(item: pytest.Item, name: str) -> str:
     """The pytest scope governing param ``name`` on ``item``.
 
-    Prefers ``callspec._arg2scope`` — pytest's own resolution, which already
-    folds in indirect parametrize, a mark's ``scope=`` override, and the
-    fixture's declared scope. Falls back to the fixture scope, then a mark's
-    ``scope=`` kwarg, then ``"function"`` for older pytest where ``_arg2scope``
-    is absent. ``callspec.params`` order is application order, NOT scope order,
-    so callers must bucket by this rather than trust position.
+    Resolved from public data, mirroring pytest's own rule (see
+    ``_find_parametrized_scope`` in pytest's ``python.py``): an explicit mark
+    ``scope=`` wins, else a parametrized/indirect fixture contributes its
+    declared ``fixturedef.scope``, else a plain ``@pytest.mark.parametrize`` axis
+    is ``"function"``. We deliberately do NOT read pytest's private
+    ``callspec._arg2scope``; the only internal still consulted is obtaining the
+    fixturedef (see ``_fixturedefs``), whose ``.scope`` attribute is public.
+
+    One intentional divergence from ``_arg2scope``: a combined ``indirect`` axis
+    (``"a,b"``) whose fixtures have different scopes gets each name its own
+    scope here, where pytest collapses both to the narrowest. Per-name placement
+    is what the report wants, and ``build_scoped_params`` already buckets by it.
+    ``callspec.params`` order is application order, NOT scope order, so callers
+    must bucket by this rather than trust position.
     """
-    callspec = getattr(item, "callspec", None)
-    if callspec is not None:
-        arg2scope = getattr(callspec, "_arg2scope", None)
-        if arg2scope is not None:
-            scope = arg2scope.get(name)
-            if scope is not None:
-                # pytest's ``Scope`` enum stringifies to the scope name.
-                return getattr(scope, "value", None) or str(scope)
+    # An explicit mark ``scope=`` takes precedence (pytest's ``Scope.from_user``
+    # before the fixture-derived scope).
+    for mark in item.iter_markers("parametrize"):
+        if name in _mark_argnames(mark):
+            mark_scope = mark.kwargs.get("scope")
+            if mark_scope:
+                return mark_scope
+    # Otherwise a parametrized or indirect fixture lends its declared scope.
     fixture_scope = _fixture_scope(item, name)
     if fixture_scope is not None:
         return fixture_scope
-    for mark in item.iter_markers("parametrize"):
-        if name in _mark_argnames(mark):
-            return mark.kwargs.get("scope") or "function"
     return "function"
 
 
@@ -379,12 +408,16 @@ def build_hierarchy_chain(
     # isn't part of pytest's public API; widen to ``Any`` for the walk.
     node: Any = item
     while node is not None:
+        # Check Package before Module: on pytest 7.x ``Package`` subclasses
+        # ``Module``, so the Module branch would otherwise swallow a package node
+        # and render it (ignoring ``sift_package_step``). pytest 8's collection
+        # refactor made them unrelated, so the order is harmless there.
         if isinstance(node, pytest.Class):
             rendered, scope = include_class, "class"
-        elif isinstance(node, pytest.Module):
-            rendered, scope = include_module, "module"
         elif isinstance(node, pytest.Package):
             rendered, scope = include_package, "package"
+        elif isinstance(node, pytest.Module):
+            rendered, scope = include_module, "module"
         else:
             node = node.parent
             continue

--- a/python/lib/sift_client/_internal/pytest_plugin/steps.py
+++ b/python/lib/sift_client/_internal/pytest_plugin/steps.py
@@ -1,6 +1,8 @@
 """Report-tree parent steps: an identity-keyed registry built without reordering.
 
-Each test's package/module/class ancestors ("hierarchy" parents) and each
+Each test's package/module/class ancestors ("hierarchy" parents), its
+scope-promoted parametrized params (session/package/module/class-scoped fixtures,
+placed at their scope's level on the ladder), and each function-scoped
 ``@pytest.mark.parametrize`` axis ("parametrize" parents) become parent steps the
 leaf nests under. Parents are kept in identity-keyed registries — created once and
 reused by every descendant regardless of execution order — so the plugin never
@@ -39,28 +41,41 @@ if TYPE_CHECKING:
 # generics (not ``list``/``tuple``) because some are used in runtime
 # ``StashKey[...]`` subscriptions, which must stay importable on Python 3.8.
 #
-# A hierarchy parent's identity is just a ``str`` (the ancestor node's
-# ``nodeid``); a parametrize parent's identity is a ``ParametrizeKey``: the
-# test's param-stripped node id followed by its outer-to-inner axis frames
-# (e.g. ``("pkg/test_m.py::TestC::test_a", "v=1")``).
-ParametrizeKey = Tuple[str, ...]
+# A hierarchy parent's identity is a ``HierarchyKey``: the literal path from the
+# report root to that parent, one segment per ancestor, each tagged by kind —
+# ``("n", node_nodeid)`` for a package/module/class step, ``("p", label)`` for a
+# scope-promoted param frame (e.g. a session/module/class-scoped parametrized
+# fixture). Building identities as kind-tagged tuples (rather than a delimited
+# string) keeps them collision-free even when a param label contains ``::``.
+# A parametrize parent's identity is a ``ParametrizeKey``: the enclosing
+# ``HierarchyKey`` path, then the test's param-stripped node id, then its
+# outer-to-inner function-axis frames (e.g. ``(<path>, "…::test_a", "v=1")``).
+HierarchySegment = Tuple[str, str]  # ("n", nodeid) | ("p", label)
+HierarchyKey = Tuple[HierarchySegment, ...]
+ParametrizeKey = Tuple[Any, ...]
 # Outer-to-inner display-name axis path stashed per parametrized item
-# (``(originalname, "v=1", ...)``); the leaf is its last frame.
+# (``(originalname, "v=1", ...)``); the leaf is its last frame. Function-scoped
+# axes only — higher-scoped params are promoted into the hierarchy.
 ParametrizePath = Tuple[str, ...]
-# One collection-tree ancestor: ``(identity, display name, docstring, rendered)``.
-# ``rendered`` is True iff that layer's ``sift_*_step`` ini flag opens a step.
-HierarchyFrame = Tuple[str, str, Optional[str], bool]
+# One collection-tree ancestor: ``(identity, display name, docstring, rendered,
+# scope)``. ``rendered`` is True iff that layer's ``sift_*_step`` ini flag opens a
+# step; ``scope`` is the pytest scope the node anchors ("package"/"module"/"class").
+HierarchyFrame = Tuple[str, str, Optional[str], bool, str]
 # Outer-to-inner ancestor frames stashed per item.
 HierarchyChain = Tuple[HierarchyFrame, ...]
 # A rendered parent to open, as returned by ``resolved_parents``.
-HierarchyParent = Tuple[str, str, Optional[str]]  # (identity, name, docstring)
+HierarchyParent = Tuple[HierarchyKey, str, Optional[str]]  # (identity, name, docstring)
 ParametrizeParent = Tuple[ParametrizeKey, str]  # (registry key, frame name)
+# Scope-promoted params (anything broader than function scope) stashed per item.
+# Each entry is ``(scope, param_name, label)``; in callspec application order.
+ScopedParams = Tuple[Tuple[str, str, str], ...]
 # A gated-in leaf's parents: its rendered hierarchy identities and parametrize keys.
-LeafParents = Tuple[List[str], List[ParametrizeKey]]
+LeafParents = Tuple[List[HierarchyKey], List[ParametrizeKey]]
 
 parametrize_path_key = pytest.StashKey[ParametrizePath]()
 
 hierarchy_key = pytest.StashKey[HierarchyChain]()
+scoped_params_key = pytest.StashKey[ScopedParams]()
 # See ``HierarchyFrame`` above for the chain entry shape. ``identity`` is the
 # node's ``nodeid``: two ancestors at the same depth with the same display name
 # but reached via different paths (e.g., ``proj_a/utils`` and ``proj_b/utils`` in
@@ -75,9 +90,9 @@ hierarchy_key = pytest.StashKey[HierarchyChain]()
 # ``ReportContext.step_stack`` (created with ``push=False``) and are closed early
 # by ``release_finished_leaf``, or at session end by ``finalize_parents``.
 #
-# Hierarchy parents (packages / modules / classes) keyed by the ancestor node's
-# ``nodeid``:
-hierarchy_parents: dict[str, NewStep] = {}
+# Hierarchy parents (packages / modules / classes / scope-promoted params) keyed
+# by their ``HierarchyKey`` root-to-node path:
+hierarchy_parents: dict[HierarchyKey, NewStep] = {}
 # Parametrize parents keyed by ``ParametrizeKey``, so sibling parametrizations of
 # one test share a parent while parametrizations under different
 # tests/classes/modules never collide:
@@ -88,18 +103,159 @@ parametrize_parents: dict[ParametrizeKey, NewStep] = {}
 # ``tally_expected_parents`` and decremented as each test finishes; when a count
 # reaches zero the parent's whole subtree is done and it is closed early (see
 # ``release_finished_leaf``) instead of waiting for session end.
-expected_hierarchy: dict[str, int] = {}
+expected_hierarchy: dict[HierarchyKey, int] = {}
 expected_parametrize: dict[ParametrizeKey, int] = {}
 # Each gated-in leaf's parent identities, so ``release_finished_leaf`` — which
 # only receives a nodeid — knows which counters to decrement.
 leaf_parents: dict[str, LeafParents] = {}
 
 
+def _fixturedefs(item: pytest.Item, name: str) -> Any:
+    """The ``FixtureDef`` tuple for ``name``, or None when it is mark-based.
+
+    pytest 8 takes the node object; older versions take the nodeid string, so
+    fall back on ``TypeError`` to stay importable across the supported range.
+    """
+    try:
+        return item.session._fixturemanager.getfixturedefs(name, item)
+    except TypeError:
+        return item.session._fixturemanager.getfixturedefs(name, item.nodeid)  # type: ignore[arg-type]
+
+
+def _fixture_scope(item: pytest.Item, name: str) -> str | None:
+    """Return the scope of a fixture param, or None if it is mark-based."""
+    defs = _fixturedefs(item, name)
+    if defs:
+        return defs[-1].scope
+    return None
+
+
+def _mark_argnames(mark: pytest.Mark) -> list[str]:
+    """The argnames a ``parametrize`` mark covers (``"a,b"`` → ``["a", "b"]``)."""
+    argnames = mark.args[0]
+    if isinstance(argnames, str):
+        return [a.strip() for a in argnames.split(",")]
+    return list(argnames)
+
+
+def _param_scope(item: pytest.Item, name: str) -> str:
+    """The pytest scope governing param ``name`` on ``item``.
+
+    Prefers ``callspec._arg2scope`` — pytest's own resolution, which already
+    folds in indirect parametrize, a mark's ``scope=`` override, and the
+    fixture's declared scope. Falls back to the fixture scope, then a mark's
+    ``scope=`` kwarg, then ``"function"`` for older pytest where ``_arg2scope``
+    is absent. ``callspec.params`` order is application order, NOT scope order,
+    so callers must bucket by this rather than trust position.
+    """
+    callspec = getattr(item, "callspec", None)
+    if callspec is not None:
+        arg2scope = getattr(callspec, "_arg2scope", None)
+        if arg2scope is not None:
+            scope = arg2scope.get(name)
+            if scope is not None:
+                # pytest's ``Scope`` enum stringifies to the scope name.
+                return getattr(scope, "value", None) or str(scope)
+    fixture_scope = _fixture_scope(item, name)
+    if fixture_scope is not None:
+        return fixture_scope
+    for mark in item.iter_markers("parametrize"):
+        if name in _mark_argnames(mark):
+            return mark.kwargs.get("scope") or "function"
+    return "function"
+
+
+def _id_from_spec(ids: Any, index: int, value: Any) -> str | None:
+    """Resolve one axis's author-supplied ``ids`` spec to a string, or None.
+
+    A list spec is indexed by the param's position; a callable spec (an ID
+    factory) is invoked with the param value, mirroring how pytest builds the
+    node ID. A callable that raises or returns ``None`` yields None, so the
+    caller falls back to the structured ``name=value`` label. ``None`` here also
+    covers "the author supplied no ``ids``" — those auto-generated IDs are noisier
+    than ``name=value`` for non-trivial values, so we never adopt them.
+    """
+    if ids is None:
+        return None
+    if callable(ids):
+        try:
+            result = ids(value)
+        except Exception:
+            return None
+        return str(result) if result is not None else None
+    if index < len(ids):
+        return str(ids[index])
+    return None
+
+
+def _explicit_param_id(item: pytest.Item, name: str, value: Any) -> str | None:
+    """The author-supplied pytest ID for param ``name`` on ``item``, else None.
+
+    Honours an explicit ``ids=`` — list or callable factory — declared on the
+    fixture (``@pytest.fixture(params=..., ids=...)``) or on the
+    ``@pytest.mark.parametrize`` axis, matching the friendly labels pytest puts
+    in the node ID. Combined axes (``"a,b"``) are skipped: their single shared
+    ID can't be attributed to one of the two frames the report renders, so those
+    fall back to ``name=value``.
+    """
+    callspec = getattr(item, "callspec", None)
+    if callspec is None:
+        return None
+    index = callspec.indices.get(name)
+    if index is None:
+        return None
+    # Fixture params: the ``ids`` spec lives on the active FixtureDef.
+    defs = _fixturedefs(item, name)
+    if defs:
+        resolved = _id_from_spec(getattr(defs[-1], "ids", None), index, value)
+        if resolved is not None:
+            return resolved
+    # mark.parametrize: the ``ids`` spec lives in the marker kwargs.
+    for mark in item.iter_markers("parametrize"):
+        names = _mark_argnames(mark)
+        if len(names) == 1 and names[0] == name:
+            resolved = _id_from_spec(mark.kwargs.get("ids"), index, value)
+            if resolved is not None:
+                return resolved
+    return None
+
+
+def _param_label(item: pytest.Item, name: str, value: Any) -> str:
+    """Display label for one param axis: its explicit pytest ID, else ``name=value``."""
+    return _explicit_param_id(item, name, value) or f"{name}={value!r}"
+
+
+def build_scoped_params(item: pytest.Item) -> ScopedParams:
+    """Scope-promoted params for ``item`` (anything broader than function scope).
+
+    Each entry is ``(scope, name, label)`` in ``callspec.params`` application
+    order. ``resolved_parents`` buckets these by scope and places them at their
+    scope's hierarchy level. Function-scoped axes are excluded — they stay inner,
+    handled by ``build_parametrize_path``.
+    """
+    callspec = getattr(item, "callspec", None)
+    if callspec is None or not callspec.params:
+        return ()
+    out: list[tuple[str, str, str]] = []
+    for name, value in callspec.params.items():
+        scope = _param_scope(item, name)
+        if scope == "function":
+            continue
+        out.append((scope, name, _param_label(item, name, value)))
+    return tuple(out)
+
+
 def build_parametrize_path(item: pytest.Item) -> ParametrizePath:
-    """Outer-to-inner step display names for a parametrized item.
+    """Outer-to-inner function-axis display names for a parametrized item.
 
     Pytest stores ``callspec.params`` with the BOTTOM decorator's axis first;
     the Sift step tree treats the TOP decorator as outermost, so we reverse.
+    Only function-scoped axes appear here — higher-scoped params are promoted
+    into the hierarchy by ``resolved_parents``. Each axis is labelled by its
+    explicit pytest ID when the author supplied one, otherwise by ``name=value``
+    (see ``_param_label``). The first frame is always ``originalname`` so the
+    leaf step (``path[-1]`` in ``report.step_impl``) is the bare function name
+    when a test has no function-scoped params of its own.
     """
     callspec = getattr(item, "callspec", None)
     if callspec is None or not callspec.params:
@@ -107,7 +263,9 @@ def build_parametrize_path(item: pytest.Item) -> ParametrizePath:
     originalname = getattr(item, "originalname", item.name)
     frames: list[str] = [originalname]
     for name, value in reversed(callspec.params.items()):
-        frames.append(f"{name}={value!r}")
+        if _param_scope(item, name) != "function":
+            continue
+        frames.append(_param_label(item, name, value))
     return tuple(frames)
 
 
@@ -115,7 +273,7 @@ def build_hierarchy_chain(
     item: pytest.Item | pytest.Collector,
     config: pytest.Config,
 ) -> HierarchyChain:
-    """Outer-to-inner ``(identity, name, docstring, rendered)`` for collection ancestors.
+    """Outer-to-inner ``(identity, name, docstring, rendered, scope)`` for collection ancestors.
 
     Walks ``item.parent`` upward and ALWAYS collects every ``pytest.Package``,
     ``pytest.Module``, and ``pytest.Class`` ancestor; they all carry the identity
@@ -146,11 +304,11 @@ def build_hierarchy_chain(
     node: Any = item
     while node is not None:
         if isinstance(node, pytest.Class):
-            rendered = include_class
+            rendered, scope = include_class, "class"
         elif isinstance(node, pytest.Module):
-            rendered = include_module
+            rendered, scope = include_module, "module"
         elif isinstance(node, pytest.Package):
-            rendered = include_package
+            rendered, scope = include_package, "package"
         else:
             node = node.parent
             continue
@@ -160,9 +318,73 @@ def build_hierarchy_chain(
             ).strip() or None
         except Exception:
             doc = None
-        chain.append((node.nodeid, node.name, doc, rendered))
+        chain.append((node.nodeid, node.name, doc, rendered, scope))
         node = node.parent
     return tuple(reversed(chain))
+
+
+def _pick_class_index(
+    node: pytest.Item, name: str, class_idxs: list[int], chain: HierarchyChain
+) -> int | None:
+    """Which Class chain frame a class-scoped param ``name`` anchors to.
+
+    For a class-scoped fixture, the owning class is the deepest Class frame whose
+    nodeid prefixes the fixture's ``baseid`` — so a fixture defined on an outer
+    class anchors there, not under an inner nested class. Mark-based class params
+    (no fixturedef) and unmatched cases fall back to the innermost class.
+    """
+    if not class_idxs:
+        return None
+    defs = _fixturedefs(node, name)
+    baseid = getattr(defs[-1], "baseid", "") if defs else ""
+    if baseid:
+        best, best_len = None, -1
+        for i in class_idxs:
+            nid = chain[i][0]
+            if (baseid == nid or baseid.startswith(nid + "::")) and len(nid) > best_len:
+                best, best_len = i, len(nid)
+        if best is not None:
+            return best
+    return class_idxs[-1]
+
+
+def _scoped_param_anchors(
+    node: pytest.Item, scoped: ScopedParams, chain: HierarchyChain
+) -> dict[int | None, list[str]]:
+    """Map each scope-promoted param to the chain-frame index it nests at.
+
+    Returns an ``anchors`` map of chain-frame index → param labels at that frame.
+    The ``None`` key holds params with no collector node — session-scoped params
+    (emitted above the chain) and the rare fall-through when a param's scope has
+    no frame at all. Scopes are processed package→module→class (so broader nests
+    outside narrower at a shared anchor), and each scope's params are reversed
+    (top-decorator-outermost). A param whose scope has no matching frame falls
+    back to the nearest broader frame (module, else the ``None`` root bucket).
+    """
+    pkg_idx = next((i for i, f in enumerate(chain) if f[4] == "package"), None)
+    mod_idx = next((i for i, f in enumerate(chain) if f[4] == "module"), None)
+    class_idxs = [i for i, f in enumerate(chain) if f[4] == "class"]
+
+    by_scope: dict[str, list[tuple[str, str]]] = {}
+    for scope, name, label in scoped:
+        by_scope.setdefault(scope, []).append((name, label))
+
+    anchors: dict[int | None, list[str]] = {}
+
+    def place(idx: int | None, label: str) -> None:
+        anchors.setdefault(idx, []).append(label)
+
+    # Reverse within each scope so the top decorator / outermost axis nests first.
+    for _name, label in reversed(by_scope.get("session", [])):
+        place(None, label)
+    for _name, label in reversed(by_scope.get("package", [])):
+        place(pkg_idx if pkg_idx is not None else mod_idx, label)
+    for _name, label in reversed(by_scope.get("module", [])):
+        place(mod_idx, label)
+    for name, label in reversed(by_scope.get("class", [])):
+        idx = _pick_class_index(node, name, class_idxs, chain)
+        place(idx if idx is not None else mod_idx, label)
+    return anchors
 
 
 def resolved_parents(
@@ -176,35 +398,68 @@ def resolved_parents(
     two can never key on different identities. Returns ``(hierarchy, parametrize)``
     outer-to-inner:
 
-    * hierarchy: ``(identity, name, doc)`` for each rendered package/module/class
-      ancestor. ``identity`` is the node's ``nodeid`` (the registry key).
-    * parametrize: ``(registry key, frame name)`` for each parametrize axis except
-      the innermost (the leaf is the ``step`` fixture's job). Empty when
-      ``sift_parametrize_nesting`` is off or the item isn't parametrized.
+    * hierarchy: ``(identity, name, doc)`` for each rendered parent, built by
+      walking the package/module/class chain and interleaving each scope-promoted
+      param (session/package/module/class-scoped parametrized fixture, or a mark
+      with ``scope=``) at its scope's level — broader scope nests outside narrower.
+      ``identity`` is the ``HierarchyKey`` registry key (the root-to-node path).
+    * parametrize: ``(registry key, frame name)`` for each function-scoped
+      ``@pytest.mark.parametrize`` axis except the innermost (the leaf is the
+      ``step`` fixture's job). Empty when ``sift_parametrize_nesting`` is off or
+      the item has no function-scoped params.
 
     Reads the per-item stash written in ``pytest_itemcollected``; recomputes for
     items a later hook injected without going through it.
     """
-    if hierarchy_key in node.stash:
-        chain = node.stash[hierarchy_key]
-    else:
-        chain = build_hierarchy_chain(node, config)
-    # Non-rendered frames open no step; the next rendered descendant attaches to
-    # the nearest rendered ancestor, so they are simply dropped here.
-    hierarchy = [(identity, name, doc) for identity, name, doc, rendered in chain if rendered]
+    chain = (
+        node.stash[hierarchy_key]
+        if hierarchy_key in node.stash
+        else build_hierarchy_chain(node, config)
+    )
+    scoped = (
+        node.stash[scoped_params_key]
+        if scoped_params_key in node.stash
+        else build_scoped_params(node)
+    )
+
+    anchors = _scoped_param_anchors(node, scoped, chain)
+
+    # Each parent's identity is the literal root-to-node path of kind-tagged
+    # segments, so it is unique by construction even when a param label collides
+    # with a node name or contains separators. Non-rendered frames still extend
+    # the path (keeping descendant identities distinct across modules/classes) but
+    # open no step; the next rendered parent attaches to the nearest rendered
+    # ancestor via ``_resolve_parent_chain``'s carry-over.
+    hierarchy: list[HierarchyParent] = []
+    path: HierarchyKey = ()
+
+    # Root-level params (session scope, plus any with no collector frame).
+    for label in anchors.pop(None, []):
+        path = (*path, ("p", label))
+        hierarchy.append((path, label, None))
+
+    for idx, (nodeid, name, _doc, rendered, _scope) in enumerate(chain):
+        path = (*path, ("n", nodeid))
+        if rendered:
+            hierarchy.append((path, name, _doc))
+        for label in anchors.get(idx, []):
+            path = (*path, ("p", label))
+            hierarchy.append((path, label, None))
 
     parametrize: list[ParametrizeParent] = []
     if PARAMETRIZE_NESTING_OPTION.resolve(config):
-        if parametrize_path_key in node.stash:
-            path = node.stash[parametrize_path_key]
-        else:
-            path = build_parametrize_path(node)
-        if path:
-            # Key parametrize parents by the test's param-stripped identity plus
-            # the outer frame prefix, so sibling params share a parent but params
-            # under different tests never merge.
-            key: ParametrizeKey = (strip_param(node.nodeid),)
-            for frame in path[:-1]:
+        ppath = (
+            node.stash[parametrize_path_key]
+            if parametrize_path_key in node.stash
+            else build_parametrize_path(node)
+        )
+        if ppath:
+            # Key function-axis parents by the full hierarchy path plus the test's
+            # param-stripped nodeid, so sibling params share a parent but params
+            # under different tests (or scope universes) never merge.
+            base = strip_param(node.nodeid)
+            key: ParametrizeKey = (path, base)
+            for frame in ppath[:-1]:
                 key = (*key, frame)
                 parametrize.append((key, frame))
     return hierarchy, parametrize

--- a/python/lib/sift_client/_internal/pytest_plugin/steps.py
+++ b/python/lib/sift_client/_internal/pytest_plugin/steps.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
 import pytest
 
+from sift_client._internal.pytest_plugin.audit_log import log_event
 from sift_client._internal.pytest_plugin.modes import gate_enabled
 from sift_client._internal.pytest_plugin.options import (
     CLASS_STEP_OPTION,
@@ -28,6 +29,46 @@ from sift_client._internal.pytest_plugin.options import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Scope-aware parametrize placement and ``ids=`` label resolution read a few
+# pytest internals (the fixture manager, ``callspec``). If a pytest version
+# moves or reshapes those, we degrade to function-scoped nesting with
+# ``name=value`` labels instead of failing the user's collection — and surface
+# the loss once per session via ``_signal_introspection_degraded``. This latch
+# keeps that to a single warning; ``reset_introspection_state`` clears it at the
+# start of each session (see ``pytest_configure``).
+_introspection_degraded = False
+
+
+def reset_introspection_state() -> None:
+    """Clear the one-shot introspection-failure latch. Called at session start."""
+    global _introspection_degraded
+    _introspection_degraded = False
+
+
+def _signal_introspection_degraded(detail: str) -> None:
+    """Warn + audit-log once that parametrize scope/label introspection failed.
+
+    Fired only when reaching a pytest internal actually fails — not for the
+    ordinary "no fixturedef, it's a mark-based param" case. The report still
+    renders; scope-promoted params just fall back to function-scoped nesting.
+    """
+    global _introspection_degraded
+    if _introspection_degraded:
+        return
+    _introspection_degraded = True
+    # Local import avoids a circular import (pytest_plugin imports this module).
+    from sift_client.pytest_plugin import SiftPytestPluginWarning
+
+    warnings.warn(
+        "Sift pytest plugin could not read pytest internals for scope-aware "
+        f"parametrize placement ({detail}); parametrized fixtures will render "
+        "flat (function-scoped) with name=value labels. The rest of the report "
+        "is unaffected. This usually means an unsupported pytest version.",
+        SiftPytestPluginWarning,
+        stacklevel=2,
+    )
+    log_event(logger, logging.WARNING, "parametrize.introspection_degraded", detail=detail)
 
 if TYPE_CHECKING:
     from typing import Callable
@@ -115,11 +156,28 @@ def _fixturedefs(item: pytest.Item, name: str) -> Any:
 
     pytest 8 takes the node object; older versions take the nodeid string, so
     fall back on ``TypeError`` to stay importable across the supported range.
+
+    A clean ``None`` means "no such fixture" (a mark-based param), which is
+    normal and not a failure. Reaching the fixture manager at all is the part
+    that depends on a pytest internal: if that attribute is gone or the call
+    raises something unexpected, degrade to ``None`` and latch the one-shot
+    warning rather than letting it escape into the user's collection.
     """
+    manager = getattr(getattr(item, "session", None), "_fixturemanager", None)
+    if manager is None:
+        _signal_introspection_degraded("fixture manager unavailable")
+        return None
     try:
-        return item.session._fixturemanager.getfixturedefs(name, item)
+        return manager.getfixturedefs(name, item)
     except TypeError:
-        return item.session._fixturemanager.getfixturedefs(name, item.nodeid)  # type: ignore[arg-type]
+        try:
+            return manager.getfixturedefs(name, item.nodeid)  # type: ignore[arg-type]
+        except Exception as exc:
+            _signal_introspection_degraded(f"getfixturedefs failed ({exc!r})")
+            return None
+    except Exception as exc:
+        _signal_introspection_degraded(f"getfixturedefs failed ({exc!r})")
+        return None
 
 
 def _fixture_scope(item: pytest.Item, name: str) -> str | None:
@@ -236,13 +294,19 @@ def build_scoped_params(item: pytest.Item) -> ScopedParams:
     callspec = getattr(item, "callspec", None)
     if callspec is None or not callspec.params:
         return ()
-    out: list[tuple[str, str, str]] = []
-    for name, value in callspec.params.items():
-        scope = _param_scope(item, name)
-        if scope == "function":
-            continue
-        out.append((scope, name, _param_label(item, name, value)))
-    return tuple(out)
+    try:
+        out: list[tuple[str, str, str]] = []
+        for name, value in callspec.params.items():
+            scope = _param_scope(item, name)
+            if scope == "function":
+                continue
+            out.append((scope, name, _param_label(item, name, value)))
+        return tuple(out)
+    except Exception as exc:
+        # Degrade to "nothing promoted": every axis stays function-scoped via
+        # build_parametrize_path, so the leaf still renders, just flat.
+        _signal_introspection_degraded(f"scoped-param resolution failed ({exc!r})")
+        return ()
 
 
 def build_parametrize_path(item: pytest.Item) -> ParametrizePath:
@@ -262,10 +326,22 @@ def build_parametrize_path(item: pytest.Item) -> ParametrizePath:
         return ()
     originalname = getattr(item, "originalname", item.name)
     frames: list[str] = [originalname]
-    for name, value in reversed(callspec.params.items()):
-        if _param_scope(item, name) != "function":
-            continue
-        frames.append(_param_label(item, name, value))
+    try:
+        for name, value in reversed(callspec.params.items()):
+            if _param_scope(item, name) != "function":
+                continue
+            frames.append(_param_label(item, name, value))
+    except Exception as exc:
+        # Mirror the build_scoped_params degradation: with scope resolution
+        # broken nothing is promoted, so render every axis here under the bare
+        # leaf name (the pre-scope-aware behavior) rather than dropping frames.
+        _signal_introspection_degraded(f"parametrize-path resolution failed ({exc!r})")
+        frames = [originalname]
+        try:
+            for name, value in reversed(callspec.params.items()):
+                frames.append(f"{name}={value!r}")
+        except Exception:
+            return ()
     return tuple(frames)
 
 

--- a/python/lib/sift_client/_internal/pytest_plugin/terminal.py
+++ b/python/lib/sift_client/_internal/pytest_plugin/terminal.py
@@ -96,6 +96,9 @@ def report_panel_title(report: Any, terminalreporter: Any) -> str:
     if not name:
         return base
     title = f"{base} · {name}"
+    # Guarded private read: ``_tw`` (the TerminalWriter) and its ``fullwidth``
+    # have no public accessor. Cosmetic only (title truncation), so a pytest
+    # change just falls back to 80 columns — no warning needed.
     fullwidth = getattr(getattr(terminalreporter, "_tw", None), "fullwidth", 80)
     # Reserve room for the separator characters and spaces write_sep adds.
     limit = max(len(base), fullwidth - 8)

--- a/python/lib/sift_client/_tests/pytest_plugin/conftest.py
+++ b/python/lib/sift_client/_tests/pytest_plugin/conftest.py
@@ -32,6 +32,19 @@ import pytest
 _SIFT_ENV_VARS = ("SIFT_API_KEY", "SIFT_GRPC_URI", "SIFT_REST_URI", "SIFT_DISABLED", "SIFT_APP_URL")
 
 
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Tag every test in this suite ``plugin_compat``.
+
+    The pytest-version compat matrix (``test-pytest-compat`` in python_ci.yaml)
+    opts in with ``-m plugin_compat`` to run the plugin's behavior suite across
+    pytest 7/8/9; the matrix sets ``GRPC_ENABLE_FORK_SUPPORT=1`` so the grpc that
+    the plugin imports survives ``runpytest_subprocess``'s fork on CI Linux.
+    Applied here so new tests in this suite join the matrix automatically.
+    """
+    for item in items:
+        item.add_marker("plugin_compat")
+
+
 @pytest.fixture
 def clear_sift_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Unset all ``SIFT_*`` environment variables for the duration of the test."""

--- a/python/lib/sift_client/_tests/pytest_plugin/test_hierarchy.py
+++ b/python/lib/sift_client/_tests/pytest_plugin/test_hierarchy.py
@@ -1508,9 +1508,7 @@ def test_no_outer_param_unaffected(pytester: pytest.Pytester, log_file: Path) ->
     assert by_name["test_plain"][0]["parent_step_id"] == mod_id
 
 
-def test_outer_param_subtree_closes_mid_session(
-    pytester: pytest.Pytester, log_file: Path
-) -> None:
+def test_outer_param_subtree_closes_mid_session(pytester: pytest.Pytester, log_file: Path) -> None:
     """The outer-param step resolves as soon as all its tests finish — not at session end."""
     pytester.makeconftest(_SESSION_FIXTURE_CONFTEST)
     pytester.makepyfile(
@@ -1538,9 +1536,7 @@ def test_outer_param_subtree_closes_mid_session(
 # ---------------------------------------------------------------------------
 
 
-def test_explicit_list_ids_on_inner_parametrize(
-    pytester: pytest.Pytester, log_file: Path
-) -> None:
+def test_explicit_list_ids_on_inner_parametrize(pytester: pytest.Pytester, log_file: Path) -> None:
     """An explicit ``ids=[...]`` list labels the parametrize steps, not ``name=value``."""
     pytester.makepyfile(
         test_lid=dedent(

--- a/python/lib/sift_client/_tests/pytest_plugin/test_hierarchy.py
+++ b/python/lib/sift_client/_tests/pytest_plugin/test_hierarchy.py
@@ -1367,3 +1367,610 @@ def test_excluded_sibling_does_not_stall_parent_close(
     assert _index(events, "UpdateTestStep", "TestFoo", terminal=True) < _index(
         events, "CreateTestStep", "TestBar"
     )
+
+
+# ---------------------------------------------------------------------------
+# Outer-param promotion (session/package scoped fixture params)
+# ---------------------------------------------------------------------------
+
+_SESSION_FIXTURE_CONFTEST = """\
+import pytest
+pytest_plugins = ["sift_client.pytest_plugin"]
+
+@pytest.fixture(scope="session", params=[10, 20], autouse=True)
+def outer(request):
+    yield request.param
+"""
+
+
+def test_session_fixture_param_promoted_above_module(
+    pytester: pytest.Pytester, log_file: Path
+) -> None:
+    """A session-scoped autouse fixture with params must appear above the module."""
+    pytester.makeconftest(_SESSION_FIXTURE_CONFTEST)
+    pytester.makepyfile(
+        test_promo=dedent(
+            """
+            def test_a():
+                pass
+
+            def test_b():
+                pass
+            """
+        )
+    )
+    result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
+    result.assert_outcomes(passed=4)
+    steps = capture.load_steps(log_file)
+    by_name = _by_name(steps)
+
+    assert len(by_name["outer=10"]) == 1
+    assert len(by_name["outer=20"]) == 1
+    # Outer param steps are roots — no parent.
+    assert by_name["outer=10"][0]["parent_step_id"] is None
+    assert by_name["outer=20"][0]["parent_step_id"] is None
+    # Module step is nested beneath each outer param step (two distinct instances).
+    assert len(by_name["test_promo.py"]) == 2
+    outer_10_id = by_name["outer=10"][0]["id"]
+    outer_20_id = by_name["outer=20"][0]["id"]
+    mod_parent_ids = {s["parent_step_id"] for s in by_name["test_promo.py"]}
+    assert outer_10_id in mod_parent_ids
+    assert outer_20_id in mod_parent_ids
+
+
+def test_two_outer_param_variants_produce_distinct_module_steps(
+    pytester: pytest.Pytester, log_file: Path
+) -> None:
+    """The same module must not be shared across outer-param universes."""
+    pytester.makeconftest(_SESSION_FIXTURE_CONFTEST)
+    pytester.makepyfile(
+        test_iso=dedent(
+            """
+            def test_x():
+                pass
+            """
+        )
+    )
+    result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
+    result.assert_outcomes(passed=2)
+    steps = capture.load_steps(log_file)
+    by_name = _by_name(steps)
+
+    # Two distinct module steps, one per outer-param universe.
+    assert len(by_name["test_iso.py"]) == 2
+    outer_10_id = by_name["outer=10"][0]["id"]
+    outer_20_id = by_name["outer=20"][0]["id"]
+    parent_ids = [s["parent_step_id"] for s in by_name["test_iso.py"]]
+    assert outer_10_id in parent_ids
+    assert outer_20_id in parent_ids
+    # Each leaf parents to its own module step.
+    assert len(by_name["test_x"]) == 2
+    leaf_parent_ids = {s["parent_step_id"] for s in by_name["test_x"]}
+    mod_ids = {s["id"] for s in by_name["test_iso.py"]}
+    assert leaf_parent_ids == mod_ids
+
+
+def test_inner_parametrize_still_works_inside_outer_param(
+    pytester: pytest.Pytester, log_file: Path
+) -> None:
+    """Inner mark-parametrize nesting must still work within each outer-param universe."""
+    pytester.makeconftest(_SESSION_FIXTURE_CONFTEST)
+    pytester.makepyfile(
+        test_inner=dedent(
+            """
+            import pytest
+
+            @pytest.mark.parametrize("v", [1, 2])
+            def test_inner(v):
+                pass
+            """
+        )
+    )
+    result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
+    result.assert_outcomes(passed=4)
+    steps = capture.load_steps(log_file)
+    by_name = _by_name(steps)
+
+    # Two outer universes → two `test_inner` parametrize parents.
+    assert len(by_name["test_inner"]) == 2
+    # Four leaves (v=1 and v=2 each appear twice, once per outer param).
+    assert len(by_name["v=1"]) == 2
+    assert len(by_name["v=2"]) == 2
+    # Each v=… leaf parents to the test_inner in its own outer-param universe.
+    test_inner_ids = {s["id"] for s in by_name["test_inner"]}
+    for leaf in by_name["v=1"] + by_name["v=2"]:
+        assert leaf["parent_step_id"] in test_inner_ids
+
+
+def test_no_outer_param_unaffected(pytester: pytest.Pytester, log_file: Path) -> None:
+    """Tests without any session-scoped fixture params produce the normal tree."""
+    pytester.makepyfile(
+        test_plain=dedent(
+            """
+            import pytest
+
+            @pytest.mark.parametrize("v", [1, 2])
+            def test_plain(v):
+                pass
+            """
+        )
+    )
+    result = pytester.runpytest_inprocess("-v")
+    result.assert_outcomes(passed=2)
+    steps = capture.load_steps(log_file)
+    by_name = _by_name(steps)
+
+    # Module step is a root (no outer param wrapper).
+    assert len(by_name["test_plain.py"]) == 1
+    assert by_name["test_plain.py"][0]["parent_step_id"] is None
+    assert len(by_name["test_plain"]) == 1
+    mod_id = by_name["test_plain.py"][0]["id"]
+    assert by_name["test_plain"][0]["parent_step_id"] == mod_id
+
+
+def test_outer_param_subtree_closes_mid_session(
+    pytester: pytest.Pytester, log_file: Path
+) -> None:
+    """The outer-param step resolves as soon as all its tests finish — not at session end."""
+    pytester.makeconftest(_SESSION_FIXTURE_CONFTEST)
+    pytester.makepyfile(
+        test_ec=dedent(
+            """
+            def test_a():
+                pass
+
+            def test_b():
+                pass
+            """
+        )
+    )
+    result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
+    result.assert_outcomes(passed=4)
+    events = capture.log_events(log_file)
+    # The first outer-param step must resolve before the second outer-param step is created.
+    assert _index(events, "UpdateTestStep", "outer=10", terminal=True) < _index(
+        events, "CreateTestStep", "outer=20"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Explicit-ID labels — author-supplied ids win over name=value
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_list_ids_on_inner_parametrize(
+    pytester: pytest.Pytester, log_file: Path
+) -> None:
+    """An explicit ``ids=[...]`` list labels the parametrize steps, not ``name=value``."""
+    pytester.makepyfile(
+        test_lid=dedent(
+            """
+            import pytest
+
+            @pytest.mark.parametrize("v", [1, 2], ids=["one", "two"])
+            def test_lid(v):
+                pass
+            """
+        )
+    )
+    result = pytester.runpytest_inprocess("-v")
+    result.assert_outcomes(passed=2)
+    by_name = _by_name(capture.load_steps(log_file))
+    # Friendly IDs are the leaf names; the structured fallback never appears.
+    assert "one" in by_name
+    assert "two" in by_name
+    assert "v=1" not in by_name
+    assert "v=2" not in by_name
+    parent_id = by_name["test_lid"][0]["id"]
+    assert by_name["one"][0]["parent_step_id"] == parent_id
+    assert by_name["two"][0]["parent_step_id"] == parent_id
+
+
+def test_callable_id_factory_on_inner_parametrize(
+    pytester: pytest.Pytester, log_file: Path
+) -> None:
+    """A callable ``ids=`` factory is invoked per value, just as pytest does."""
+    pytester.makepyfile(
+        test_cid=dedent(
+            """
+            import pytest
+
+            def label(v):
+                return f"ch_{v}"
+
+            @pytest.mark.parametrize("v", [0, 1], ids=label)
+            def test_cid(v):
+                pass
+            """
+        )
+    )
+    result = pytester.runpytest_inprocess("-v")
+    result.assert_outcomes(passed=2)
+    by_name = _by_name(capture.load_steps(log_file))
+    assert "ch_0" in by_name
+    assert "ch_1" in by_name
+    assert "v=0" not in by_name
+
+
+def test_explicit_ids_on_session_fixture_label_outer_param(
+    pytester: pytest.Pytester, log_file: Path
+) -> None:
+    """A session fixture's explicit ``ids`` label the promoted outer-param steps."""
+    pytester.makeconftest(
+        dedent(
+            """
+            import pytest
+            pytest_plugins = ["sift_client.pytest_plugin"]
+
+            @pytest.fixture(scope="session", params=[24, 36],
+                            ids=["lo", "hi"], autouse=True)
+            def outer(request):
+                yield request.param
+            """
+        )
+    )
+    pytester.makepyfile(
+        test_oid=dedent(
+            """
+            def test_a():
+                pass
+            """
+        )
+    )
+    result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
+    result.assert_outcomes(passed=2)
+    by_name = _by_name(capture.load_steps(log_file))
+    assert "lo" in by_name
+    assert "hi" in by_name
+    assert "outer=24" not in by_name
+    # Both labelled steps are roots, each scoping its own module subtree.
+    assert by_name["lo"][0]["parent_step_id"] is None
+    assert by_name["hi"][0]["parent_step_id"] is None
+    assert len(by_name["test_oid.py"]) == 2
+
+
+def test_auto_generated_ids_fall_back_to_name_value(
+    pytester: pytest.Pytester, log_file: Path
+) -> None:
+    """With no author-supplied ``ids``, steps use the structured ``name=value`` label."""
+    pytester.makepyfile(
+        test_auto=dedent(
+            """
+            import pytest
+
+            @pytest.mark.parametrize("v", [1, 2])
+            def test_auto(v):
+                pass
+            """
+        )
+    )
+    result = pytester.runpytest_inprocess("-v")
+    result.assert_outcomes(passed=2)
+    by_name = _by_name(capture.load_steps(log_file))
+    assert "v=1" in by_name
+    assert "v=2" in by_name
+
+
+def test_combined_axis_ids_fall_back_to_name_value(
+    pytester: pytest.Pytester, log_file: Path
+) -> None:
+    """A combined ``"a,b"`` axis can't attribute its shared ID, so each frame uses
+    ``name=value`` rather than mislabelling both with the same combined ID.
+    """
+    pytester.makepyfile(
+        test_comb=dedent(
+            """
+            import pytest
+
+            @pytest.mark.parametrize("a,b", [(1, 2)], ids=["combined"])
+            def test_comb(a, b):
+                pass
+            """
+        )
+    )
+    result = pytester.runpytest_inprocess("-v")
+    result.assert_outcomes(passed=1)
+    by_name = _by_name(capture.load_steps(log_file))
+    # The shared "combined" ID is not adopted for either per-arg frame.
+    assert "combined" not in by_name
+    assert "a=1" in by_name
+    assert "b=2" in by_name
+
+
+# ---------------------------------------------------------------------------
+# Scope-ladder placement — params sit at their scope's hierarchy level
+# ---------------------------------------------------------------------------
+
+
+def test_class_scoped_fixture_param_lifts_above_method(
+    pytester: pytest.Pytester, log_file: Path
+) -> None:
+    """A class-scoped parametrized fixture nests ABOVE the method; the method's own
+    function param stays inside it (the inversion fix).
+    """
+    pytester.makepyfile(
+        test_cs=dedent(
+            """
+            import pytest
+
+            @pytest.fixture(scope="class", params=["A", "B"])
+            def cfix(request):
+                return request.param
+
+            class TestFoo:
+                @pytest.mark.parametrize("v", [10, 20])
+                def test_b(self, cfix, v):
+                    pass
+            """
+        )
+    )
+    result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
+    result.assert_outcomes(passed=4)
+    steps = capture.load_steps(log_file)
+    by_name = _by_name(steps)
+    # cfix lifts between the class and the method.
+    assert len(by_name["cfix='A'"]) == 1
+    assert len(by_name["cfix='B'"]) == 1
+    class_id = by_name["TestFoo"][0]["id"]
+    assert by_name["cfix='A'"][0]["parent_step_id"] == class_id
+    assert by_name["cfix='B'"][0]["parent_step_id"] == class_id
+    # The method (and its function param) nest under each cfix universe.
+    leaf = by_name["v=10"][0]
+    chain = _ancestor_names(steps, leaf)
+    assert chain[:4] == ["v=10", "test_b", "cfix='A'", "TestFoo"]
+
+
+# A module-scoped parametrized fixture shared by two functions in one module.
+_MODULE_FIXTURE_SRC = dedent(
+    """
+    import pytest
+
+    @pytest.fixture(scope="module", params=["M1", "M2"])
+    def mfix(request):
+        return request.param
+
+    def test_one(mfix):
+        pass
+
+    def test_two(mfix):
+        pass
+    """
+)
+
+
+def test_module_scoped_fixture_param_lifts_above_functions(
+    pytester: pytest.Pytester, log_file: Path
+) -> None:
+    """A module-scoped parametrized fixture nests above the functions in the module,
+    and two functions sharing it group under ONE param step per value (not split).
+    """
+    pytester.makepyfile(test_ms=_MODULE_FIXTURE_SRC)
+    result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
+    result.assert_outcomes(passed=4)
+    steps = capture.load_steps(log_file)
+    by_name = _by_name(steps)
+    mod_id = by_name["test_ms.py"][0]["id"]
+    # One mfix step per value, each under the module (shared by both functions).
+    assert len(by_name["mfix='M1'"]) == 1
+    assert len(by_name["mfix='M2'"]) == 1
+    assert by_name["mfix='M1'"][0]["parent_step_id"] == mod_id
+    m1_id = by_name["mfix='M1'"][0]["id"]
+    # Both functions' M1 leaves parent to the single shared mfix='M1' step.
+    test_one_m1 = [s for s in by_name["test_one"] if s["parent_step_id"] == m1_id]
+    test_two_m1 = [s for s in by_name["test_two"] if s["parent_step_id"] == m1_id]
+    assert len(test_one_m1) == 1
+    assert len(test_two_m1) == 1
+
+
+def test_module_scoped_param_step_early_closes_when_shared_subtree_done(
+    pytester: pytest.Pytester, log_file: Path
+) -> None:
+    """A shared module-scoped param step resolves once all its tests finish, before
+    the next param value's step opens.
+    """
+    pytester.makepyfile(test_msc=_MODULE_FIXTURE_SRC)
+    result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
+    result.assert_outcomes(passed=4)
+    events = capture.log_events(log_file)
+    assert _index(events, "UpdateTestStep", "mfix='M1'", terminal=True) < _index(
+        events, "CreateTestStep", "mfix='M2'"
+    )
+
+
+def test_mark_scope_class_lifts_to_class(pytester: pytest.Pytester, log_file: Path) -> None:
+    """A ``@pytest.mark.parametrize(..., scope="class")`` lifts to the class level."""
+    pytester.makepyfile(
+        test_msk=dedent(
+            """
+            import pytest
+
+            class TestFoo:
+                @pytest.mark.parametrize("cv", [1, 2], scope="class")
+                def test_a(self, cv):
+                    pass
+            """
+        )
+    )
+    result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
+    result.assert_outcomes(passed=2)
+    by_name = _by_name(capture.load_steps(log_file))
+    class_id = by_name["TestFoo"][0]["id"]
+    # cv lifts to sit directly under the class, above the method.
+    assert by_name["cv=1"][0]["parent_step_id"] == class_id
+    assert by_name["cv=2"][0]["parent_step_id"] == class_id
+    cv1_id = by_name["cv=1"][0]["id"]
+    assert by_name["test_a"][0]["parent_step_id"] in {cv1_id, by_name["cv=2"][0]["id"]}
+
+
+def test_mark_scope_session_lifts_to_root(pytester: pytest.Pytester, log_file: Path) -> None:
+    """A ``@pytest.mark.parametrize(..., scope="session")`` lifts above the module
+    (closes the gap where mark-scoped session params were treated as function-scoped).
+    """
+    pytester.makepyfile(
+        test_mss=dedent(
+            """
+            import pytest
+
+            @pytest.mark.parametrize("sx", [7, 8], scope="session")
+            def test_s(sx):
+                pass
+            """
+        )
+    )
+    result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
+    result.assert_outcomes(passed=2)
+    by_name = _by_name(capture.load_steps(log_file))
+    # sx steps are roots, each scoping its own module subtree.
+    assert by_name["sx=7"][0]["parent_step_id"] is None
+    assert by_name["sx=8"][0]["parent_step_id"] is None
+    assert len(by_name["test_mss.py"]) == 2
+
+
+def test_bare_class_mark_stays_under_method(pytester: pytest.Pytester, log_file: Path) -> None:
+    """A class-level mark WITHOUT ``scope=`` is function-scoped, so it stays under the
+    method — not lifted to the class.
+    """
+    pytester.makepyfile(
+        test_bcm=dedent(
+            """
+            import pytest
+
+            @pytest.mark.parametrize("cv", [1, 2])
+            class TestFoo:
+                def test_a(self, cv):
+                    pass
+            """
+        )
+    )
+    result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
+    result.assert_outcomes(passed=2)
+    by_name = _by_name(capture.load_steps(log_file))
+    method_id = by_name["test_a"][0]["id"]
+    class_id = by_name["TestFoo"][0]["id"]
+    # cv parents to the method, and the method parents directly to the class.
+    assert by_name["cv=1"][0]["parent_step_id"] == method_id
+    assert by_name["cv=2"][0]["parent_step_id"] == method_id
+    assert method_id != class_id
+    assert by_name["test_a"][0]["parent_step_id"] == class_id
+
+
+def test_nested_class_fixture_anchors_to_defining_class(
+    pytester: pytest.Pytester, log_file: Path
+) -> None:
+    """A class-scoped fixture defined on the OUTER class anchors there, not under the
+    innermost nested class.
+    """
+    pytester.makepyfile(
+        test_ncf=dedent(
+            """
+            import pytest
+
+            class TestOuter:
+                @pytest.fixture(scope="class", params=["A", "B"])
+                def cfix(self, request):
+                    return request.param
+
+                class TestInner:
+                    def test_a(self, cfix):
+                        pass
+            """
+        )
+    )
+    result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
+    result.assert_outcomes(passed=2)
+    steps = capture.load_steps(log_file)
+    by_name = _by_name(steps)
+    outer_id = by_name["TestOuter"][0]["id"]
+    # cfix sits directly under TestOuter (its defining class), above TestInner.
+    assert by_name["cfix='A'"][0]["parent_step_id"] == outer_id
+    leaf = by_name["test_a"][0]
+    chain = _ancestor_names(steps, leaf)
+    assert chain[:4] == ["test_a", "TestInner", "cfix='A'", "TestOuter"]
+
+
+def test_class_param_falls_through_when_class_step_disabled(
+    pytester: pytest.Pytester, log_file: Path
+) -> None:
+    """With ``sift_class_step=false`` the class step is suppressed, but a class-scoped
+    param still renders and attaches to the module (nearest rendered ancestor).
+    """
+    _write_ini(pytester, log_file, sift_class_step="false")
+    pytester.makepyfile(
+        test_cft=dedent(
+            """
+            import pytest
+
+            @pytest.fixture(scope="class", params=["A", "B"])
+            def cfix(request):
+                return request.param
+
+            class TestFoo:
+                def test_a(self, cfix):
+                    pass
+            """
+        )
+    )
+    result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
+    result.assert_outcomes(passed=2)
+    by_name = _by_name(capture.load_steps(log_file))
+    assert "TestFoo" not in by_name
+    mod_id = by_name["test_cft.py"][0]["id"]
+    # The class param falls through to the module step.
+    assert by_name["cfix='A'"][0]["parent_step_id"] == mod_id
+    cfix_a_id = by_name["cfix='A'"][0]["id"]
+    assert by_name["test_a"][0]["parent_step_id"] in {
+        cfix_a_id,
+        by_name["cfix='B'"][0]["id"],
+    }
+
+
+def test_collection_skipped_param_item_uses_cleaned_leaf_name(
+    pytester: pytest.Pytester, log_file: Path
+) -> None:
+    """A collection-skipped item under a scope-promoted param keeps the cleaned leaf
+    name (no parametrize bracket), matching how a run sibling is named, and still
+    nests under its param universe.
+
+    The skip is evaluated before the autouse ``step`` fixture runs, so the inline
+    step from the makereport hook must name itself the same way ``step_impl`` would.
+    The passing test is declared first so the report context is bootstrapped before
+    the skip fires in each outer-param universe.
+    """
+    pytester.makeconftest(
+        dedent(
+            """
+            import pytest
+            pytest_plugins = ["sift_client.pytest_plugin"]
+
+            @pytest.fixture(scope="session", params=[10, 20], autouse=True)
+            def outer(request):
+                yield request.param
+            """
+        )
+    )
+    pytester.makepyfile(
+        test_sk=dedent(
+            """
+            import pytest
+
+            def test_ok():
+                pass
+
+            @pytest.mark.skip(reason="demo skip")
+            def test_skipped():
+                pass
+            """
+        )
+    )
+    result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
+    result.assert_outcomes(passed=2, skipped=2)
+    steps = capture.load_steps(log_file)
+    by_name = _by_name(steps)
+    # Cleaned leaf name (no ``[10]`` bracket), one per outer-param universe.
+    assert len(by_name["test_skipped"]) == 2
+    assert "test_skipped[10]" not in by_name
+    for leaf in by_name["test_skipped"]:
+        chain = _ancestor_names(steps, leaf)
+        assert chain[:2] == ["test_skipped", "test_sk.py"]
+        assert chain[2] in ("outer=10", "outer=20")
+        assert leaf["statuses"][-1] == TestStatus.SKIPPED

--- a/python/lib/sift_client/_tests/pytest_plugin/test_hierarchy.py
+++ b/python/lib/sift_client/_tests/pytest_plugin/test_hierarchy.py
@@ -17,7 +17,7 @@ import warnings
 from datetime import datetime, timezone
 from textwrap import dedent
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
@@ -1986,9 +1986,19 @@ def test_collection_skipped_param_item_uses_cleaned_leaf_name(
 # ---------------------------------------------------------------------------
 
 
-def _fake_item_without_fixture_manager() -> SimpleNamespace:
+def _fake_item(**attrs: object) -> pytest.Item:
+    """A stand-in pytest item for unit-testing the introspection helpers directly.
+
+    The helpers only touch a few attributes (``session``, ``callspec``, ``nodeid``,
+    ``originalname``, ``name``), so a ``SimpleNamespace`` suffices; cast keeps the
+    typed signatures honest without a real collected item.
+    """
+    return cast("pytest.Item", SimpleNamespace(**attrs))
+
+
+def _fake_item_without_fixture_manager() -> pytest.Item:
     """An item whose ``session`` has no ``_fixturemanager`` (the internal moved)."""
-    return SimpleNamespace(session=SimpleNamespace(), nodeid="t.py::test_x")
+    return _fake_item(session=SimpleNamespace(), nodeid="t.py::test_x")
 
 
 def _raise(*_args: object, **_kwargs: object) -> None:
@@ -2010,7 +2020,7 @@ def test_fixturedefs_degrades_when_getfixturedefs_raises() -> None:
         def getfixturedefs(self, name: str, node: object) -> object:
             raise RuntimeError("boom")
 
-    item = SimpleNamespace(
+    item = _fake_item(
         session=SimpleNamespace(_fixturemanager=_FixtureManager()),
         nodeid="t.py::test_x",
     )
@@ -2021,7 +2031,7 @@ def test_fixturedefs_degrades_when_getfixturedefs_raises() -> None:
 def test_build_scoped_params_degrades_to_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     steps.reset_introspection_state()
     monkeypatch.setattr(steps, "_param_scope", _raise)
-    item = SimpleNamespace(callspec=SimpleNamespace(params={"v": 1}))
+    item = _fake_item(callspec=SimpleNamespace(params={"v": 1}))
     with pytest.warns(SiftPytestPluginWarning):
         # Nothing promoted -> every axis stays function-scoped (rendered flat).
         assert steps.build_scoped_params(item) == ()
@@ -2030,7 +2040,7 @@ def test_build_scoped_params_degrades_to_empty(monkeypatch: pytest.MonkeyPatch) 
 def test_build_parametrize_path_degrades_to_flat(monkeypatch: pytest.MonkeyPatch) -> None:
     steps.reset_introspection_state()
     monkeypatch.setattr(steps, "_param_scope", _raise)
-    item = SimpleNamespace(
+    item = _fake_item(
         callspec=SimpleNamespace(params={"a": 1, "b": 2}),
         originalname="test_x",
         name="test_x[1-2]",
@@ -2054,15 +2064,35 @@ def test_introspection_warning_fires_only_once() -> None:
         assert steps._fixturedefs(item, "y") is None
 
 
-def test_introspection_failure_is_audit_logged(caplog: pytest.LogCaptureFixture) -> None:
+def test_introspection_failure_is_audit_logged() -> None:
+    """The degradation emits a ``parametrize.introspection_degraded`` audit line.
+
+    Captured via a handler attached directly to the plugin's logger, NOT
+    ``caplog``: audit logging sets ``sift_client.propagate = False`` (audit_log.py),
+    so root-propagation-based capture is order-dependent under randomized runs.
+    """
     steps.reset_introspection_state()
-    item = _fake_item_without_fixture_manager()
-    logger_name = "sift_client._internal.pytest_plugin.steps"
-    with caplog.at_level(logging.WARNING, logger=logger_name), pytest.warns(
-        SiftPytestPluginWarning
-    ):
-        steps._fixturedefs(item, "x")
-    assert any("introspection_degraded" in r.getMessage() for r in caplog.records)
+
+    class _Capture(logging.Handler):
+        def __init__(self) -> None:
+            super().__init__()
+            self.records: list[logging.LogRecord] = []
+
+        def emit(self, record: logging.LogRecord) -> None:
+            self.records.append(record)
+
+    plugin_logger = logging.getLogger("sift_client._internal.pytest_plugin.steps")
+    handler = _Capture()
+    plugin_logger.addHandler(handler)
+    previous_level = plugin_logger.level
+    plugin_logger.setLevel(logging.WARNING)
+    try:
+        with pytest.warns(SiftPytestPluginWarning):
+            steps._fixturedefs(_fake_item_without_fixture_manager(), "x")
+    finally:
+        plugin_logger.removeHandler(handler)
+        plugin_logger.setLevel(previous_level)
+    assert any("introspection_degraded" in r.getMessage() for r in handler.records)
 
 
 def test_internals_failure_does_not_break_collection(
@@ -2095,3 +2125,69 @@ def test_internals_failure_does_not_break_collection(
     assert "scope-aware parametrize placement" in result.stdout.str()
     # A report was still produced; the module-scoped param simply wasn't promoted.
     assert capture.load_steps(log_file)
+
+
+def test_indirect_parametrize_lifts_to_fixture_scope(
+    pytester: pytest.Pytester, log_file: Path
+) -> None:
+    """An ``indirect=True`` axis routed through a module-scoped fixture lifts to
+    the module level. Scope comes from the fixture's public ``fixturedef.scope``,
+    resolved without pytest's private ``callspec._arg2scope``.
+    """
+    pytester.makepyfile(
+        test_ind=dedent(
+            """
+            import pytest
+
+            @pytest.fixture(scope="module")
+            def mfix(request):
+                return request.param
+
+            @pytest.mark.parametrize("mfix", ["M1", "M2"], indirect=True)
+            def test_a(step, mfix):
+                step.measure(name="m", value=True, bounds=True)
+            """
+        )
+    )
+    result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
+    result.assert_outcomes(passed=2)
+    steps = capture.load_steps(log_file)
+    by_name = _by_name(steps)
+    mod_id = by_name["test_ind.py"][0]["id"]
+    # One param step per value, lifted to module scope (under the module step).
+    assert len(by_name["mfix='M1'"]) == 1
+    assert len(by_name["mfix='M2'"]) == 1
+    assert by_name["mfix='M1'"][0]["parent_step_id"] == mod_id
+    # The leaf nests under its param universe, not directly under the module.
+    m1_id = by_name["mfix='M1'"][0]["id"]
+    assert [s for s in by_name["test_a"] if s["parent_step_id"] == m1_id]
+
+
+def test_fixturedefs_falls_back_to_nodeid_on_pytest7_signature() -> None:
+    """On pytest 7.x ``getfixturedefs`` takes a nodeid string; passing a Node
+    hits ``nodeid.find(...)`` → ``AttributeError`` (a Node has no ``.find``).
+
+    The fallback must retry with ``item.nodeid`` and succeed, NOT degrade — so
+    scope-aware placement keeps working on pytest 7.x. (pytest 8.x/9.x take the
+    Node directly and never reach the fallback.)
+    """
+    steps.reset_introspection_state()
+    sentinel = object()
+
+    class _Pytest7FixtureManager:
+        def getfixturedefs(self, name: str, node_or_nodeid: object) -> object:
+            # pytest 7.x accepts a nodeid string; a Node argument blows up the
+            # way the real ``iterparentnodeids`` would (``node.find`` is absent).
+            if isinstance(node_or_nodeid, str):
+                return (sentinel,)
+            raise AttributeError("'Function' object has no attribute 'find'")
+
+    item = _fake_item(
+        session=SimpleNamespace(_fixturemanager=_Pytest7FixtureManager()),
+        nodeid="t.py::test_x",
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # a degradation warning would raise here
+        result = steps._fixturedefs(item, "x")
+    assert result == (sentinel,)
+    assert steps._introspection_degraded is False

--- a/python/lib/sift_client/_tests/pytest_plugin/test_hierarchy.py
+++ b/python/lib/sift_client/_tests/pytest_plugin/test_hierarchy.py
@@ -12,6 +12,8 @@ API call to that JSONL log, and the outer test parses it via
 
 from __future__ import annotations
 
+import logging
+import warnings
 from datetime import datetime, timezone
 from textwrap import dedent
 from types import SimpleNamespace
@@ -19,7 +21,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from sift_client._internal.pytest_plugin import steps
 from sift_client._tests.pytest_plugin import _step_status_capture as capture
+from sift_client.pytest_plugin import SiftPytestPluginWarning
 from sift_client.sift_types.test_report import TestStatus
 
 if TYPE_CHECKING:
@@ -1970,3 +1974,124 @@ def test_collection_skipped_param_item_uses_cleaned_leaf_name(
         assert chain[:2] == ["test_skipped", "test_sk.py"]
         assert chain[2] in ("outer=10", "outer=20")
         assert leaf["statuses"][-1] == TestStatus.SKIPPED
+
+
+# ---------------------------------------------------------------------------
+# Degradation when pytest internals are unavailable
+#
+# Scope-aware placement and ``ids=`` labels read a few pytest internals. If a
+# pytest version moves them, the plugin must degrade (function-scoped nesting,
+# ``name=value`` labels) and warn once, NOT break the user's collection. See
+# ``steps._signal_introspection_degraded``.
+# ---------------------------------------------------------------------------
+
+
+def _fake_item_without_fixture_manager() -> SimpleNamespace:
+    """An item whose ``session`` has no ``_fixturemanager`` (the internal moved)."""
+    return SimpleNamespace(session=SimpleNamespace(), nodeid="t.py::test_x")
+
+
+def _raise(*_args: object, **_kwargs: object) -> None:
+    raise RuntimeError("simulated pytest internals change")
+
+
+def test_fixturedefs_degrades_when_fixture_manager_missing() -> None:
+    steps.reset_introspection_state()
+    item = _fake_item_without_fixture_manager()
+    with pytest.warns(SiftPytestPluginWarning, match="scope-aware parametrize"):
+        assert steps._fixturedefs(item, "x") is None
+    assert steps._introspection_degraded is True
+
+
+def test_fixturedefs_degrades_when_getfixturedefs_raises() -> None:
+    steps.reset_introspection_state()
+
+    class _FixtureManager:
+        def getfixturedefs(self, name: str, node: object) -> object:
+            raise RuntimeError("boom")
+
+    item = SimpleNamespace(
+        session=SimpleNamespace(_fixturemanager=_FixtureManager()),
+        nodeid="t.py::test_x",
+    )
+    with pytest.warns(SiftPytestPluginWarning):
+        assert steps._fixturedefs(item, "x") is None
+
+
+def test_build_scoped_params_degrades_to_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    steps.reset_introspection_state()
+    monkeypatch.setattr(steps, "_param_scope", _raise)
+    item = SimpleNamespace(callspec=SimpleNamespace(params={"v": 1}))
+    with pytest.warns(SiftPytestPluginWarning):
+        # Nothing promoted -> every axis stays function-scoped (rendered flat).
+        assert steps.build_scoped_params(item) == ()
+
+
+def test_build_parametrize_path_degrades_to_flat(monkeypatch: pytest.MonkeyPatch) -> None:
+    steps.reset_introspection_state()
+    monkeypatch.setattr(steps, "_param_scope", _raise)
+    item = SimpleNamespace(
+        callspec=SimpleNamespace(params={"a": 1, "b": 2}),
+        originalname="test_x",
+        name="test_x[1-2]",
+    )
+    with pytest.warns(SiftPytestPluginWarning):
+        path = steps.build_parametrize_path(item)
+    # Degraded output: the bare leaf name plus every axis as name=value.
+    assert path[0] == "test_x"
+    assert set(path[1:]) == {"a=1", "b=2"}
+
+
+def test_introspection_warning_fires_only_once() -> None:
+    steps.reset_introspection_state()
+    item = _fake_item_without_fixture_manager()
+    with pytest.warns(SiftPytestPluginWarning):
+        steps._fixturedefs(item, "x")
+    # A second failure in the same session is silent (the latch is set), so
+    # turning warnings into errors here must not trip.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert steps._fixturedefs(item, "y") is None
+
+
+def test_introspection_failure_is_audit_logged(caplog: pytest.LogCaptureFixture) -> None:
+    steps.reset_introspection_state()
+    item = _fake_item_without_fixture_manager()
+    logger_name = "sift_client._internal.pytest_plugin.steps"
+    with caplog.at_level(logging.WARNING, logger=logger_name), pytest.warns(
+        SiftPytestPluginWarning
+    ):
+        steps._fixturedefs(item, "x")
+    assert any("introspection_degraded" in r.getMessage() for r in caplog.records)
+
+
+def test_internals_failure_does_not_break_collection(
+    pytester: pytest.Pytester, log_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end: a forced internals failure degrades, it does not error the run.
+
+    ``runpytest_inprocess`` shares this process's ``steps`` module, so the outer
+    ``monkeypatch`` patches the inner run too and is restored afterward.
+    """
+    monkeypatch.setattr(steps, "_fixturedefs", _raise)
+    pytester.makepyfile(
+        test_x=dedent(
+            """
+            import pytest
+
+            @pytest.fixture(scope="module", params=[1, 2])
+            def fw(request):
+                return request.param
+
+            def test_a(step, fw):
+                step.measure(name="m", value=True, bounds=True)
+            """
+        )
+    )
+    result = pytester.runpytest_inprocess("-p", "no:randomly")
+    # The user's tests still run and pass despite the forced internals failure.
+    result.assert_outcomes(passed=2)
+    # The degradation is surfaced, not silent.
+    assert "scope-aware parametrize placement" in result.stdout.str()
+    # A report was still produced; the module-scoped param simply wasn't promoted.
+    assert capture.load_steps(log_file)

--- a/python/lib/sift_client/_tests/pytest_plugin/test_pass_fail.py
+++ b/python/lib/sift_client/_tests/pytest_plugin/test_pass_fail.py
@@ -566,6 +566,22 @@ def test_measure_out_of_bounds_maps_to_failed(inner):
     assert capture.final_status("test_x") == TestStatus.FAILED
 
 
+def test_mixed_measurements_one_failing_maps_to_failed(inner):
+    # Case: API-03b
+    _run(
+        inner,
+        """
+        def test_x(step):
+            step.measure(name="ok", value=1.0, bounds={"min": 0.0, "max": 5.0})
+            step.measure(name="bad", value=10.0, bounds={"min": 0.0, "max": 5.0})
+            step.measure(name="ok2", value=2.0, bounds={"min": 0.0, "max": 5.0})
+        """,
+    )
+    # A single failing measurement among passing ones still fails the step: the
+    # step outcome latches to False and does not get cleared by later passes.
+    assert capture.final_status("test_x") == TestStatus.FAILED
+
+
 def test_substep_failure_propagates_to_parent(inner):
     # Case: API-04
     _run(

--- a/python/lib/sift_client/pytest_plugin.py
+++ b/python/lib/sift_client/pytest_plugin.py
@@ -70,6 +70,7 @@ from sift_client._internal.pytest_plugin.steps import (
     hierarchy_key,
     parametrize_path_key,
     release_finished_leaf,
+    reset_introspection_state,
     resolve_parent_chain_in_context,
     scoped_params_key,
     tally_expected_parents,
@@ -413,6 +414,9 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 def pytest_configure(config: pytest.Config) -> None:
     """Register the Sift gate markers and warn on unknown ``SIFT_*`` settings."""
+    # Clear the parametrize-introspection failure latch so the one-shot
+    # degradation warning can fire once per session, not once per process.
+    reset_introspection_state()
     config.addinivalue_line(
         "markers",
         "sift_include: force the Sift autouse fixtures to activate for this test "

--- a/python/lib/sift_client/pytest_plugin.py
+++ b/python/lib/sift_client/pytest_plugin.py
@@ -577,13 +577,23 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     finalize_parents()
 
 
+def _verbosity(config: pytest.Config) -> int:
+    """Global verbosity (the ``-v`` count minus ``-q``), pytest 7/8/9-compatible.
+
+    ``Config.get_verbosity()`` only exists since pytest 8.0; ``config.option.verbose``
+    is the value it returns for the global case and is present across the supported
+    pytest range, so reading it directly keeps the plugin importable on pytest 7.x.
+    """
+    return getattr(config.option, "verbose", 0)
+
+
 def pytest_report_header(config: pytest.Config) -> str | None:
     """Emit a session-start header with the SDK version and active mode.
 
     Suppressed under ``-q`` (negative verbosity), matching how pytest hides its
     own platform/plugin header.
     """
-    if config.get_verbosity() < 0:
+    if _verbosity(config) < 0:
         return None
     return f"Sift: sift-stack-py {sdk_version()} — {mode_label(config)} mode"
 
@@ -596,7 +606,7 @@ def pytest_terminal_summary(terminalreporter: Any, exitstatus: int, config: pyte
     other plugins and CI steps can consume the result. The panel itself is
     rendered by ``write_report_summary``; this hook handles the side effects.
     """
-    quiet = config.get_verbosity() < 0
+    quiet = _verbosity(config) < 0
 
     # End-state validation view: the final step tree with statuses, written to
     # the audit log (not the terminal) in every mode. created_steps are retained

--- a/python/lib/sift_client/pytest_plugin.py
+++ b/python/lib/sift_client/pytest_plugin.py
@@ -56,6 +56,7 @@ from sift_client._internal.pytest_plugin.report import (
     OFFLINE_DEFAULTS,
     build_disabled_client,
     finalize_after_teardown,
+    leaf_step_name,
     report_context_impl,
     resolve_report_link,
     step_impl,
@@ -63,12 +64,14 @@ from sift_client._internal.pytest_plugin.report import (
 from sift_client._internal.pytest_plugin.steps import (
     build_hierarchy_chain,
     build_parametrize_path,
+    build_scoped_params,
     finalize_parents,
     get_or_create_parent_chain,
     hierarchy_key,
     parametrize_path_key,
     release_finished_leaf,
     resolve_parent_chain_in_context,
+    scoped_params_key,
     tally_expected_parents,
 )
 from sift_client._internal.pytest_plugin.terminal import (
@@ -471,10 +474,12 @@ def pytest_itemcollected(item: pytest.Item) -> None:
     """
     chain = build_hierarchy_chain(item, item.config)
     parametrize_path = build_parametrize_path(item)
+    scoped_params = build_scoped_params(item)
     item.stash[hierarchy_key] = chain
     item.stash[parametrize_path_key] = parametrize_path
+    item.stash[scoped_params_key] = scoped_params
     gated = gate_enabled(item, item.config)
-    rendered_hierarchy = "/".join(name for _id, name, _doc, rendered in chain if rendered)
+    rendered_hierarchy = "/".join(name for _id, name, _doc, rendered, _scope in chain if rendered)
     log_event(
         logger,
         logging.DEBUG,
@@ -535,7 +540,7 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[Any]):
         parent_ns = resolve_parent_chain_in_context(item, item.config, REPORT_CONTEXT)
         parent_step = parent_ns.current_step if parent_ns is not None else None
         with REPORT_CONTEXT.new_step(
-            name=item.name,
+            name=leaf_step_name(item, item.config),
             parent=parent_step,
             origin="pytest_runtest_makereport",
             source_path=item.nodeid,

--- a/python/lib/sift_client/util/test_results/bounds.py
+++ b/python/lib/sift_client/util/test_results/bounds.py
@@ -88,7 +88,7 @@ def assign_value_to_measurement(
 
 def value_passes_bounds(
     value: float | str | bool,
-    bounds: dict[str, float] | NumericBounds | str | bool | None,
+    bounds: dict[str, float] | NumericBounds | str | bool | float | None,
 ) -> bool:
     """Evaluate a value against bounds without recording a measurement."""
     if bounds is None:
@@ -104,6 +104,10 @@ def value_passes_bounds(
             raise ValueError("Value must be a string if bounds provided is a string")
         if isinstance(value, bool):
             return str(value).lower() == str(bounds).lower()
+        return value == bounds
+    if isinstance(bounds, (int, float)):
+        # A scalar numeric bound is an exact-match expectation (e.g. 1 matches
+        # True). bool is handled above, so this only sees real ints/floats.
         return value == bounds
     # NumericBounds
     try:
@@ -121,7 +125,7 @@ def value_passes_bounds(
 def evaluate_measurement_bounds(
     measurement: TestMeasurement | TestMeasurementCreate | TestMeasurementUpdate,
     value: float | str | bool,
-    bounds: dict[str, float] | NumericBounds | str | bool | None,
+    bounds: dict[str, float] | NumericBounds | str | bool | float | None,
 ) -> bool:
     """Update a measurement with the resolved bounds type and result of evaluating the given value against those bounds.
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -438,7 +438,11 @@ testpaths = [
 ]
 
 markers = [
-    "integration: mark a test as an integration test (requires API)"
+    "integration: mark a test as an integration test (requires API)",
+    # Opt-in suite for the pytest-version compat matrix (test-pytest-compat in
+    # python_ci.yaml), auto-applied to this suite's tests by its conftest. The
+    # matrix runs `-m plugin_compat` across pytest 7/8/9.
+    "plugin_compat: sift pytest-plugin behavior test, run in the version matrix",
 ]
 
 [tool.sift.pytest.report]

--- a/python/scripts/dev
+++ b/python/scripts/dev
@@ -123,13 +123,16 @@ run_tests_pytest_compat() {
     "3.8 ~=7.4 3.15.0" \
     "3.9 ~=8.4 3.16.0" \
     "3.10 ~=9.0 4.1.0"
+  # Fork support keeps the grpc the plugin imports from aborting in the parent
+  # when runpytest_subprocess forks (mirrors the CI job env).
+  export GRPC_ENABLE_FORK_SUPPORT=1
   for cell in "$@"; do
     read -r py spec randomly <<< "$cell"
     echo "=== Python $py, pytest $spec, pytest-randomly $randomly ==="
     uv run --python "$py" --no-project --with-editable '.' \
       --with "pytest$spec" \
       --with "pytest-randomly==$randomly" \
-      pytest lib/sift_client/_tests/pytest_plugin -m "not integration"
+      pytest lib/sift_client/_tests/pytest_plugin -m "plugin_compat"
   done
 }
 

--- a/python/scripts/dev
+++ b/python/scripts/dev
@@ -28,6 +28,7 @@ Subcommands:
   test             Execute non-integration tests against the project's Python
   test-floor       Execute non-integration tests against the floor Python (3.8)
   test-ceiling     Execute non-integration tests against the ceiling Python (3.14)
+  test-pytest-compat Run the pytest-plugin test subset against pytest 7/8/9
   test-integration Execute integration tests
   test-all         Execute all tests
 
@@ -112,6 +113,26 @@ run_tests_ceiling() {
   uv run --python 3.14 --no-project --with-editable '.[dev-all]' pytest -m "not integration"
 }
 
+run_tests_pytest_compat() {
+  # Run the self-contained pytest-plugin test subset against pytest 7/8/9,
+  # mirroring the CI `test-pytest-compat` matrix. Each cell pairs a pytest line
+  # with a compatible Python and pytest-randomly pin (the subset drives inner
+  # pytester sessions and needs no other plugins). uv downloads interpreters on
+  # first run. Catches breakage from pytest internals the plugin reads.
+  set -- \
+    "3.8 ~=7.4 3.15.0" \
+    "3.9 ~=8.4 3.16.0" \
+    "3.10 ~=9.0 4.1.0"
+  for cell in "$@"; do
+    read -r py spec randomly <<< "$cell"
+    echo "=== Python $py, pytest $spec, pytest-randomly $randomly ==="
+    uv run --python "$py" --no-project --with-editable '.' \
+      --with "pytest$spec" \
+      --with "pytest-randomly==$randomly" \
+      pytest lib/sift_client/_tests/pytest_plugin -m "not integration"
+  done
+}
+
 run_tests_integration() {
   uv run pytest -m "integration"
 }
@@ -188,6 +209,9 @@ case "$1" in
         ;;
     test-ceiling)
         run_tests_ceiling
+        ;;
+    test-pytest-compat)
+        run_tests_pytest_compat
         ;;
     test-integration)
         run_tests_integration


### PR DESCRIPTION
Nests parametrized tests under parent steps in the Sift report, placed by the scope at which pytest actually re-runs them.

- Each `@pytest.mark.parametrize` axis and each parametrized fixture becomes a parent step, so `test_x[3.3]` and `test_x[5.0]` cluster under a shared parent.
- Scope-aware placement: function-scoped params nest under the test, while a class/module/session-scoped parametrized fixture (or `parametrize(..., scope=...)`) sits at that level instead, matching how pytest re-runs the work.
- Parent labels use the explicit `ids=` from the mark or fixture when present, otherwise pytest's own value labels.
- Parent identities are kind-tagged tuples rather than delimited strings, so axis values containing the delimiter can't collide.
- Docs and examples: report structure guide, quickstart, the example README and demo test. Adds `test_hierarchy.py` coverage.

