### PR TITLE
rust(feat): mcp rate-limiting

### DIFF
--- a/rust/crates/sift_mcp/Cargo.toml
+++ b/rust/crates/sift_mcp/Cargo.toml
@@ -25,6 +25,7 @@ clap = { workspace = true, features = ["cargo"] }
 pbjson-types.workspace = true
 percent-encoding.workspace = true
 prost.workspace = true
+rand.workspace = true
 arrow.workspace = true
 parquet.workspace = true
 polars = { workspace = true, features = ["lazy", "parquet", "sql"] }

--- a/rust/crates/sift_mcp/src/error/mod.rs
+++ b/rust/crates/sift_mcp/src/error/mod.rs
@@ -1,4 +1,4 @@
-use rmcp::model::{CallToolResult, Content, ErrorCode};
+use rmcp::model::{CallToolResult, ErrorCode};
 use tonic::{Code, Status};
 
 #[cfg(test)]
@@ -6,34 +6,9 @@ mod test;
 
 pub type McpResult = Result<CallToolResult, rmcp::ErrorData>;
 
-pub fn from_anyhow(error: anyhow::Error) -> rmcp::ErrorData {
-    let mut code = ErrorCode::INTERNAL_ERROR;
-    let message = format!("{error:?}");
-
-    if let Ok(grpc_status) = error.downcast::<Status>() {
-        code = from_grpc_code(grpc_status.code());
-    }
-
-    rmcp::ErrorData {
-        code,
-        message: message.into(),
-        data: None,
-    }
-}
-
-fn from_grpc_code(code: Code) -> ErrorCode {
-    match code {
-        Code::InvalidArgument | Code::OutOfRange => ErrorCode::INVALID_PARAMS,
-        Code::NotFound => ErrorCode::RESOURCE_NOT_FOUND,
-        Code::Unimplemented => ErrorCode::METHOD_NOT_FOUND,
-        _ => ErrorCode::INTERNAL_ERROR,
-    }
-}
-
-/// gRPC codes that warrant a structured "stopped, do not retry in this prompt"
-/// response to the calling agent instead of an opaque error. Returns the
-/// machine-readable reason and the human-readable guidance text shown to the
-/// agent.
+/// gRPC codes that warrant a "stopped — do not retry in this prompt" message
+/// to the agent. Returns a machine-readable reason and the human-readable
+/// guidance.
 fn soft_signal_guidance(code: Code) -> Option<(&'static str, &'static str)> {
     match code {
         Code::Unavailable => Some((
@@ -62,45 +37,40 @@ fn soft_signal_guidance(code: Code) -> Option<(&'static str, &'static str)> {
     }
 }
 
-/// Convert an `anyhow::Error` into an `McpResult`. gRPC status codes that map
-/// to a soft signal (see [`soft_signal_guidance`]) are returned as a structured
-/// `CallToolResult` instructing the agent not to retry; everything else falls
-/// back to [`from_anyhow`].
-pub fn err_into_mcp_result(err: anyhow::Error) -> McpResult {
-    let soft = err
-        .downcast_ref::<Status>()
-        .and_then(|s| soft_signal_guidance(s.code()));
-    if let Some((reason, guidance)) = soft {
-        let mut result = CallToolResult::structured(serde_json::json!({
-            "status": "stopped",
-            "reason": reason,
-            "guidance": guidance,
-        }));
-        result.content = vec![Content::text(guidance.to_string())];
-        return Ok(result);
-    }
-    Err(from_anyhow(err))
-}
-
-/// Convert a fallible operation's result into an `McpResult`. `Ok` values are
-/// wrapped in [`CallToolResult::structured`]; `Err` values route through
-/// [`err_into_mcp_result`].
-pub fn into_tool_result(result: Result<serde_json::Value, anyhow::Error>) -> McpResult {
-    match result {
-        Ok(value) => Ok(CallToolResult::structured(value)),
-        Err(err) => err_into_mcp_result(err),
-    }
-}
-
-/// `?`-like macro for tool handlers: returns the unwrapped value on `Ok`,
-/// early-returns an `McpResult` (either a soft-signal `Ok` or a normal `Err`)
-/// from the enclosing function on `Err`. Use inside `pub async fn ... -> McpResult`.
-#[macro_export]
-macro_rules! tool_try {
-    ($expr:expr) => {
-        match $expr {
-            Ok(v) => v,
-            Err(e) => return $crate::error::err_into_mcp_result(e),
+pub fn from_anyhow(error: anyhow::Error) -> rmcp::ErrorData {
+    if let Some(status) = error.downcast_ref::<Status>() {
+        if let Some((reason, guidance)) = soft_signal_guidance(status.code()) {
+            return rmcp::ErrorData {
+                code: ErrorCode::INTERNAL_ERROR,
+                message: guidance.into(),
+                data: Some(serde_json::json!({
+                    "status": "stopped",
+                    "reason": reason,
+                    "guidance": guidance,
+                })),
+            };
         }
-    };
+    }
+
+    let message = format!("{error:?}");
+    let mut code = ErrorCode::INTERNAL_ERROR;
+
+    if let Ok(grpc_status) = error.downcast::<Status>() {
+        code = from_grpc_code(grpc_status.code());
+    }
+
+    rmcp::ErrorData {
+        code,
+        message: message.into(),
+        data: None,
+    }
+}
+
+fn from_grpc_code(code: Code) -> ErrorCode {
+    match code {
+        Code::InvalidArgument | Code::OutOfRange => ErrorCode::INVALID_PARAMS,
+        Code::NotFound => ErrorCode::RESOURCE_NOT_FOUND,
+        Code::Unimplemented => ErrorCode::METHOD_NOT_FOUND,
+        _ => ErrorCode::INTERNAL_ERROR,
+    }
 }

--- a/rust/crates/sift_mcp/src/error/mod.rs
+++ b/rust/crates/sift_mcp/src/error/mod.rs
@@ -8,7 +8,8 @@ pub type McpResult = Result<CallToolResult, rmcp::ErrorData>;
 
 /// gRPC codes that warrant a "stopped — do not retry in this prompt" message
 /// to the agent. Returns a machine-readable reason and the human-readable
-/// guidance.
+/// guidance. Classification follows AIP-194: only `Unavailable` is retried
+/// upstream by `with_retry`; every other code here surfaces immediately.
 fn soft_signal_guidance(code: Code) -> Option<(&'static str, &'static str)> {
     match code {
         Code::Unavailable => Some((
@@ -32,6 +33,31 @@ fn soft_signal_guidance(code: Code) -> Option<(&'static str, &'static str)> {
             "backend_error",
             "The Sift backend returned an internal error. \
              Do not retry this tool in this prompt. Surface this to the user; the issue is on the backend side.",
+        )),
+        Code::Aborted => Some((
+            "conflict",
+            "The Sift backend reported a conflict (concurrent modification or constraint violation). \
+             Do not retry this tool in this prompt. Surface this to the user so they can resolve the conflicting state.",
+        )),
+        Code::AlreadyExists => Some((
+            "already_exists",
+            "The resource already exists. \
+             Do not retry; the operation cannot succeed as-is. If the user intended to update an existing resource, surface this distinction to them.",
+        )),
+        Code::PermissionDenied => Some((
+            "permission_denied",
+            "The caller lacks permission for this operation. \
+             Do not retry; permission will not change within this prompt. Surface this to the user.",
+        )),
+        Code::Unauthenticated => Some((
+            "unauthenticated",
+            "Authentication is missing or invalid. \
+             Do not retry; the user must re-authenticate. Surface this to the user.",
+        )),
+        Code::Cancelled => Some((
+            "cancelled",
+            "The request was cancelled. \
+             Do not retry; the cancellation is intentional. Surface this to the user.",
         )),
         _ => None,
     }

--- a/rust/crates/sift_mcp/src/error/mod.rs
+++ b/rust/crates/sift_mcp/src/error/mod.rs
@@ -1,4 +1,5 @@
 use rmcp::model::{CallToolResult, ErrorCode};
+use std::fmt::{self, Display};
 use tonic::{Code, Status};
 
 #[cfg(test)]
@@ -7,69 +8,104 @@ mod test;
 pub type McpResult = Result<CallToolResult, rmcp::ErrorData>;
 
 /// gRPC codes that warrant a "stopped — do not retry in this prompt" message
-/// to the agent. Returns a machine-readable reason and the human-readable
-/// guidance. Classification follows AIP-194: only `Unavailable` is retried
-/// upstream by `with_retry`; every other code here surfaces immediately.
-fn soft_signal_guidance(code: Code) -> Option<(&'static str, &'static str)> {
-    match code {
-        Code::Unavailable => Some((
-            "backend_unreachable",
-            "The Sift backend was unreachable after multiple attempts. \
-             Do not retry this tool in this prompt. Inform the user that the backend appears to be down.",
-        )),
-        Code::ResourceExhausted => Some((
-            "rate_limited",
-            "The Sift backend is rate-limiting requests. \
-             Do not retry this tool in this prompt. Either wait, narrow your query (shorter time \
-             range or more specific filter), or ask the user to refine their request.",
-        )),
-        Code::DeadlineExceeded => Some((
-            "query_too_expensive",
-            "The query exceeded the server's deadline. \
-             Do not retry this tool with the same parameters. Narrow your query (shorter time range, \
-             more specific filter, or smaller limit) before trying again.",
-        )),
-        Code::Internal => Some((
-            "backend_error",
-            "The Sift backend returned an internal error. \
-             Do not retry this tool in this prompt. Surface this to the user; the issue is on the backend side.",
-        )),
-        Code::Aborted => Some((
-            "conflict",
-            "The Sift backend reported a conflict (concurrent modification or constraint violation). \
-             Do not retry this tool in this prompt. Surface this to the user so they can resolve the conflicting state.",
-        )),
-        Code::AlreadyExists => Some((
-            "already_exists",
-            "The resource already exists. \
-             Do not retry; the operation cannot succeed as-is. If the user intended to update an existing resource, surface this distinction to them.",
-        )),
-        Code::PermissionDenied => Some((
-            "permission_denied",
-            "The caller lacks permission for this operation. \
-             Do not retry; permission will not change within this prompt. Surface this to the user.",
-        )),
-        Code::Unauthenticated => Some((
-            "unauthenticated",
-            "Authentication is missing or invalid. \
-             Do not retry; the user must re-authenticate. Surface this to the user.",
-        )),
-        Code::Cancelled => Some((
-            "cancelled",
-            "The request was cancelled. \
-             Do not retry; the cancellation is intentional. Surface this to the user.",
-        )),
-        _ => None,
+/// to the agent. Classification follows AIP-194: only `Unavailable` is retried
+/// upstream by `with_retry`; every other variant here surfaces immediately.
+///
+/// `Debug` yields the machine-readable reason (the variant name).
+/// `Display` yields the human-readable guidance.
+#[derive(Debug)]
+enum AgentSignal {
+    BackendUnreachable,
+    RateLimited,
+    QueryTooExpensive,
+    BackendError,
+    Conflict,
+    AlreadyExists,
+    PermissionDenied,
+    Unauthenticated,
+    Cancelled,
+}
+
+impl AgentSignal {
+    fn from_code(code: Code) -> Option<Self> {
+        Some(match code {
+            Code::Unavailable => Self::BackendUnreachable,
+            Code::ResourceExhausted => Self::RateLimited,
+            Code::DeadlineExceeded => Self::QueryTooExpensive,
+            Code::Internal => Self::BackendError,
+            Code::Aborted => Self::Conflict,
+            Code::AlreadyExists => Self::AlreadyExists,
+            Code::PermissionDenied => Self::PermissionDenied,
+            Code::Unauthenticated => Self::Unauthenticated,
+            Code::Cancelled => Self::Cancelled,
+            _ => return None,
+        })
+    }
+}
+
+impl Display for AgentSignal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BackendUnreachable => write!(
+                f,
+                "The Sift backend was unreachable after multiple attempts. \
+                 Do not retry this tool in this prompt. Inform the user that the backend appears to be down."
+            ),
+            Self::RateLimited => write!(
+                f,
+                "The Sift backend is rate-limiting requests. \
+                 Do not retry this tool in this prompt. Either wait, narrow your query (shorter time \
+                 range or more specific filter), or ask the user to refine their request."
+            ),
+            Self::QueryTooExpensive => write!(
+                f,
+                "The query exceeded the server's deadline. \
+                 Do not retry this tool with the same parameters. Narrow your query (shorter time range, \
+                 more specific filter, or smaller limit) before trying again."
+            ),
+            Self::BackendError => write!(
+                f,
+                "The Sift backend returned an internal error. \
+                 Do not retry this tool in this prompt. Surface this to the user; the issue is on the backend side."
+            ),
+            Self::Conflict => write!(
+                f,
+                "The Sift backend reported a conflict (concurrent modification or constraint violation). \
+                 Do not retry this tool in this prompt. Surface this to the user so they can resolve the conflicting state."
+            ),
+            Self::AlreadyExists => write!(
+                f,
+                "The resource already exists. \
+                 Do not retry; the operation cannot succeed as-is. If the user intended to update an existing resource, surface this distinction to them."
+            ),
+            Self::PermissionDenied => write!(
+                f,
+                "The caller lacks permission for this operation. \
+                 Do not retry; permission will not change within this prompt. Surface this to the user."
+            ),
+            Self::Unauthenticated => write!(
+                f,
+                "Authentication is missing or invalid. \
+                 Do not retry; the user must re-authenticate. Surface this to the user."
+            ),
+            Self::Cancelled => write!(
+                f,
+                "The request was cancelled. \
+                 Do not retry; the cancellation is intentional. Surface this to the user."
+            ),
+        }
     }
 }
 
 pub fn from_anyhow(error: anyhow::Error) -> rmcp::ErrorData {
     if let Some(status) = error.downcast_ref::<Status>()
-        && let Some((reason, guidance)) = soft_signal_guidance(status.code())
+        && let Some(signal) = AgentSignal::from_code(status.code())
     {
+        let reason = format!("{signal:?}");
+        let guidance = signal.to_string();
         return rmcp::ErrorData {
             code: ErrorCode::INTERNAL_ERROR,
-            message: guidance.into(),
+            message: guidance.clone().into(),
             data: Some(serde_json::json!({
                 "status": "stopped",
                 "reason": reason,

--- a/rust/crates/sift_mcp/src/error/mod.rs
+++ b/rust/crates/sift_mcp/src/error/mod.rs
@@ -64,18 +64,18 @@ fn soft_signal_guidance(code: Code) -> Option<(&'static str, &'static str)> {
 }
 
 pub fn from_anyhow(error: anyhow::Error) -> rmcp::ErrorData {
-    if let Some(status) = error.downcast_ref::<Status>() {
-        if let Some((reason, guidance)) = soft_signal_guidance(status.code()) {
-            return rmcp::ErrorData {
-                code: ErrorCode::INTERNAL_ERROR,
-                message: guidance.into(),
-                data: Some(serde_json::json!({
-                    "status": "stopped",
-                    "reason": reason,
-                    "guidance": guidance,
-                })),
-            };
-        }
+    if let Some(status) = error.downcast_ref::<Status>()
+        && let Some((reason, guidance)) = soft_signal_guidance(status.code())
+    {
+        return rmcp::ErrorData {
+            code: ErrorCode::INTERNAL_ERROR,
+            message: guidance.into(),
+            data: Some(serde_json::json!({
+                "status": "stopped",
+                "reason": reason,
+                "guidance": guidance,
+            })),
+        };
     }
 
     let message = format!("{error:?}");

--- a/rust/crates/sift_mcp/src/error/mod.rs
+++ b/rust/crates/sift_mcp/src/error/mod.rs
@@ -1,5 +1,8 @@
-use rmcp::model::{CallToolResult, ErrorCode};
+use rmcp::model::{CallToolResult, Content, ErrorCode};
 use tonic::{Code, Status};
+
+#[cfg(test)]
+mod test;
 
 pub type McpResult = Result<CallToolResult, rmcp::ErrorData>;
 
@@ -25,4 +28,79 @@ fn from_grpc_code(code: Code) -> ErrorCode {
         Code::Unimplemented => ErrorCode::METHOD_NOT_FOUND,
         _ => ErrorCode::INTERNAL_ERROR,
     }
+}
+
+/// gRPC codes that warrant a structured "stopped, do not retry in this prompt"
+/// response to the calling agent instead of an opaque error. Returns the
+/// machine-readable reason and the human-readable guidance text shown to the
+/// agent.
+fn soft_signal_guidance(code: Code) -> Option<(&'static str, &'static str)> {
+    match code {
+        Code::Unavailable => Some((
+            "backend_unreachable",
+            "The Sift backend was unreachable after multiple attempts. \
+             Do not retry this tool in this prompt. Inform the user that the backend appears to be down.",
+        )),
+        Code::ResourceExhausted => Some((
+            "rate_limited",
+            "The Sift backend is rate-limiting requests. \
+             Do not retry this tool in this prompt. Either wait, narrow your query (shorter time \
+             range or more specific filter), or ask the user to refine their request.",
+        )),
+        Code::DeadlineExceeded => Some((
+            "query_too_expensive",
+            "The query exceeded the server's deadline. \
+             Do not retry this tool with the same parameters. Narrow your query (shorter time range, \
+             more specific filter, or smaller limit) before trying again.",
+        )),
+        Code::Internal => Some((
+            "backend_error",
+            "The Sift backend returned an internal error. \
+             Do not retry this tool in this prompt. Surface this to the user; the issue is on the backend side.",
+        )),
+        _ => None,
+    }
+}
+
+/// Convert an `anyhow::Error` into an `McpResult`. gRPC status codes that map
+/// to a soft signal (see [`soft_signal_guidance`]) are returned as a structured
+/// `CallToolResult` instructing the agent not to retry; everything else falls
+/// back to [`from_anyhow`].
+pub fn err_into_mcp_result(err: anyhow::Error) -> McpResult {
+    let soft = err
+        .downcast_ref::<Status>()
+        .and_then(|s| soft_signal_guidance(s.code()));
+    if let Some((reason, guidance)) = soft {
+        let mut result = CallToolResult::structured(serde_json::json!({
+            "status": "stopped",
+            "reason": reason,
+            "guidance": guidance,
+        }));
+        result.content = vec![Content::text(guidance.to_string())];
+        return Ok(result);
+    }
+    Err(from_anyhow(err))
+}
+
+/// Convert a fallible operation's result into an `McpResult`. `Ok` values are
+/// wrapped in [`CallToolResult::structured`]; `Err` values route through
+/// [`err_into_mcp_result`].
+pub fn into_tool_result(result: Result<serde_json::Value, anyhow::Error>) -> McpResult {
+    match result {
+        Ok(value) => Ok(CallToolResult::structured(value)),
+        Err(err) => err_into_mcp_result(err),
+    }
+}
+
+/// `?`-like macro for tool handlers: returns the unwrapped value on `Ok`,
+/// early-returns an `McpResult` (either a soft-signal `Ok` or a normal `Err`)
+/// from the enclosing function on `Err`. Use inside `pub async fn ... -> McpResult`.
+#[macro_export]
+macro_rules! tool_try {
+    ($expr:expr) => {
+        match $expr {
+            Ok(v) => v,
+            Err(e) => return $crate::error::err_into_mcp_result(e),
+        }
+    };
 }

--- a/rust/crates/sift_mcp/src/error/mod.rs
+++ b/rust/crates/sift_mcp/src/error/mod.rs
@@ -13,6 +13,8 @@ pub type McpResult = Result<CallToolResult, rmcp::ErrorData>;
 ///
 /// `Debug` yields the machine-readable reason (the variant name).
 /// `Display` yields the human-readable guidance.
+/// `Unclassified` is the catch-all for codes that aren't soft-signals and
+/// should pass through to the generic error path in `from_anyhow`.
 #[derive(Debug)]
 enum AgentSignal {
     BackendUnreachable,
@@ -24,11 +26,12 @@ enum AgentSignal {
     PermissionDenied,
     Unauthenticated,
     Cancelled,
+    Unclassified,
 }
 
-impl AgentSignal {
-    fn from_code(code: Code) -> Option<Self> {
-        Some(match code {
+impl From<Code> for AgentSignal {
+    fn from(code: Code) -> Self {
+        match code {
             Code::Unavailable => Self::BackendUnreachable,
             Code::ResourceExhausted => Self::RateLimited,
             Code::DeadlineExceeded => Self::QueryTooExpensive,
@@ -38,8 +41,8 @@ impl AgentSignal {
             Code::PermissionDenied => Self::PermissionDenied,
             Code::Unauthenticated => Self::Unauthenticated,
             Code::Cancelled => Self::Cancelled,
-            _ => return None,
-        })
+            _ => Self::Unclassified,
+        }
     }
 }
 
@@ -93,25 +96,27 @@ impl Display for AgentSignal {
                 "The request was cancelled. \
                  Do not retry; the cancellation is intentional. Surface this to the user."
             ),
+            Self::Unclassified => write!(f, "Unclassified gRPC error."),
         }
     }
 }
 
 pub fn from_anyhow(error: anyhow::Error) -> rmcp::ErrorData {
-    if let Some(status) = error.downcast_ref::<Status>()
-        && let Some(signal) = AgentSignal::from_code(status.code())
-    {
-        let reason = format!("{signal:?}");
-        let guidance = signal.to_string();
-        return rmcp::ErrorData {
-            code: ErrorCode::INTERNAL_ERROR,
-            message: guidance.clone().into(),
-            data: Some(serde_json::json!({
-                "status": "stopped",
-                "reason": reason,
-                "guidance": guidance,
-            })),
-        };
+    if let Some(status) = error.downcast_ref::<Status>() {
+        let signal = AgentSignal::from(status.code());
+        if !matches!(signal, AgentSignal::Unclassified) {
+            let reason = format!("{signal:?}");
+            let guidance = signal.to_string();
+            return rmcp::ErrorData {
+                code: ErrorCode::INTERNAL_ERROR,
+                message: guidance.clone().into(),
+                data: Some(serde_json::json!({
+                    "status": "stopped",
+                    "reason": reason,
+                    "guidance": guidance,
+                })),
+            };
+        }
     }
 
     let message = format!("{error:?}");

--- a/rust/crates/sift_mcp/src/error/mod.rs
+++ b/rust/crates/sift_mcp/src/error/mod.rs
@@ -13,8 +13,6 @@ pub type McpResult = Result<CallToolResult, rmcp::ErrorData>;
 ///
 /// `Debug` yields the machine-readable reason (the variant name).
 /// `Display` yields the human-readable guidance.
-/// `Unclassified` is the catch-all for codes that aren't soft-signals and
-/// should pass through to the generic error path in `from_anyhow`.
 #[derive(Debug)]
 enum AgentSignal {
     BackendUnreachable,
@@ -26,12 +24,13 @@ enum AgentSignal {
     PermissionDenied,
     Unauthenticated,
     Cancelled,
-    Unclassified,
 }
 
-impl From<Code> for AgentSignal {
-    fn from(code: Code) -> Self {
-        match code {
+impl TryFrom<Code> for AgentSignal {
+    type Error = Code;
+
+    fn try_from(code: Code) -> Result<Self, Code> {
+        Ok(match code {
             Code::Unavailable => Self::BackendUnreachable,
             Code::ResourceExhausted => Self::RateLimited,
             Code::DeadlineExceeded => Self::QueryTooExpensive,
@@ -41,8 +40,8 @@ impl From<Code> for AgentSignal {
             Code::PermissionDenied => Self::PermissionDenied,
             Code::Unauthenticated => Self::Unauthenticated,
             Code::Cancelled => Self::Cancelled,
-            _ => Self::Unclassified,
-        }
+            other => return Err(other),
+        })
     }
 }
 
@@ -96,27 +95,25 @@ impl Display for AgentSignal {
                 "The request was cancelled. \
                  Do not retry; the cancellation is intentional. Surface this to the user."
             ),
-            Self::Unclassified => write!(f, "Unclassified gRPC error."),
         }
     }
 }
 
 pub fn from_anyhow(error: anyhow::Error) -> rmcp::ErrorData {
-    if let Some(status) = error.downcast_ref::<Status>() {
-        let signal = AgentSignal::from(status.code());
-        if !matches!(signal, AgentSignal::Unclassified) {
-            let reason = format!("{signal:?}");
-            let guidance = signal.to_string();
-            return rmcp::ErrorData {
-                code: ErrorCode::INTERNAL_ERROR,
-                message: guidance.clone().into(),
-                data: Some(serde_json::json!({
-                    "status": "stopped",
-                    "reason": reason,
-                    "guidance": guidance,
-                })),
-            };
-        }
+    if let Some(status) = error.downcast_ref::<Status>()
+        && let Ok(signal) = AgentSignal::try_from(status.code())
+    {
+        let reason = format!("{signal:?}");
+        let guidance = signal.to_string();
+        return rmcp::ErrorData {
+            code: ErrorCode::INTERNAL_ERROR,
+            message: guidance.clone().into(),
+            data: Some(serde_json::json!({
+                "status": "stopped",
+                "reason": reason,
+                "guidance": guidance,
+            })),
+        };
     }
 
     let message = format!("{error:?}");

--- a/rust/crates/sift_mcp/src/error/test.rs
+++ b/rust/crates/sift_mcp/src/error/test.rs
@@ -1,4 +1,3 @@
-use anyhow::Context as _;
 use rmcp::model::ErrorCode;
 use tonic::Status;
 
@@ -65,4 +64,47 @@ fn not_found_keeps_existing_mapping() {
 
     let data = from_anyhow(err);
     assert_eq!(data.code, ErrorCode::RESOURCE_NOT_FOUND);
+}
+
+#[test]
+fn soft_signal_for_aborted() {
+    let err = anyhow::Error::from(Status::aborted("conflict")).context("failed to update run");
+
+    let data = from_anyhow(err);
+    assert_eq!(reason_from_data(&data), "conflict");
+}
+
+#[test]
+fn soft_signal_for_already_exists() {
+    let err =
+        anyhow::Error::from(Status::already_exists("duplicate")).context("failed to create run");
+
+    let data = from_anyhow(err);
+    assert_eq!(reason_from_data(&data), "already_exists");
+}
+
+#[test]
+fn soft_signal_for_permission_denied() {
+    let err =
+        anyhow::Error::from(Status::permission_denied("nope")).context("failed to query assets");
+
+    let data = from_anyhow(err);
+    assert_eq!(reason_from_data(&data), "permission_denied");
+}
+
+#[test]
+fn soft_signal_for_unauthenticated() {
+    let err = anyhow::Error::from(Status::unauthenticated("no token")).context("failed to query");
+
+    let data = from_anyhow(err);
+    assert_eq!(reason_from_data(&data), "unauthenticated");
+}
+
+#[test]
+fn soft_signal_for_cancelled() {
+    let err = anyhow::Error::from(Status::cancelled("cancelled by server"))
+        .context("failed to get data");
+
+    let data = from_anyhow(err);
+    assert_eq!(reason_from_data(&data), "cancelled");
 }

--- a/rust/crates/sift_mcp/src/error/test.rs
+++ b/rust/crates/sift_mcp/src/error/test.rs
@@ -1,0 +1,99 @@
+use anyhow::Context as _;
+use rmcp::model::ErrorCode;
+use tonic::Status;
+
+use super::{err_into_mcp_result, into_tool_result};
+
+fn extract_reason(value: &serde_json::Value) -> &str {
+    value
+        .get("reason")
+        .and_then(|v| v.as_str())
+        .expect("missing reason field")
+}
+
+#[test]
+fn soft_signal_for_resource_exhausted() {
+    let err = anyhow::Error::from(Status::resource_exhausted("slow down"))
+        .context("failed to query assets");
+
+    let result = err_into_mcp_result(err).expect("expected Ok with structured guidance");
+    let content = result
+        .structured_content
+        .expect("expected structured content");
+    assert_eq!(extract_reason(&content), "rate_limited");
+}
+
+#[test]
+fn soft_signal_for_unavailable() {
+    let err =
+        anyhow::Error::from(Status::unavailable("backend gone")).context("failed to query runs");
+
+    let result = err_into_mcp_result(err).expect("expected Ok with structured guidance");
+    let content = result
+        .structured_content
+        .expect("expected structured content");
+    assert_eq!(extract_reason(&content), "backend_unreachable");
+}
+
+#[test]
+fn soft_signal_for_deadline_exceeded() {
+    let err = anyhow::Error::from(Status::deadline_exceeded("too slow"))
+        .context("failed to get data");
+
+    let result = err_into_mcp_result(err).expect("expected Ok with structured guidance");
+    let content = result
+        .structured_content
+        .expect("expected structured content");
+    assert_eq!(extract_reason(&content), "query_too_expensive");
+}
+
+#[test]
+fn soft_signal_for_internal() {
+    let err =
+        anyhow::Error::from(Status::internal("backend bug")).context("failed to query channels");
+
+    let result = err_into_mcp_result(err).expect("expected Ok with structured guidance");
+    let content = result
+        .structured_content
+        .expect("expected structured content");
+    assert_eq!(extract_reason(&content), "backend_error");
+}
+
+#[test]
+fn invalid_argument_still_errors() {
+    let err = anyhow::Error::from(Status::invalid_argument("bad filter"))
+        .context("failed to query assets");
+
+    let data = err_into_mcp_result(err).expect_err("expected Err for non-soft-signal code");
+    assert_eq!(data.code, ErrorCode::INVALID_PARAMS);
+}
+
+#[test]
+fn not_found_still_errors() {
+    let err = anyhow::Error::from(Status::not_found("missing")).context("lookup failed");
+
+    let data = err_into_mcp_result(err).expect_err("expected Err for not-found");
+    assert_eq!(data.code, ErrorCode::RESOURCE_NOT_FOUND);
+}
+
+#[test]
+fn into_tool_result_passes_through_success() {
+    let value = serde_json::json!({ "assets": [] });
+    let result =
+        into_tool_result(Ok(value.clone())).expect("expected Ok with structured success");
+    assert_eq!(
+        result
+            .structured_content
+            .expect("expected structured content"),
+        value
+    );
+}
+
+#[test]
+fn soft_signal_emits_text_content() {
+    let err = anyhow::Error::from(Status::resource_exhausted("slow down"))
+        .context("failed to query assets");
+
+    let result = err_into_mcp_result(err).expect("expected Ok");
+    assert!(!result.content.is_empty(), "expected text content block");
+}

--- a/rust/crates/sift_mcp/src/error/test.rs
+++ b/rust/crates/sift_mcp/src/error/test.rs
@@ -102,8 +102,8 @@ fn soft_signal_for_unauthenticated() {
 
 #[test]
 fn soft_signal_for_cancelled() {
-    let err = anyhow::Error::from(Status::cancelled("cancelled by server"))
-        .context("failed to get data");
+    let err =
+        anyhow::Error::from(Status::cancelled("cancelled by server")).context("failed to get data");
 
     let data = from_anyhow(err);
     assert_eq!(reason_from_data(&data), "cancelled");

--- a/rust/crates/sift_mcp/src/error/test.rs
+++ b/rust/crates/sift_mcp/src/error/test.rs
@@ -2,13 +2,14 @@ use anyhow::Context as _;
 use rmcp::model::ErrorCode;
 use tonic::Status;
 
-use super::{err_into_mcp_result, into_tool_result};
+use super::from_anyhow;
 
-fn extract_reason(value: &serde_json::Value) -> &str {
-    value
-        .get("reason")
+fn reason_from_data(data: &rmcp::ErrorData) -> &str {
+    data.data
+        .as_ref()
+        .and_then(|v| v.get("reason"))
         .and_then(|v| v.as_str())
-        .expect("missing reason field")
+        .expect("missing reason field in error data")
 }
 
 #[test]
@@ -16,11 +17,9 @@ fn soft_signal_for_resource_exhausted() {
     let err = anyhow::Error::from(Status::resource_exhausted("slow down"))
         .context("failed to query assets");
 
-    let result = err_into_mcp_result(err).expect("expected Ok with structured guidance");
-    let content = result
-        .structured_content
-        .expect("expected structured content");
-    assert_eq!(extract_reason(&content), "rate_limited");
+    let data = from_anyhow(err);
+    assert_eq!(reason_from_data(&data), "rate_limited");
+    assert!(data.message.contains("rate-limiting"));
 }
 
 #[test]
@@ -28,23 +27,17 @@ fn soft_signal_for_unavailable() {
     let err =
         anyhow::Error::from(Status::unavailable("backend gone")).context("failed to query runs");
 
-    let result = err_into_mcp_result(err).expect("expected Ok with structured guidance");
-    let content = result
-        .structured_content
-        .expect("expected structured content");
-    assert_eq!(extract_reason(&content), "backend_unreachable");
+    let data = from_anyhow(err);
+    assert_eq!(reason_from_data(&data), "backend_unreachable");
 }
 
 #[test]
 fn soft_signal_for_deadline_exceeded() {
-    let err = anyhow::Error::from(Status::deadline_exceeded("too slow"))
-        .context("failed to get data");
+    let err =
+        anyhow::Error::from(Status::deadline_exceeded("too slow")).context("failed to get data");
 
-    let result = err_into_mcp_result(err).expect("expected Ok with structured guidance");
-    let content = result
-        .structured_content
-        .expect("expected structured content");
-    assert_eq!(extract_reason(&content), "query_too_expensive");
+    let data = from_anyhow(err);
+    assert_eq!(reason_from_data(&data), "query_too_expensive");
 }
 
 #[test]
@@ -52,48 +45,24 @@ fn soft_signal_for_internal() {
     let err =
         anyhow::Error::from(Status::internal("backend bug")).context("failed to query channels");
 
-    let result = err_into_mcp_result(err).expect("expected Ok with structured guidance");
-    let content = result
-        .structured_content
-        .expect("expected structured content");
-    assert_eq!(extract_reason(&content), "backend_error");
+    let data = from_anyhow(err);
+    assert_eq!(reason_from_data(&data), "backend_error");
 }
 
 #[test]
-fn invalid_argument_still_errors() {
+fn invalid_argument_keeps_existing_mapping() {
     let err = anyhow::Error::from(Status::invalid_argument("bad filter"))
         .context("failed to query assets");
 
-    let data = err_into_mcp_result(err).expect_err("expected Err for non-soft-signal code");
+    let data = from_anyhow(err);
     assert_eq!(data.code, ErrorCode::INVALID_PARAMS);
+    assert!(data.data.is_none());
 }
 
 #[test]
-fn not_found_still_errors() {
+fn not_found_keeps_existing_mapping() {
     let err = anyhow::Error::from(Status::not_found("missing")).context("lookup failed");
 
-    let data = err_into_mcp_result(err).expect_err("expected Err for not-found");
+    let data = from_anyhow(err);
     assert_eq!(data.code, ErrorCode::RESOURCE_NOT_FOUND);
-}
-
-#[test]
-fn into_tool_result_passes_through_success() {
-    let value = serde_json::json!({ "assets": [] });
-    let result =
-        into_tool_result(Ok(value.clone())).expect("expected Ok with structured success");
-    assert_eq!(
-        result
-            .structured_content
-            .expect("expected structured content"),
-        value
-    );
-}
-
-#[test]
-fn soft_signal_emits_text_content() {
-    let err = anyhow::Error::from(Status::resource_exhausted("slow down"))
-        .context("failed to query assets");
-
-    let result = err_into_mcp_result(err).expect("expected Ok");
-    assert!(!result.content.is_empty(), "expected text content block");
 }

--- a/rust/crates/sift_mcp/src/error/test.rs
+++ b/rust/crates/sift_mcp/src/error/test.rs
@@ -17,7 +17,7 @@ fn soft_signal_for_resource_exhausted() {
         .context("failed to query assets");
 
     let data = from_anyhow(err);
-    assert_eq!(reason_from_data(&data), "rate_limited");
+    assert_eq!(reason_from_data(&data), "RateLimited");
     assert!(data.message.contains("rate-limiting"));
 }
 
@@ -27,7 +27,7 @@ fn soft_signal_for_unavailable() {
         anyhow::Error::from(Status::unavailable("backend gone")).context("failed to query runs");
 
     let data = from_anyhow(err);
-    assert_eq!(reason_from_data(&data), "backend_unreachable");
+    assert_eq!(reason_from_data(&data), "BackendUnreachable");
 }
 
 #[test]
@@ -36,7 +36,7 @@ fn soft_signal_for_deadline_exceeded() {
         anyhow::Error::from(Status::deadline_exceeded("too slow")).context("failed to get data");
 
     let data = from_anyhow(err);
-    assert_eq!(reason_from_data(&data), "query_too_expensive");
+    assert_eq!(reason_from_data(&data), "QueryTooExpensive");
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn soft_signal_for_internal() {
         anyhow::Error::from(Status::internal("backend bug")).context("failed to query channels");
 
     let data = from_anyhow(err);
-    assert_eq!(reason_from_data(&data), "backend_error");
+    assert_eq!(reason_from_data(&data), "BackendError");
 }
 
 #[test]
@@ -71,7 +71,7 @@ fn soft_signal_for_aborted() {
     let err = anyhow::Error::from(Status::aborted("conflict")).context("failed to update run");
 
     let data = from_anyhow(err);
-    assert_eq!(reason_from_data(&data), "conflict");
+    assert_eq!(reason_from_data(&data), "Conflict");
 }
 
 #[test]
@@ -80,7 +80,7 @@ fn soft_signal_for_already_exists() {
         anyhow::Error::from(Status::already_exists("duplicate")).context("failed to create run");
 
     let data = from_anyhow(err);
-    assert_eq!(reason_from_data(&data), "already_exists");
+    assert_eq!(reason_from_data(&data), "AlreadyExists");
 }
 
 #[test]
@@ -89,7 +89,7 @@ fn soft_signal_for_permission_denied() {
         anyhow::Error::from(Status::permission_denied("nope")).context("failed to query assets");
 
     let data = from_anyhow(err);
-    assert_eq!(reason_from_data(&data), "permission_denied");
+    assert_eq!(reason_from_data(&data), "PermissionDenied");
 }
 
 #[test]
@@ -97,7 +97,7 @@ fn soft_signal_for_unauthenticated() {
     let err = anyhow::Error::from(Status::unauthenticated("no token")).context("failed to query");
 
     let data = from_anyhow(err);
-    assert_eq!(reason_from_data(&data), "unauthenticated");
+    assert_eq!(reason_from_data(&data), "Unauthenticated");
 }
 
 #[test]
@@ -106,5 +106,5 @@ fn soft_signal_for_cancelled() {
         anyhow::Error::from(Status::cancelled("cancelled by server")).context("failed to get data");
 
     let data = from_anyhow(err);
-    assert_eq!(reason_from_data(&data), "cancelled");
+    assert_eq!(reason_from_data(&data), "Cancelled");
 }

--- a/rust/crates/sift_mcp/src/lib.rs
+++ b/rust/crates/sift_mcp/src/lib.rs
@@ -7,6 +7,7 @@ mod server;
 use server::SiftMcpServer;
 
 mod error;
+mod policy;
 mod prompt;
 mod service;
 mod tool;

--- a/rust/crates/sift_mcp/src/policy/mod.rs
+++ b/rust/crates/sift_mcp/src/policy/mod.rs
@@ -22,10 +22,11 @@ impl Default for RetryPolicy {
     }
 }
 
-/// Wrap a gRPC call in retry-with-backoff policy. Retries on transient codes
-/// (`Unavailable`, `ResourceExhausted`) using exponential backoff with full
-/// jitter. Returns the most recent `Status` when retries exhaust or when a
-/// non-retriable code is observed.
+/// Wrap a gRPC call in retry-with-backoff policy. Per AIP-194, only
+/// `Unavailable` is automatically retried (with exponential backoff and full
+/// jitter). All other codes — including `ResourceExhausted`, which is a
+/// server-side rate-limit signal — return immediately so the caller can surface
+/// the failure rather than amplifying load.
 pub async fn with_retry<T, F, Fut>(policy: &RetryPolicy, op: F) -> Result<T, Status>
 where
     F: Fn() -> Fut,
@@ -37,14 +38,12 @@ where
         match op().await {
             Ok(v) => return Ok(v),
             Err(s) => match s.code() {
-                Code::Unavailable | Code::ResourceExhausted => {
+                Code::Unavailable => {
                     attempt += 1;
                     if attempt >= policy.max_attempts {
                         return Err(s);
                     }
                 }
-                Code::DeadlineExceeded => return Err(s),
-                Code::Internal => return Err(s),
                 _ => return Err(s),
             },
         }

--- a/rust/crates/sift_mcp/src/policy/mod.rs
+++ b/rust/crates/sift_mcp/src/policy/mod.rs
@@ -1,0 +1,58 @@
+use std::time::Duration;
+
+use rand::RngExt;
+use tokio::time::sleep;
+use tonic::{Code, Status};
+
+#[cfg(test)]
+mod test;
+
+#[derive(Debug, Clone)]
+pub struct RetryPolicy {
+    pub max_attempts: u32,
+    pub base_backoff_ms: u64,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: 3,
+            base_backoff_ms: 250,
+        }
+    }
+}
+
+/// Wrap a gRPC call in retry-with-backoff policy. Retries on transient codes
+/// (`Unavailable`, `ResourceExhausted`) using exponential backoff with full
+/// jitter. Returns the most recent `Status` when retries exhaust or when a
+/// non-retriable code is observed.
+pub async fn with_retry<T, F, Fut>(policy: &RetryPolicy, op: F) -> Result<T, Status>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<T, Status>>,
+{
+    let mut attempt: u32 = 0;
+
+    loop {
+        match op().await {
+            Ok(v) => return Ok(v),
+            Err(s) => match s.code() {
+                Code::Unavailable | Code::ResourceExhausted => {
+                    attempt += 1;
+                    if attempt >= policy.max_attempts {
+                        return Err(s);
+                    }
+                }
+                Code::DeadlineExceeded => return Err(s),
+                Code::Internal => return Err(s),
+                _ => return Err(s),
+            },
+        }
+
+        let backoff_ms = policy
+            .base_backoff_ms
+            .saturating_mul(2u64.saturating_pow(attempt - 1));
+        let jittered = rand::rng().random_range(0..=backoff_ms);
+        sleep(Duration::from_millis(jittered)).await;
+    }
+}

--- a/rust/crates/sift_mcp/src/policy/test.rs
+++ b/rust/crates/sift_mcp/src/policy/test.rs
@@ -41,15 +41,32 @@ async fn returns_last_status_on_max_attempts() {
         let counter = counter.clone();
         async move {
             counter.fetch_add(1, Ordering::SeqCst);
-            Err(Status::resource_exhausted("nope"))
+            Err(Status::unavailable("nope"))
         }
     })
     .await;
 
     let err = result.unwrap_err();
-    assert_eq!(err.code(), Code::ResourceExhausted);
+    assert_eq!(err.code(), Code::Unavailable);
     assert_eq!(err.message(), "nope");
     assert_eq!(counter.load(Ordering::SeqCst), 3);
+}
+
+#[tokio::test]
+async fn resource_exhausted_does_not_retry() {
+    let policy = fast_policy();
+    let counter = Arc::new(AtomicU32::new(0));
+    let result: Result<(), Status> = with_retry(&policy, || {
+        let counter = counter.clone();
+        async move {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Err(Status::resource_exhausted("slow down"))
+        }
+    })
+    .await;
+
+    assert_eq!(result.unwrap_err().code(), Code::ResourceExhausted);
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]

--- a/rust/crates/sift_mcp/src/policy/test.rs
+++ b/rust/crates/sift_mcp/src/policy/test.rs
@@ -1,0 +1,104 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use tonic::{Code, Status};
+
+use super::{RetryPolicy, with_retry};
+
+fn fast_policy() -> RetryPolicy {
+    RetryPolicy {
+        max_attempts: 3,
+        base_backoff_ms: 1,
+    }
+}
+
+#[tokio::test]
+async fn succeeds_after_transient_failures() {
+    let policy = fast_policy();
+    let counter = Arc::new(AtomicU32::new(0));
+    let result = with_retry(&policy, || {
+        let counter = counter.clone();
+        async move {
+            let n = counter.fetch_add(1, Ordering::SeqCst);
+            if n < 2 {
+                Err(Status::unavailable("retry me"))
+            } else {
+                Ok(42i32)
+            }
+        }
+    })
+    .await;
+
+    assert_eq!(result.unwrap(), 42);
+    assert_eq!(counter.load(Ordering::SeqCst), 3);
+}
+
+#[tokio::test]
+async fn returns_last_status_on_max_attempts() {
+    let policy = fast_policy();
+    let counter = Arc::new(AtomicU32::new(0));
+    let result: Result<(), Status> = with_retry(&policy, || {
+        let counter = counter.clone();
+        async move {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Err(Status::resource_exhausted("nope"))
+        }
+    })
+    .await;
+
+    let err = result.unwrap_err();
+    assert_eq!(err.code(), Code::ResourceExhausted);
+    assert_eq!(err.message(), "nope");
+    assert_eq!(counter.load(Ordering::SeqCst), 3);
+}
+
+#[tokio::test]
+async fn deadline_exceeded_does_not_retry() {
+    let policy = fast_policy();
+    let counter = Arc::new(AtomicU32::new(0));
+    let result: Result<(), Status> = with_retry(&policy, || {
+        let counter = counter.clone();
+        async move {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Err(Status::deadline_exceeded("too slow"))
+        }
+    })
+    .await;
+
+    assert_eq!(result.unwrap_err().code(), Code::DeadlineExceeded);
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn internal_does_not_retry() {
+    let policy = fast_policy();
+    let counter = Arc::new(AtomicU32::new(0));
+    let result: Result<(), Status> = with_retry(&policy, || {
+        let counter = counter.clone();
+        async move {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Err(Status::internal("boom"))
+        }
+    })
+    .await;
+
+    assert_eq!(result.unwrap_err().code(), Code::Internal);
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn invalid_argument_does_not_retry() {
+    let policy = fast_policy();
+    let counter = Arc::new(AtomicU32::new(0));
+    let result: Result<(), Status> = with_retry(&policy, || {
+        let counter = counter.clone();
+        async move {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Err(Status::invalid_argument("bad input"))
+        }
+    })
+    .await;
+
+    assert_eq!(result.unwrap_err().code(), Code::InvalidArgument);
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+}

--- a/rust/crates/sift_mcp/src/server/mod.rs
+++ b/rust/crates/sift_mcp/src/server/mod.rs
@@ -9,6 +9,7 @@ use rmcp::{
 };
 use sift_rs::SiftChannel;
 
+use crate::policy::RetryPolicy;
 use crate::service::{
     assets::AssetService, channels::ChannelService, data::DataService, explore::ExploreService,
     ingest::IngestService, reports::ReportService, rules::RuleService, runs::RunService,
@@ -48,14 +49,16 @@ impl SiftMcpServer {
 
         let prompt_router = Self::prompt_router();
 
-        let asset_service = AssetService::new(channel.clone());
-        let data_service = DataService::new(channel.clone());
-        let channel_service = ChannelService::new(channel.clone());
+        let retry_policy = RetryPolicy::default();
+
+        let asset_service = AssetService::new(channel.clone(), retry_policy.clone());
+        let data_service = DataService::new(channel.clone(), retry_policy.clone());
+        let channel_service = ChannelService::new(channel.clone(), retry_policy.clone());
         let explore_service = ExploreService::new(rest_uri);
         let ingest_service = IngestService::new(channel.clone());
-        let run_service = RunService::new(channel.clone());
-        let report_service = ReportService::new(channel.clone());
-        let rule_service = RuleService::new(channel.clone());
+        let run_service = RunService::new(channel.clone(), retry_policy.clone());
+        let report_service = ReportService::new(channel.clone(), retry_policy.clone());
+        let rule_service = RuleService::new(channel.clone(), retry_policy);
 
         Self {
             asset_service,

--- a/rust/crates/sift_mcp/src/server/mod.rs
+++ b/rust/crates/sift_mcp/src/server/mod.rs
@@ -12,7 +12,8 @@ use sift_rs::SiftChannel;
 use crate::policy::RetryPolicy;
 use crate::service::{
     assets::AssetService, channels::ChannelService, data::DataService, explore::ExploreService,
-    ingest::IngestService, reports::ReportService, rules::RuleService, runs::RunService,
+    ingest::IngestService, ping::PingService, reports::ReportService, rules::RuleService,
+    runs::RunService,
 };
 
 #[derive(Clone)]
@@ -25,6 +26,7 @@ pub struct SiftMcpServer {
     pub data_service: DataService,
     pub explore_service: ExploreService,
     pub ingest_service: IngestService,
+    pub ping_service: PingService,
     pub run_service: RunService,
     pub report_service: ReportService,
     pub rule_service: RuleService,
@@ -46,6 +48,7 @@ impl SiftMcpServer {
         let mut tool_router = Self::list_router();
         tool_router.merge(Self::data_router());
         tool_router.merge(Self::explore_router());
+        tool_router.merge(Self::ping_router());
 
         let prompt_router = Self::prompt_router();
 
@@ -56,6 +59,7 @@ impl SiftMcpServer {
         let channel_service = ChannelService::new(channel.clone(), retry_policy.clone());
         let explore_service = ExploreService::new(rest_uri);
         let ingest_service = IngestService::new(channel.clone());
+        let ping_service = PingService::new(channel.clone(), retry_policy.clone());
         let run_service = RunService::new(channel.clone(), retry_policy.clone());
         let report_service = ReportService::new(channel.clone(), retry_policy.clone());
         let rule_service = RuleService::new(channel.clone(), retry_policy);
@@ -66,6 +70,7 @@ impl SiftMcpServer {
             data_service,
             explore_service,
             ingest_service,
+            ping_service,
             run_service,
             report_service,
             rule_service,

--- a/rust/crates/sift_mcp/src/service/assets/mod.rs
+++ b/rust/crates/sift_mcp/src/service/assets/mod.rs
@@ -1,3 +1,4 @@
+use crate::policy::{RetryPolicy, with_retry};
 use crate::service::common;
 use anyhow::{Context, Result};
 use sift_rs::{
@@ -13,11 +14,12 @@ mod test;
 #[derive(Clone)]
 pub struct AssetService {
     channel: SiftChannel,
+    policy: RetryPolicy,
 }
 
 impl AssetService {
-    pub fn new(channel: SiftChannel) -> Self {
-        Self { channel }
+    pub fn new(channel: SiftChannel, policy: RetryPolicy) -> Self {
+        Self { channel, policy }
     }
 
     pub async fn list_assets(
@@ -28,25 +30,42 @@ impl AssetService {
     ) -> Result<Vec<Asset>> {
         let (page_size, record_limit) = common::paging(limit);
 
-        let mut client = AssetServiceClient::new(self.channel.clone());
         let mut page_token = String::new();
         let mut results = Vec::new();
 
+        let order_by = order_by.unwrap_or_default();
+
         loop {
-            let resp = client
-                .list_assets(ListAssetsRequest {
-                    filter: filter.to_string(),
-                    page_size,
-                    page_token,
-                    order_by: order_by.clone().unwrap_or_default(),
-                })
-                .await
-                .context("failed to query assets")?;
+            let channel = self.channel.clone();
+            let filter = filter.clone();
+            let order_by = order_by.clone();
+            let token = page_token.clone();
+
+            let resp = with_retry(&self.policy, move || {
+                let channel = channel.clone();
+                let filter = filter.clone();
+                let order_by = order_by.clone();
+                let token = token.clone();
+                async move {
+                    let mut client = AssetServiceClient::new(channel);
+                    client
+                        .list_assets(ListAssetsRequest {
+                            filter,
+                            page_size,
+                            page_token: token,
+                            order_by,
+                        })
+                        .await
+                        .map(|resp| resp.into_inner())
+                }
+            })
+            .await
+            .context("failed to query assets")?;
 
             let ListAssetsResponse {
                 assets,
                 next_page_token,
-            } = resp.into_inner();
+            } = resp;
             if assets.is_empty() {
                 break;
             }

--- a/rust/crates/sift_mcp/src/service/assets/test.rs
+++ b/rust/crates/sift_mcp/src/service/assets/test.rs
@@ -4,6 +4,7 @@ use tokio::task::JoinHandle;
 use tonic::{Response, Status, transport::Server};
 
 use super::AssetService;
+use crate::policy::RetryPolicy;
 use crate::service::common::PAGE_SIZE;
 
 async fn service_with_mock(mock: MockAssetServiceImpl) -> (AssetService, JoinHandle<()>) {
@@ -18,7 +19,7 @@ async fn service_with_mock(mock: MockAssetServiceImpl) -> (AssetService, JoinHan
             .unwrap();
     });
 
-    (AssetService::new(channel), handle)
+    (AssetService::new(channel, RetryPolicy::default()), handle)
 }
 
 #[tokio::test]

--- a/rust/crates/sift_mcp/src/service/channels/mod.rs
+++ b/rust/crates/sift_mcp/src/service/channels/mod.rs
@@ -1,3 +1,4 @@
+use crate::policy::{RetryPolicy, with_retry};
 use crate::service::common;
 use anyhow::{Context, Result};
 use sift_rs::{
@@ -14,11 +15,12 @@ mod test;
 #[derive(Clone)]
 pub struct ChannelService {
     channel: SiftChannel,
+    policy: RetryPolicy,
 }
 
 impl ChannelService {
-    pub fn new(channel: SiftChannel) -> Self {
-        Self { channel }
+    pub fn new(channel: SiftChannel, policy: RetryPolicy) -> Self {
+        Self { channel, policy }
     }
 
     pub async fn list_channels(
@@ -29,25 +31,42 @@ impl ChannelService {
     ) -> Result<Vec<Channel>> {
         let (page_size, record_limit) = common::paging(limit);
 
-        let mut client = ChannelServiceClient::new(self.channel.clone());
         let mut page_token = String::new();
         let mut results = Vec::new();
 
+        let order_by = order_by.unwrap_or_default();
+
         loop {
-            let resp = client
-                .list_channels(ListChannelsRequest {
-                    filter: filter.clone(),
-                    page_size,
-                    page_token,
-                    order_by: order_by.clone().unwrap_or_default(),
-                })
-                .await
-                .context("failed to query channels")?;
+            let channel = self.channel.clone();
+            let filter = filter.clone();
+            let order_by = order_by.clone();
+            let token = page_token.clone();
+
+            let resp = with_retry(&self.policy, move || {
+                let channel = channel.clone();
+                let filter = filter.clone();
+                let order_by = order_by.clone();
+                let token = token.clone();
+                async move {
+                    let mut client = ChannelServiceClient::new(channel);
+                    client
+                        .list_channels(ListChannelsRequest {
+                            filter,
+                            page_size,
+                            page_token: token,
+                            order_by,
+                        })
+                        .await
+                        .map(|resp| resp.into_inner())
+                }
+            })
+            .await
+            .context("failed to query channels")?;
 
             let ListChannelsResponse {
                 channels,
                 next_page_token,
-            } = resp.into_inner();
+            } = resp;
             if channels.is_empty() {
                 break;
             }

--- a/rust/crates/sift_mcp/src/service/channels/test.rs
+++ b/rust/crates/sift_mcp/src/service/channels/test.rs
@@ -20,7 +20,10 @@ async fn service_with_mock(mock: MockChannelServiceImpl) -> (ChannelService, Joi
             .unwrap();
     });
 
-    (ChannelService::new(channel), handle)
+    (
+        ChannelService::new(channel, crate::policy::RetryPolicy::default()),
+        handle,
+    )
 }
 
 #[tokio::test]

--- a/rust/crates/sift_mcp/src/service/data/mod.rs
+++ b/rust/crates/sift_mcp/src/service/data/mod.rs
@@ -37,6 +37,7 @@ use sift_rs::{
     runs::v2::Run,
 };
 
+use crate::policy::{RetryPolicy, with_retry};
 use crate::service::common::{
     BIT_FIELD_METADATA_KEY, ColumnName, ENUM_METADATA_KEY, PAGE_SIZE, TS_COLUMN_NAME,
     secs_and_subsec_nanos_to_unix_nanos, unix_nanos_to_secs_and_subsec_nanos,
@@ -51,6 +52,7 @@ const SIZE_FLUSH_THRESHOLD: usize = 64 << 20;
 #[derive(Clone)]
 pub struct DataService {
     channel: SiftChannel,
+    policy: RetryPolicy,
 }
 
 pub enum ChannelInput {
@@ -97,8 +99,8 @@ enum ChannelValue {
 }
 
 impl DataService {
-    pub fn new(channel: SiftChannel) -> Self {
-        Self { channel }
+    pub fn new(channel: SiftChannel, policy: RetryPolicy) -> Self {
+        Self { channel, policy }
     }
 
     pub fn sql<W: Write>(
@@ -253,27 +255,42 @@ impl DataService {
             })
             .collect::<Vec<_>>();
 
-        let mut data_service = DataServiceClient::new(self.channel.clone());
         let mut page_token = String::new();
         let mut columns = HashMap::<ColumnName, ChannelColumn>::new();
 
         loop {
-            let resp = data_service
-                .get_data(GetDataRequest {
-                    sample_ms,
-                    page_token,
-                    queries: queries.clone(),
-                    start_time: Some(start_time),
-                    end_time: Some(end_time),
-                    page_size: PAGE_SIZE,
-                })
-                .await
-                .context("failed to get data")?;
+            let channel = self.channel.clone();
+            let queries = queries.clone();
+            let token = page_token.clone();
+            let start_time = start_time;
+            let end_time = end_time;
+
+            let resp = with_retry(&self.policy, move || {
+                let channel = channel.clone();
+                let queries = queries.clone();
+                let token = token.clone();
+                async move {
+                    let mut data_service = DataServiceClient::new(channel);
+                    data_service
+                        .get_data(GetDataRequest {
+                            sample_ms,
+                            page_token: token,
+                            queries,
+                            start_time: Some(start_time),
+                            end_time: Some(end_time),
+                            page_size: PAGE_SIZE,
+                        })
+                        .await
+                        .map(|resp| resp.into_inner())
+                }
+            })
+            .await
+            .context("failed to get data")?;
 
             let GetDataResponse {
                 data,
                 next_page_token,
-            } = resp.into_inner();
+            } = resp;
 
             for channel_page in data {
                 match channel_page.type_url.as_str() {

--- a/rust/crates/sift_mcp/src/service/data/mod.rs
+++ b/rust/crates/sift_mcp/src/service/data/mod.rs
@@ -262,8 +262,6 @@ impl DataService {
             let channel = self.channel.clone();
             let queries = queries.clone();
             let token = page_token.clone();
-            let start_time = start_time;
-            let end_time = end_time;
 
             let resp = with_retry(&self.policy, move || {
                 let channel = channel.clone();

--- a/rust/crates/sift_mcp/src/service/data/test.rs
+++ b/rust/crates/sift_mcp/src/service/data/test.rs
@@ -34,7 +34,10 @@ async fn service_with_mock(mock: MockDataServiceImpl) -> (DataService, JoinHandl
             .unwrap();
     });
 
-    (DataService::new(channel), handle)
+    (
+        DataService::new(channel, crate::policy::RetryPolicy::default()),
+        handle,
+    )
 }
 
 fn raw_channel(channel_id: &str) -> ChannelInput {

--- a/rust/crates/sift_mcp/src/service/mod.rs
+++ b/rust/crates/sift_mcp/src/service/mod.rs
@@ -3,6 +3,7 @@ pub mod channels;
 pub mod data;
 pub mod explore;
 pub mod ingest;
+pub mod ping;
 pub mod reports;
 pub mod rules;
 pub mod runs;

--- a/rust/crates/sift_mcp/src/service/ping/mod.rs
+++ b/rust/crates/sift_mcp/src/service/ping/mod.rs
@@ -1,0 +1,35 @@
+use crate::policy::{RetryPolicy, with_retry};
+use anyhow::{Context, Result};
+use sift_rs::{
+    SiftChannel,
+    ping::v1::{PingRequest, ping_service_client::PingServiceClient},
+};
+
+#[derive(Clone)]
+pub struct PingService {
+    channel: SiftChannel,
+    policy: RetryPolicy,
+}
+
+impl PingService {
+    pub fn new(channel: SiftChannel, policy: RetryPolicy) -> Self {
+        Self { channel, policy }
+    }
+
+    pub async fn ping(&self) -> Result<String> {
+        let channel = self.channel.clone();
+
+        with_retry(&self.policy, move || {
+            let channel = channel.clone();
+            async move {
+                let mut client = PingServiceClient::new(channel);
+                client
+                    .ping(PingRequest::default())
+                    .await
+                    .map(|resp| resp.into_inner().response)
+            }
+        })
+        .await
+        .context("failed to ping Sift")
+    }
+}

--- a/rust/crates/sift_mcp/src/service/reports/mod.rs
+++ b/rust/crates/sift_mcp/src/service/reports/mod.rs
@@ -1,3 +1,4 @@
+use crate::policy::{RetryPolicy, with_retry};
 use crate::service::common;
 use anyhow::{Context, Result};
 use sift_rs::{
@@ -13,11 +14,12 @@ mod test;
 #[derive(Clone)]
 pub struct ReportService {
     channel: SiftChannel,
+    policy: RetryPolicy,
 }
 
 impl ReportService {
-    pub fn new(channel: SiftChannel) -> Self {
-        Self { channel }
+    pub fn new(channel: SiftChannel, policy: RetryPolicy) -> Self {
+        Self { channel, policy }
     }
 
     pub async fn list_reports(
@@ -29,26 +31,46 @@ impl ReportService {
     ) -> Result<Vec<Report>> {
         let (page_size, record_limit) = common::paging(limit);
 
-        let mut client = ReportServiceClient::new(self.channel.clone());
         let mut page_token = String::new();
         let mut results = Vec::new();
 
+        let order_by = order_by.unwrap_or_default();
+        let organization_id = organization_id.unwrap_or_default();
+
         loop {
-            let resp = client
-                .list_reports(ListReportsRequest {
-                    filter: filter.clone(),
-                    page_size,
-                    page_token,
-                    order_by: order_by.clone().unwrap_or_default(),
-                    organization_id: organization_id.clone().unwrap_or_default(),
-                })
-                .await
-                .context("failed to query reports")?;
+            let channel = self.channel.clone();
+            let filter = filter.clone();
+            let order_by = order_by.clone();
+            let organization_id = organization_id.clone();
+            let token = page_token.clone();
+
+            let resp = with_retry(&self.policy, move || {
+                let channel = channel.clone();
+                let filter = filter.clone();
+                let order_by = order_by.clone();
+                let organization_id = organization_id.clone();
+                let token = token.clone();
+                async move {
+                    let mut client = ReportServiceClient::new(channel);
+                    client
+                        .list_reports(ListReportsRequest {
+                            filter,
+                            page_size,
+                            page_token: token,
+                            order_by,
+                            organization_id,
+                        })
+                        .await
+                        .map(|resp| resp.into_inner())
+                }
+            })
+            .await
+            .context("failed to query reports")?;
 
             let ListReportsResponse {
                 reports,
                 next_page_token,
-            } = resp.into_inner();
+            } = resp;
             if reports.is_empty() {
                 break;
             }

--- a/rust/crates/sift_mcp/src/service/reports/test.rs
+++ b/rust/crates/sift_mcp/src/service/reports/test.rs
@@ -20,7 +20,10 @@ async fn service_with_mock(mock: MockReportServiceImpl) -> (ReportService, JoinH
             .unwrap();
     });
 
-    (ReportService::new(channel), handle)
+    (
+        ReportService::new(channel, crate::policy::RetryPolicy::default()),
+        handle,
+    )
 }
 
 #[tokio::test]

--- a/rust/crates/sift_mcp/src/service/rules/mod.rs
+++ b/rust/crates/sift_mcp/src/service/rules/mod.rs
@@ -1,3 +1,4 @@
+use crate::policy::{RetryPolicy, with_retry};
 use crate::service::common;
 use anyhow::{Context, Result};
 use sift_rs::{
@@ -13,11 +14,12 @@ mod test;
 #[derive(Clone)]
 pub struct RuleService {
     channel: SiftChannel,
+    policy: RetryPolicy,
 }
 
 impl RuleService {
-    pub fn new(channel: SiftChannel) -> Self {
-        Self { channel }
+    pub fn new(channel: SiftChannel, policy: RetryPolicy) -> Self {
+        Self { channel, policy }
     }
 
     pub async fn list_rules(
@@ -28,25 +30,42 @@ impl RuleService {
     ) -> Result<Vec<Rule>> {
         let (page_size, record_limit) = common::paging(limit);
 
-        let mut client = RuleServiceClient::new(self.channel.clone());
         let mut page_token = String::new();
         let mut results = Vec::new();
 
+        let order_by = order_by.unwrap_or_default();
+
         loop {
-            let resp = client
-                .list_rules(ListRulesRequest {
-                    filter: filter.clone(),
-                    page_size,
-                    page_token,
-                    order_by: order_by.clone().unwrap_or_default(),
-                })
-                .await
-                .context("failed to query rules")?;
+            let channel = self.channel.clone();
+            let filter = filter.clone();
+            let order_by = order_by.clone();
+            let token = page_token.clone();
+
+            let resp = with_retry(&self.policy, move || {
+                let channel = channel.clone();
+                let filter = filter.clone();
+                let order_by = order_by.clone();
+                let token = token.clone();
+                async move {
+                    let mut client = RuleServiceClient::new(channel);
+                    client
+                        .list_rules(ListRulesRequest {
+                            filter,
+                            page_size,
+                            page_token: token,
+                            order_by,
+                        })
+                        .await
+                        .map(|resp| resp.into_inner())
+                }
+            })
+            .await
+            .context("failed to query rules")?;
 
             let ListRulesResponse {
                 rules,
                 next_page_token,
-            } = resp.into_inner();
+            } = resp;
             if rules.is_empty() {
                 break;
             }

--- a/rust/crates/sift_mcp/src/service/rules/test.rs
+++ b/rust/crates/sift_mcp/src/service/rules/test.rs
@@ -18,7 +18,10 @@ async fn service_with_mock(mock: MockRuleServiceImpl) -> (RuleService, JoinHandl
             .unwrap();
     });
 
-    (RuleService::new(channel), handle)
+    (
+        RuleService::new(channel, crate::policy::RetryPolicy::default()),
+        handle,
+    )
 }
 
 #[tokio::test]

--- a/rust/crates/sift_mcp/src/service/runs/mod.rs
+++ b/rust/crates/sift_mcp/src/service/runs/mod.rs
@@ -1,3 +1,4 @@
+use crate::policy::{RetryPolicy, with_retry};
 use crate::service::common;
 use anyhow::{Context, Result};
 use sift_rs::{
@@ -11,11 +12,12 @@ mod test;
 #[derive(Clone)]
 pub struct RunService {
     channel: SiftChannel,
+    policy: RetryPolicy,
 }
 
 impl RunService {
-    pub fn new(channel: SiftChannel) -> Self {
-        Self { channel }
+    pub fn new(channel: SiftChannel, policy: RetryPolicy) -> Self {
+        Self { channel, policy }
     }
 
     pub async fn list_runs(
@@ -26,25 +28,42 @@ impl RunService {
     ) -> Result<Vec<Run>> {
         let (page_size, record_limit) = common::paging(limit);
 
-        let mut client = RunServiceClient::new(self.channel.clone());
         let mut page_token = String::new();
         let mut results = Vec::new();
 
+        let order_by = order_by.unwrap_or_default();
+
         loop {
-            let resp = client
-                .list_runs(ListRunsRequest {
-                    filter: filter.clone(),
-                    page_size,
-                    page_token,
-                    order_by: order_by.clone().unwrap_or_default(),
-                })
-                .await
-                .context("failed to query runs")?;
+            let channel = self.channel.clone();
+            let filter = filter.clone();
+            let order_by = order_by.clone();
+            let token = page_token.clone();
+
+            let resp = with_retry(&self.policy, move || {
+                let channel = channel.clone();
+                let filter = filter.clone();
+                let order_by = order_by.clone();
+                let token = token.clone();
+                async move {
+                    let mut client = RunServiceClient::new(channel);
+                    client
+                        .list_runs(ListRunsRequest {
+                            filter,
+                            page_size,
+                            page_token: token,
+                            order_by,
+                        })
+                        .await
+                        .map(|resp| resp.into_inner())
+                }
+            })
+            .await
+            .context("failed to query runs")?;
 
             let ListRunsResponse {
                 runs,
                 next_page_token,
-            } = resp.into_inner();
+            } = resp;
             if runs.is_empty() {
                 break;
             }

--- a/rust/crates/sift_mcp/src/service/runs/test.rs
+++ b/rust/crates/sift_mcp/src/service/runs/test.rs
@@ -18,7 +18,10 @@ async fn service_with_mock(mock: MockRunServiceImpl) -> (RunService, JoinHandle<
             .unwrap();
     });
 
-    (RunService::new(channel), handle)
+    (
+        RunService::new(channel, crate::policy::RetryPolicy::default()),
+        handle,
+    )
 }
 
 #[tokio::test]

--- a/rust/crates/sift_mcp/src/tool/data/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/data/mod.rs
@@ -15,12 +15,13 @@ use sift_rs::metadata::v1::{
 };
 
 use crate::{
-    error::{self, from_anyhow},
+    error,
     server::SiftMcpServer,
     service::{
         data::{ChannelInput, DataService, TimeRange},
         ingest::RunForm,
     },
+    tool_try,
 };
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -162,16 +163,16 @@ impl SiftMcpServer {
         }
 
         let asset_filter = format!("name == \"{}\"", cel_escape(&asset_name));
-        let asset = self
-            .asset_service
-            .list_assets(asset_filter, None, Some(1))
-            .await
-            .map_err(from_anyhow)?
-            .into_iter()
-            .next()
-            .ok_or_else(|| {
-                ErrorData::resource_not_found(format!("asset '{asset_name}' not found"), None)
-            })?;
+        let asset = tool_try!(
+            self.asset_service
+                .list_assets(asset_filter, None, Some(1))
+                .await
+        )
+        .into_iter()
+        .next()
+        .ok_or_else(|| {
+            ErrorData::resource_not_found(format!("asset '{asset_name}' not found"), None)
+        })?;
 
         let run = match run_name.as_deref() {
             Some(name) => {
@@ -180,19 +181,19 @@ impl SiftMcpServer {
                     cel_escape(name),
                     asset.asset_id,
                 );
-                let run = self
-                    .run_service
-                    .list_runs(filter, None, Some(1))
-                    .await
-                    .map_err(from_anyhow)?
-                    .into_iter()
-                    .next()
-                    .ok_or_else(|| {
-                        ErrorData::resource_not_found(
-                            format!("run '{name}' not found for asset '{asset_name}'"),
-                            None,
-                        )
-                    })?;
+                let run = tool_try!(
+                    self.run_service
+                        .list_runs(filter, None, Some(1))
+                        .await
+                )
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    ErrorData::resource_not_found(
+                        format!("run '{name}' not found for asset '{asset_name}'"),
+                        None,
+                    )
+                })?;
                 Some(run)
             }
             None => None,
@@ -234,11 +235,11 @@ impl SiftMcpServer {
             asset.asset_id
         );
 
-        let channels = self
-            .channel_service
-            .list_channels(channel_filter, None, None)
-            .await
-            .map_err(from_anyhow)?;
+        let channels = tool_try!(
+            self.channel_service
+                .list_channels(channel_filter, None, None)
+                .await
+        );
 
         if channels.is_empty() {
             return Err(ErrorData::resource_not_found(
@@ -264,19 +265,21 @@ impl SiftMcpServer {
             },
         };
 
-        let mut file = File::options()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(&output)
-            .context("failed to open output parquet file")
-            .map_err(from_anyhow)?;
+        let mut file = tool_try!(
+            File::options()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(&output)
+                .context("failed to open output parquet file")
+        );
 
-        self.data_service
-            .get_data(&channel_inputs, time_range, sample_ms, &mut file)
-            .await
-            .context("get data call failure - data_router")
-            .map_err(from_anyhow)?;
+        tool_try!(
+            self.data_service
+                .get_data(&channel_inputs, time_range, sample_ms, &mut file)
+                .await
+                .context("get data call failure - data_router")
+        );
 
         let output_str = output.to_string_lossy().into_owned();
         let next_step = format!(
@@ -349,7 +352,7 @@ impl SiftMcpServer {
         }
 
         let output_for_task = output.clone();
-        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+        let sql_result = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
             let mut file = File::options()
                 .create(true)
                 .write(true)
@@ -359,8 +362,8 @@ impl SiftMcpServer {
             DataService::sql(inputs, &mut file, &table_name, &query)
         })
         .await
-        .map_err(|e| ErrorData::internal_error(format!("sql task panicked: {e}"), None))?
-        .map_err(from_anyhow)?;
+        .map_err(|e| ErrorData::internal_error(format!("sql task panicked: {e}"), None))?;
+        tool_try!(sql_result);
 
         let output_str = output.to_string_lossy().into_owned();
         let next_step = format!(
@@ -450,16 +453,14 @@ impl SiftMcpServer {
             metadata: metadata.into_iter().map(MetadataValue::from).collect(),
         });
 
-        let file = File::open(&input)
-            .context("failed to open input parquet file")
-            .map_err(from_anyhow)?;
+        let file = tool_try!(File::open(&input).context("failed to open input parquet file"));
 
-        let uploaded = self
-            .ingest_service
-            .upload_dataset(asset, run, file)
-            .await
-            .context("upload dataset failure - data_router")
-            .map_err(from_anyhow)?;
+        let uploaded = tool_try!(
+            self.ingest_service
+                .upload_dataset(asset, run, file)
+                .await
+                .context("upload dataset failure - data_router")
+        );
 
         let input_str = input.to_string_lossy().into_owned();
         let run_summary = match (&uploaded.run_name, &uploaded.run_id) {

--- a/rust/crates/sift_mcp/src/tool/data/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/data/mod.rs
@@ -15,13 +15,12 @@ use sift_rs::metadata::v1::{
 };
 
 use crate::{
-    error,
+    error::{self, from_anyhow},
     server::SiftMcpServer,
     service::{
         data::{ChannelInput, DataService, TimeRange},
         ingest::RunForm,
     },
-    tool_try,
 };
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -163,16 +162,16 @@ impl SiftMcpServer {
         }
 
         let asset_filter = format!("name == \"{}\"", cel_escape(&asset_name));
-        let asset = tool_try!(
-            self.asset_service
-                .list_assets(asset_filter, None, Some(1))
-                .await
-        )
-        .into_iter()
-        .next()
-        .ok_or_else(|| {
-            ErrorData::resource_not_found(format!("asset '{asset_name}' not found"), None)
-        })?;
+        let asset = self
+            .asset_service
+            .list_assets(asset_filter, None, Some(1))
+            .await
+            .map_err(from_anyhow)?
+            .into_iter()
+            .next()
+            .ok_or_else(|| {
+                ErrorData::resource_not_found(format!("asset '{asset_name}' not found"), None)
+            })?;
 
         let run = match run_name.as_deref() {
             Some(name) => {
@@ -181,19 +180,19 @@ impl SiftMcpServer {
                     cel_escape(name),
                     asset.asset_id,
                 );
-                let run = tool_try!(
-                    self.run_service
-                        .list_runs(filter, None, Some(1))
-                        .await
-                )
-                .into_iter()
-                .next()
-                .ok_or_else(|| {
-                    ErrorData::resource_not_found(
-                        format!("run '{name}' not found for asset '{asset_name}'"),
-                        None,
-                    )
-                })?;
+                let run = self
+                    .run_service
+                    .list_runs(filter, None, Some(1))
+                    .await
+                    .map_err(from_anyhow)?
+                    .into_iter()
+                    .next()
+                    .ok_or_else(|| {
+                        ErrorData::resource_not_found(
+                            format!("run '{name}' not found for asset '{asset_name}'"),
+                            None,
+                        )
+                    })?;
                 Some(run)
             }
             None => None,
@@ -235,11 +234,11 @@ impl SiftMcpServer {
             asset.asset_id
         );
 
-        let channels = tool_try!(
-            self.channel_service
-                .list_channels(channel_filter, None, None)
-                .await
-        );
+        let channels = self
+            .channel_service
+            .list_channels(channel_filter, None, None)
+            .await
+            .map_err(from_anyhow)?;
 
         if channels.is_empty() {
             return Err(ErrorData::resource_not_found(
@@ -265,21 +264,19 @@ impl SiftMcpServer {
             },
         };
 
-        let mut file = tool_try!(
-            File::options()
-                .create(true)
-                .write(true)
-                .truncate(true)
-                .open(&output)
-                .context("failed to open output parquet file")
-        );
+        let mut file = File::options()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&output)
+            .context("failed to open output parquet file")
+            .map_err(from_anyhow)?;
 
-        tool_try!(
-            self.data_service
-                .get_data(&channel_inputs, time_range, sample_ms, &mut file)
-                .await
-                .context("get data call failure - data_router")
-        );
+        self.data_service
+            .get_data(&channel_inputs, time_range, sample_ms, &mut file)
+            .await
+            .context("get data call failure - data_router")
+            .map_err(from_anyhow)?;
 
         let output_str = output.to_string_lossy().into_owned();
         let next_step = format!(
@@ -352,7 +349,7 @@ impl SiftMcpServer {
         }
 
         let output_for_task = output.clone();
-        let sql_result = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
             let mut file = File::options()
                 .create(true)
                 .write(true)
@@ -362,8 +359,8 @@ impl SiftMcpServer {
             DataService::sql(inputs, &mut file, &table_name, &query)
         })
         .await
-        .map_err(|e| ErrorData::internal_error(format!("sql task panicked: {e}"), None))?;
-        tool_try!(sql_result);
+        .map_err(|e| ErrorData::internal_error(format!("sql task panicked: {e}"), None))?
+        .map_err(from_anyhow)?;
 
         let output_str = output.to_string_lossy().into_owned();
         let next_step = format!(
@@ -453,14 +450,16 @@ impl SiftMcpServer {
             metadata: metadata.into_iter().map(MetadataValue::from).collect(),
         });
 
-        let file = tool_try!(File::open(&input).context("failed to open input parquet file"));
+        let file = File::open(&input)
+            .context("failed to open input parquet file")
+            .map_err(from_anyhow)?;
 
-        let uploaded = tool_try!(
-            self.ingest_service
-                .upload_dataset(asset, run, file)
-                .await
-                .context("upload dataset failure - data_router")
-        );
+        let uploaded = self
+            .ingest_service
+            .upload_dataset(asset, run, file)
+            .await
+            .context("upload dataset failure - data_router")
+            .map_err(from_anyhow)?;
 
         let input_str = input.to_string_lossy().into_owned();
         let run_summary = match (&uploaded.run_name, &uploaded.run_id) {

--- a/rust/crates/sift_mcp/src/tool/list/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/list/mod.rs
@@ -1,12 +1,13 @@
 use rmcp::{
     handler::server::wrapper::Parameters,
+    model::CallToolResult,
     schemars::{self, JsonSchema},
     tool, tool_router,
 };
 use serde::Deserialize;
 
 use crate::{
-    error::{self, into_tool_result},
+    error::{self, from_anyhow},
     server::SiftMcpServer,
 };
 
@@ -67,13 +68,14 @@ impl SiftMcpServer {
             order_by,
         }) = params;
 
-        let result = self
+        let out = self
             .asset_service
             .list_assets(filter, order_by, limit)
             .await
-            .map(|assets| serde_json::json!({ "assets": assets }));
+            .map(|assets| serde_json::json!({ "assets": assets }))
+            .map_err(from_anyhow)?;
 
-        into_tool_result(result)
+        Ok(CallToolResult::structured(out))
     }
 
     #[tool(
@@ -121,13 +123,14 @@ impl SiftMcpServer {
             limit,
         }) = params;
 
-        let result = self
+        let out = self
             .run_service
             .list_runs(filter, order_by, limit)
             .await
-            .map(|runs| serde_json::json!({ "runs": runs }));
+            .map(|runs| serde_json::json!({ "runs": runs }))
+            .map_err(from_anyhow)?;
 
-        into_tool_result(result)
+        Ok(CallToolResult::structured(out))
     }
 
     #[tool(
@@ -168,13 +171,14 @@ impl SiftMcpServer {
             limit,
         }) = params;
 
-        let result = self
+        let out = self
             .channel_service
             .list_channels(filter, order_by, limit)
             .await
-            .map(|channels| serde_json::json!({ "channels": channels }));
+            .map(|channels| serde_json::json!({ "channels": channels }))
+            .map_err(from_anyhow)?;
 
-        into_tool_result(result)
+        Ok(CallToolResult::structured(out))
     }
 
     #[tool(
@@ -219,13 +223,14 @@ impl SiftMcpServer {
             organization_id,
         }) = params;
 
-        let result = self
+        let out = self
             .report_service
             .list_reports(filter, order_by, limit, organization_id)
             .await
-            .map(|reports| serde_json::json!({ "reports": reports }));
+            .map(|reports| serde_json::json!({ "reports": reports }))
+            .map_err(from_anyhow)?;
 
-        into_tool_result(result)
+        Ok(CallToolResult::structured(out))
     }
 
     #[tool(
@@ -271,12 +276,13 @@ impl SiftMcpServer {
             limit,
         }) = params;
 
-        let result = self
+        let out = self
             .rule_service
             .list_rules(filter, order_by, limit)
             .await
-            .map(|rules| serde_json::json!({ "rules": rules }));
+            .map(|rules| serde_json::json!({ "rules": rules }))
+            .map_err(from_anyhow)?;
 
-        into_tool_result(result)
+        Ok(CallToolResult::structured(out))
     }
 }

--- a/rust/crates/sift_mcp/src/tool/list/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/list/mod.rs
@@ -1,13 +1,12 @@
 use rmcp::{
     handler::server::wrapper::Parameters,
-    model::CallToolResult,
     schemars::{self, JsonSchema},
     tool, tool_router,
 };
 use serde::Deserialize;
 
 use crate::{
-    error::{self, from_anyhow},
+    error::{self, into_tool_result},
     server::SiftMcpServer,
 };
 
@@ -68,14 +67,13 @@ impl SiftMcpServer {
             order_by,
         }) = params;
 
-        let out = self
+        let result = self
             .asset_service
             .list_assets(filter, order_by, limit)
             .await
-            .map(|assets| serde_json::json!({ "assets": assets }))
-            .map_err(from_anyhow)?;
+            .map(|assets| serde_json::json!({ "assets": assets }));
 
-        Ok(CallToolResult::structured(out))
+        into_tool_result(result)
     }
 
     #[tool(
@@ -123,14 +121,13 @@ impl SiftMcpServer {
             limit,
         }) = params;
 
-        let out = self
+        let result = self
             .run_service
             .list_runs(filter, order_by, limit)
             .await
-            .map(|runs| serde_json::json!({ "runs": runs }))
-            .map_err(from_anyhow)?;
+            .map(|runs| serde_json::json!({ "runs": runs }));
 
-        Ok(CallToolResult::structured(out))
+        into_tool_result(result)
     }
 
     #[tool(
@@ -171,14 +168,13 @@ impl SiftMcpServer {
             limit,
         }) = params;
 
-        let out = self
+        let result = self
             .channel_service
             .list_channels(filter, order_by, limit)
             .await
-            .map(|channels| serde_json::json!({ "channels": channels }))
-            .map_err(from_anyhow)?;
+            .map(|channels| serde_json::json!({ "channels": channels }));
 
-        Ok(CallToolResult::structured(out))
+        into_tool_result(result)
     }
 
     #[tool(
@@ -223,14 +219,13 @@ impl SiftMcpServer {
             organization_id,
         }) = params;
 
-        let out = self
+        let result = self
             .report_service
             .list_reports(filter, order_by, limit, organization_id)
             .await
-            .map(|reports| serde_json::json!({ "reports": reports }))
-            .map_err(from_anyhow)?;
+            .map(|reports| serde_json::json!({ "reports": reports }));
 
-        Ok(CallToolResult::structured(out))
+        into_tool_result(result)
     }
 
     #[tool(
@@ -276,13 +271,12 @@ impl SiftMcpServer {
             limit,
         }) = params;
 
-        let out = self
+        let result = self
             .rule_service
             .list_rules(filter, order_by, limit)
             .await
-            .map(|rules| serde_json::json!({ "rules": rules }))
-            .map_err(from_anyhow)?;
+            .map(|rules| serde_json::json!({ "rules": rules }));
 
-        Ok(CallToolResult::structured(out))
+        into_tool_result(result)
     }
 }

--- a/rust/crates/sift_mcp/src/tool/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/mod.rs
@@ -1,3 +1,4 @@
 pub mod data;
 pub mod explore;
 pub mod list;
+pub mod ping;

--- a/rust/crates/sift_mcp/src/tool/ping/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/ping/mod.rs
@@ -1,0 +1,52 @@
+use rmcp::{
+    handler::server::wrapper::Parameters,
+    model::CallToolResult,
+    schemars::{self, JsonSchema},
+    tool, tool_router,
+};
+use serde::Deserialize;
+
+use crate::{
+    error::{self, from_anyhow},
+    server::SiftMcpServer,
+};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PingParams {}
+
+#[tool_router(router = ping_router, vis = "pub(crate)")]
+impl SiftMcpServer {
+    #[tool(
+        name = "ping",
+        description = "
+            Send a Ping request to the Sift backend and return the server-supplied response string.
+
+            Output:
+              - `{ \"response\": \"<string>\" }`. Server-defined message.
+
+            Parameters:
+              - None.
+
+            Errors:
+              - Surfaces upstream gRPC failures via the standard retry / soft-signal flow:
+                `UNAVAILABLE` retries up to the policy limit before reporting `backend_unreachable`;
+                `RESOURCE_EXHAUSTED`, `DEADLINE_EXCEEDED`, `INTERNAL`, and other soft-signal codes
+                return immediately with their structured guidance.
+
+            Guidance:
+              - Useful as a connectivity smoke check. If `ping` fails, the broader Sift toolset is
+                likely also failing — surface that to the user instead of attempting other tools.
+        ",
+        annotations(title = "ping_router/ping", read_only_hint = true)
+    )]
+    pub async fn ping(&self, _params: Parameters<PingParams>) -> error::McpResult {
+        let out = self
+            .ping_service
+            .ping()
+            .await
+            .map(|response| serde_json::json!({ "response": response }))
+            .map_err(from_anyhow)?;
+
+        Ok(CallToolResult::structured(out))
+    }
+}


### PR DESCRIPTION
# Description
Implements gRPC status handling for backoff and retries in the mcp. 

We construct each Service with a `Retry Policy` that outlines how to handle gRPC status codes. In here we implement a retry loop that takes in a closure. With this new structure we wrap our gRPC calls within the retry loop so we can handle the gRPC status codes when they come in.

When the retry layer gives up, we give the agent a soft-signal to not retry this tool without the user providing more context or the general shape of the request is different. We do handle the different tonic statuses differently.

Following the status codes laid out here: https://google.aip.dev/194 

`UNAVAILABLE` = Retry with backoff, then soft signal on exhaustion
`RESOURCE_EXHAUSTED, DEADLINE_EXCEEDED, INTERNAL, ABORTED, ALREADY_EXISTS, PERMISSION_DENIED, UNAUTHENTICATED, CANCELLED` = Immediate error return with soft signal

Errors without set soft-guidance are given a hard rmcp error code back:

`INVALID_ARGUMENT and OUT_OF_RANGE` = `INVALID_PARAMS`
`NOT_FOUND` = `RESOURCE_NOT_FOUND`
`UNIMPLEMENTED` = `METHOD_NOT_FOUND`
`FAILED_PRECONDITION, DATA_LOSS, UNKNOWN` = `INTERNAL_ERROR`

What this does not limit:
- Number of tools being used at once
- Total request count over a session

# Verification
- Mock tests
- Unit tests
- Pointed the mcp to an unreachable address and did manual testing to get errors back