### PR TITLE
rust(feat): surface dropped hdf5 channels

### DIFF
--- a/rust/crates/sift_cli/src/cmd/import/hdf5/detect_hdf5_schema.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/detect_hdf5_schema.rs
@@ -11,7 +11,12 @@ use sift_rs::{
 
 use crate::cli::hdf5::Hdf5Schema;
 use crate::cmd::import::utils::group_path_to_channel_name;
-use crate::util::tty::Output;
+
+#[derive(Debug, Clone)]
+pub struct SkippedDataset {
+    pub path: String,
+    pub reason: String,
+}
 
 const ROOT_PATH: &str = "/";
 const TIME_NAMES: &[&str] = &["time", "timestamp", "timestamps", "ts"];
@@ -116,7 +121,7 @@ pub fn detect_config(
     time_index: u64,
     time_field: Option<&str>,
     time_name: Option<&str>,
-) -> Result<(Vec<Hdf5DataConfig>, Vec<ChannelConfig>)> {
+) -> Result<(Vec<Hdf5DataConfig>, Vec<ChannelConfig>, Vec<SkippedDataset>)> {
     let file = File::open(path).map_err(|e| anyhow!("failed to open hdf5 file: {e}"))?;
     let datasets = collect_datasets_recursive(&file)?;
 
@@ -127,12 +132,12 @@ pub fn detect_config(
     };
 
     match result {
-        Ok((data, _)) if data.is_empty() => Err(no_match_error(
+        Ok((data, _, _)) if data.is_empty() => Err(no_match_error(
             &datasets, schema, time_index, time_field, time_name,
         )),
-        Ok((data, channel_configs)) => {
+        Ok((data, channel_configs, skipped)) => {
             let woven = weave_time_channel_rows(&data, &channel_configs);
-            Ok((data, woven))
+            Ok((data, woven, skipped))
         }
         Err(e) => Err(e),
     }
@@ -193,7 +198,7 @@ fn no_match_error(
                 Hdf5Schema::Compound => detect_compound(datasets, time_index, time_field),
             };
             match probe {
-                Ok((data, _)) if !data.is_empty() => Some(*name),
+                Ok((data, _, _)) if !data.is_empty() => Some(*name),
                 _ => None,
             }
         })
@@ -222,7 +227,7 @@ fn no_match_error(
 fn detect_one_d(
     datasets: &[Dataset],
     time_name: Option<&str>,
-) -> Result<(Vec<Hdf5DataConfig>, Vec<ChannelConfig>)> {
+) -> Result<(Vec<Hdf5DataConfig>, Vec<ChannelConfig>, Vec<SkippedDataset>)> {
     let mut group_time: HashMap<String, String> = HashMap::new();
     for ds in datasets {
         let name = ds.name();
@@ -254,35 +259,43 @@ fn detect_one_d(
 
     let mut data_configs = Vec::new();
     let mut channel_configs = Vec::new();
+    let mut skipped: Vec<SkippedDataset> = Vec::new();
 
     for ds in datasets {
         let name = ds.name();
-        if is_time_dataset_name(&name) || ds.ndim() != 1 {
+        if is_time_dataset_name(&name) {
+            continue;
+        }
+        if ds.ndim() != 1 {
+            skipped.push(SkippedDataset {
+                path: name.clone(),
+                reason: format!("wrong rank (expected 1D, got {}D)", ds.ndim()),
+            });
             continue;
         }
         let Some(time_dataset) = nearest_time_dataset(&group_time, &name) else {
+            skipped.push(SkippedDataset {
+                path: name.clone(),
+                reason: "no time dataset nearby".into(),
+            });
             continue;
         };
 
         let dtype = match ds.dtype().and_then(|t| t.to_descriptor()) {
             Ok(d) => d,
             Err(e) => {
-                Output::new()
-                    .line(format!(
-                        "skipping {name}: cannot describe HDF5 dtype ({e}). \
-                         Supported types: {SUPPORTED_TYPES_BLURB}."
-                    ))
-                    .eprint();
+                skipped.push(SkippedDataset {
+                    path: name.clone(),
+                    reason: format!("cannot describe HDF5 dtype ({e})"),
+                });
                 continue;
             }
         };
         let Some(channel_type) = hdf5_to_sift_data_type(&dtype) else {
-            Output::new()
-                .line(format!(
-                    "skipping {name}: unsupported HDF5 type {dtype:?}. \
-                     Supported types: {SUPPORTED_TYPES_BLURB}."
-                ))
-                .eprint();
+            skipped.push(SkippedDataset {
+                path: name.clone(),
+                reason: format!("unsupported HDF5 type {dtype:?}"),
+            });
             continue;
         };
 
@@ -314,7 +327,7 @@ fn detect_one_d(
         channel_configs.push(channel_config);
     }
 
-    Ok((data_configs, channel_configs))
+    Ok((data_configs, channel_configs, skipped))
 }
 
 fn nearest_time_dataset(group_time: &HashMap<String, String>, value_path: &str) -> Option<String> {
@@ -341,13 +354,18 @@ fn one_d_channel_name(value_path: &str) -> String {
 fn detect_two_d(
     datasets: &[Dataset],
     time_index: u64,
-) -> Result<(Vec<Hdf5DataConfig>, Vec<ChannelConfig>)> {
+) -> Result<(Vec<Hdf5DataConfig>, Vec<ChannelConfig>, Vec<SkippedDataset>)> {
     let mut data_configs = Vec::new();
     let mut channel_configs = Vec::new();
+    let mut skipped: Vec<SkippedDataset> = Vec::new();
 
     for ds in datasets {
         let name = ds.name();
         if ds.ndim() != 2 {
+            skipped.push(SkippedDataset {
+                path: name.clone(),
+                reason: format!("wrong rank (expected 2D, got {}D)", ds.ndim()),
+            });
             continue;
         }
         let shape = ds.shape();
@@ -395,16 +413,17 @@ fn detect_two_d(
         }
     }
 
-    Ok((data_configs, channel_configs))
+    Ok((data_configs, channel_configs, skipped))
 }
 
 fn detect_compound(
     datasets: &[Dataset],
     time_index: u64,
     time_field: Option<&str>,
-) -> Result<(Vec<Hdf5DataConfig>, Vec<ChannelConfig>)> {
+) -> Result<(Vec<Hdf5DataConfig>, Vec<ChannelConfig>, Vec<SkippedDataset>)> {
     let mut data_configs = Vec::new();
     let mut channel_configs = Vec::new();
+    let mut skipped: Vec<SkippedDataset> = Vec::new();
 
     for ds in datasets {
         let name = ds.name();
@@ -414,6 +433,10 @@ fn detect_compound(
             .to_descriptor()
             .map_err(|e| anyhow!("failed to describe dtype for {name}: {e}"))?;
         let TypeDescriptor::Compound(compound) = dtype else {
+            skipped.push(SkippedDataset {
+                path: name.clone(),
+                reason: "not a compound type".into(),
+            });
             continue;
         };
 
@@ -471,5 +494,5 @@ fn detect_compound(
         }
     }
 
-    Ok((data_configs, channel_configs))
+    Ok((data_configs, channel_configs, skipped))
 }

--- a/rust/crates/sift_cli/src/cmd/import/hdf5/detect_hdf5_schema.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/detect_hdf5_schema.rs
@@ -71,6 +71,15 @@ fn get_string_attr(ds: &Dataset, name: &str) -> Option<String> {
 pub const SUPPORTED_TYPES_BLURB: &str =
     "bool, int8/16/32/64, uint8/16/32/64, float32, float64, string, enum";
 
+fn describe_type(dtype: &TypeDescriptor) -> String {
+    match dtype {
+        TypeDescriptor::Compound(_) => "compound".into(),
+        TypeDescriptor::VarLenArray(_) => "variable-length array".into(),
+        TypeDescriptor::FixedArray(_, _) => "fixed-size array".into(),
+        other => format!("{other:?}"),
+    }
+}
+
 pub fn hdf5_to_sift_data_type(ty: &TypeDescriptor) -> Option<ChannelDataType> {
     match ty {
         TypeDescriptor::Boolean => Some(ChannelDataType::Bool),
@@ -294,7 +303,7 @@ fn detect_one_d(
         let Some(channel_type) = hdf5_to_sift_data_type(&dtype) else {
             skipped.push(SkippedDataset {
                 path: name.clone(),
-                reason: format!("unsupported HDF5 type {dtype:?}"),
+                reason: format!("unsupported HDF5 type ({})", describe_type(&dtype)),
             });
             continue;
         };
@@ -376,16 +385,22 @@ fn detect_two_d(
             ));
         }
 
-        let dtype = ds
-            .dtype()
-            .map_err(|e| anyhow!("failed to read dtype for {name}: {e}"))?
-            .to_descriptor()
-            .map_err(|e| anyhow!("failed to describe dtype for {name}: {e}"))?;
+        let dtype = match ds.dtype().and_then(|t| t.to_descriptor()) {
+            Ok(d) => d,
+            Err(e) => {
+                skipped.push(SkippedDataset {
+                    path: name.clone(),
+                    reason: format!("cannot describe HDF5 dtype ({e})"),
+                });
+                continue;
+            }
+        };
         let Some(channel_type) = hdf5_to_sift_data_type(&dtype) else {
-            return Err(anyhow!(
-                "unsupported HDF5 type for dataset {name}: {dtype:?}. \
-                 Supported types: {SUPPORTED_TYPES_BLURB}."
-            ));
+            skipped.push(SkippedDataset {
+                path: name.clone(),
+                reason: format!("unsupported HDF5 type ({})", describe_type(&dtype)),
+            });
+            continue;
         };
 
         for col in 0..n_cols {
@@ -427,11 +442,16 @@ fn detect_compound(
 
     for ds in datasets {
         let name = ds.name();
-        let dtype = ds
-            .dtype()
-            .map_err(|e| anyhow!("failed to read dtype for {name}: {e}"))?
-            .to_descriptor()
-            .map_err(|e| anyhow!("failed to describe dtype for {name}: {e}"))?;
+        let dtype = match ds.dtype().and_then(|t| t.to_descriptor()) {
+            Ok(d) => d,
+            Err(e) => {
+                skipped.push(SkippedDataset {
+                    path: name.clone(),
+                    reason: format!("cannot describe HDF5 dtype ({e})"),
+                });
+                continue;
+            }
+        };
         let TypeDescriptor::Compound(compound) = dtype else {
             skipped.push(SkippedDataset {
                 path: name.clone(),
@@ -465,13 +485,11 @@ fn detect_compound(
                 continue;
             }
             let Some(channel_type) = hdf5_to_sift_data_type(&field.ty) else {
-                return Err(anyhow!(
-                    "unsupported HDF5 type for field {}.{}: {:?}. \
-                     Supported types: {SUPPORTED_TYPES_BLURB}.",
-                    name,
-                    field.name,
-                    field.ty
-                ));
+                skipped.push(SkippedDataset {
+                    path: format!("{name}.{}", field.name),
+                    reason: format!("unsupported HDF5 type ({})", describe_type(&field.ty)),
+                });
+                continue;
             };
             let channel_name = format!("{}.{}", group_path_to_channel_name(&name), field.name);
             let channel_config = ChannelConfig {

--- a/rust/crates/sift_cli/src/cmd/import/hdf5/import.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/import.rs
@@ -17,7 +17,7 @@ use crate::{
     cmd::{
         Context,
         import::{
-            hdf5::detect_hdf5_schema::{SkippedDataset, SUPPORTED_TYPES_BLURB, detect_config},
+            hdf5::detect_hdf5_schema::{SUPPORTED_TYPES_BLURB, SkippedDataset, detect_config},
             preview_import_config,
             utils::{upload_gzipped_file, validate_time_format},
             wait_for_job_completion,

--- a/rust/crates/sift_cli/src/cmd/import/hdf5/import.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/import.rs
@@ -17,7 +17,7 @@ use crate::{
     cmd::{
         Context,
         import::{
-            hdf5::detect_hdf5_schema::detect_config,
+            hdf5::detect_hdf5_schema::{SkippedDataset, SUPPORTED_TYPES_BLURB, detect_config},
             preview_import_config,
             utils::{upload_gzipped_file, validate_time_format},
             wait_for_job_completion,
@@ -25,6 +25,20 @@ use crate::{
     },
     util::{api::create_grpc_channel, tty::Output},
 };
+
+fn print_skipped_block(skipped: &[SkippedDataset]) {
+    if skipped.is_empty() {
+        return;
+    }
+    let mut out = Output::new();
+    out.line(format!("{}: {{", "Skipped".green()));
+    for s in skipped {
+        out.line(format!("  {}: {}", s.path.clone().yellow(), s.reason));
+    }
+    out.line("}");
+    out.line(format!("Supported types: {SUPPORTED_TYPES_BLURB}"));
+    out.print();
+}
 
 pub async fn run(ctx: Context, args: ImportHdf5Args) -> Result<ExitCode> {
     let grpc_channel =
@@ -46,9 +60,10 @@ pub async fn run(ctx: Context, args: ImportHdf5Args) -> Result<ExitCode> {
             args.time_field.as_deref(),
             args.time_name.as_deref(),
         ) {
-            Ok((_, channel_configs)) => {
+            Ok((_, channel_configs, skipped)) => {
                 let refs: Vec<&ChannelConfig> = channel_configs.iter().collect();
                 preview_import_config(&args.common.asset, run_label, None, &refs);
+                print_skipped_block(&skipped);
             }
             Err(e) => {
                 preview_import_config(&args.common.asset, run_label, None, &[]);
@@ -61,7 +76,7 @@ pub async fn run(ctx: Context, args: ImportHdf5Args) -> Result<ExitCode> {
         return Ok(ExitCode::SUCCESS);
     }
 
-    let (data_configs, _) = detect_config(
+    let (data_configs, _, skipped) = detect_config(
         &args.common.path,
         args.schema,
         args.time_index.unwrap_or(0),
@@ -70,6 +85,16 @@ pub async fn run(ctx: Context, args: ImportHdf5Args) -> Result<ExitCode> {
     )
     .context("failed to parse hdf5 file")?;
     hdf5_config.data = data_configs;
+
+    if !skipped.is_empty() {
+        Output::new()
+            .line(format!(
+                "{}: {} dataset(s) skipped — run with --preview to see details",
+                "warning".yellow(),
+                skipped.len()
+            ))
+            .eprint();
+    }
 
     let file = File::open(&args.common.path).context("failed to open hdf5 file")?;
 


### PR DESCRIPTION
# Description
When parsing a preview of a hdf5 file some datasets might have types or shapes the client-side parser can't map. We now skip those in the preview and surface them under a "skipped" block instead of erroring out. 

I tested with a mixed file below that has all three schemas in one file.

1D in a mixed file
```Asset: test
Channels: {
  CHANNEL_DATA_TYPE_INT_64    timestamp
    description [time]
  CHANNEL_DATA_TYPE_DOUBLE    voltage_1d
}
Skipped: {
  /data_3d: wrong rank (expected 1D, got 3D)
  /sensors: unsupported HDF5 type (compound)
  /voltage_2d: wrong rank (expected 1D, got 2D)
}
Supported types: bool, int8/16/32/64, uint8/16/32/64, float32, float64, string, enum
```

2D in a mixed file
```Asset: test
Channels: {
  CHANNEL_DATA_TYPE_INT_64    voltage_2d.0
    description [time]
  CHANNEL_DATA_TYPE_DOUBLE    voltage_2d.1
}
Skipped: {
  /data_3d: wrong rank (expected 2D, got 3D)
  /sensors: wrong rank (expected 2D, got 1D)
  /timestamp: wrong rank (expected 2D, got 1D)
  /voltage_1d: wrong rank (expected 2D, got 1D)
}
Supported types: bool, int8/16/32/64, uint8/16/32/64, float32, float64, string, enum
```

Compound in a mixed file
```Asset: test
Channels: {
  CHANNEL_DATA_TYPE_INT_64    sensors.timestamp
    description [time]
  CHANNEL_DATA_TYPE_DOUBLE    sensors.temperature
  CHANNEL_DATA_TYPE_DOUBLE    sensors.pressure
  CHANNEL_DATA_TYPE_DOUBLE    sensors.voltage
}
Skipped: {
  /data_3d: not a compound type
  /timestamp: not a compound type
  /voltage_1d: not a compound type
  /voltage_2d: not a compound type
}
Supported types: bool, int8/16/32/64, uint8/16/32/64, float32, float64, string, enum
```



# Validation
Full E2E Testing