### PR TITLE
sift_cli(fix): match vendored HDF5 to static MSVC CRT on Windows

### DIFF
--- a/.github/workflows/includes/build-setup.yml
+++ b/.github/workflows/includes/build-setup.yml
@@ -5,3 +5,11 @@
   uses: peaceiris/actions-mdbook@v2
   with:
     mdbook-version: '0.4.40'
+# cargo-dist links the static MSVC CRT (/MT) by default, but hdf5-metno-src's
+# CMake build defaults to the dynamic CRT (/MD), which leaves __imp_* CRT
+# symbols unresolved at link time. hdf5-metno-src forwards this env var to
+# CMake so the vendored HDF5 matches the static CRT.
+- name: Use static MSVC CRT for vendored HDF5
+  if: runner.os == 'Windows'
+  shell: bash
+  run: echo "CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded" >> "$GITHUB_ENV"

--- a/.github/workflows/sift_cli-v-release.yml
+++ b/.github/workflows/sift_cli-v-release.yml
@@ -131,6 +131,14 @@ jobs:
         uses: "peaceiris/actions-mdbook@v2"
         with:
           "mdbook-version": "0.4.40"
+      - name: "Use static MSVC CRT for vendored HDF5"
+        if: "runner.os == 'Windows'"
+        run: "echo \"CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded\" >> \"$GITHUB_ENV\""
+        shell: "bash"
+      - uses: swatinem/rust-cache@v2
+        with:
+          key: ${{ join(matrix.targets, '-') }}
+          cache-provider: ${{ matrix.cache_provider }}
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/.github/workflows/sift_cli-v-release.yml
+++ b/.github/workflows/sift_cli-v-release.yml
@@ -135,10 +135,6 @@ jobs:
         if: "runner.os == 'Windows'"
         run: "echo \"CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded\" >> \"$GITHUB_ENV\""
         shell: "bash"
-      - uses: swatinem/rust-cache@v2
-        with:
-          key: ${{ join(matrix.targets, '-') }}
-          cache-provider: ${{ matrix.cache_provider }}
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -20,3 +20,5 @@ install-updater = false
 # Extra CI steps injected into the build job before `dist build`.
 # sift_cli's build.rs invokes `mdbook build`, so mdbook must be on PATH.
 github-build-setup = "includes/build-setup.yml"
+# TODO: remove after verifying the Windows CRT fix; makes PRs build all targets
+pr-run-mode = "upload"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -20,5 +20,3 @@ install-updater = false
 # Extra CI steps injected into the build job before `dist build`.
 # sift_cli's build.rs invokes `mdbook build`, so mdbook must be on PATH.
 github-build-setup = "includes/build-setup.yml"
-# TODO: remove after verifying the Windows CRT fix; makes PRs build all targets
-pr-run-mode = "upload"

--- a/rust/crates/sift_stream_bindings/Cargo.toml
+++ b/rust/crates/sift_stream_bindings/Cargo.toml
@@ -10,6 +10,11 @@ license = { workspace = true }
 categories = { workspace = true }
 readme = "README.md"
 
+# The stub_gen bin makes cargo-dist treat this package as a distributable
+# app; it's a dev tool released via PyPI tooling, not cargo-dist.
+[package.metadata.dist]
+dist = false
+
 [lib]
 name = "sift_stream_bindings"
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
## Problem

The `sift_cli-v0.2.0-alpha.1` release build fails on `x86_64-pc-windows-msvc` with `LNK1120: 54 unresolved externals`. Every unresolved symbol is a CRT function (`__imp_strdup`, `__imp__getcwd`, `__imp__fstat64`, ...) referenced from `libhdf5_metno_sys` objects.

## Root cause

cargo-dist defaults `msvc-crt-static = true`, so the final link uses the static CRT (`/defaultlib:libcmt` in the link line). But `hdf5-metno-src`'s CMake build sets `CMAKE_POLICY_DEFAULT_CMP0091=NEW`, under which the MSVC runtime defaults to the dynamic CRT (`/MD`). The vendored HDF5 objects therefore import CRT symbols from the DLL runtime that the static link never provides. The `LNK4098: defaultlib 'MSVCRT' conflicts` warning in the log confirms the mixed CRT.

## Fix

`hdf5-metno-src`'s build script forwards the `CMAKE_MSVC_RUNTIME_LIBRARY` env var to CMake. This PR sets it to `MultiThreaded` (`/MT`) on Windows build runners via the `github-build-setup` include, so HDF5 matches the static-CRT link. The release workflow is regenerated with `dist generate` (cargo-dist 0.31.0).

## Verification

`pr-run-mode = "upload"` is set temporarily so this PR runs the full `build-local-artifacts (x86_64-pc-windows-msvc)` job. Will remove that line once the Windows build is green.
