### PR TITLE
Python(feat): clean up the abort propagation and output location settings

### DIFF
--- a/python/docs/guides/pytest_plugin/configuration.md
+++ b/python/docs/guides/pytest_plugin/configuration.md
@@ -67,7 +67,7 @@ Prefer real environment variables (shell exports, CI secrets) for anything you
 can't keep in a local file.
 
 !!! warning "FedRAMP / shared environments"
-    Pass `--sift-log-file=false` (or set the ini key to `"false"`) to skip the
+    Pass `--no-sift-log-file` (or set `sift_log_file = false`) to skip the
     temp file + worker pipeline. Create/update calls then run inline against the
     API instead of being deferred through a subprocess.
 
@@ -146,8 +146,9 @@ suggestion, so typos like `SIFT_REPORT_SERIALNUM` surface immediately.
 
 | Setting | CLI flag | Ini (`[tool.pytest.ini_options]`) |
 |---|---|---|
-| Path to the JSONL log of create/update calls (path \| true \| false \| none). | `--sift-log-file` | `sift_log_file` |
-| DEBUG-level audit trace of plugin behavior (path \| true \| false). On by default to a temp file, with warnings echoed to stdout; set a path to pin the file, or false to disable. | `--sift-audit-log` | `sift_audit_log` |
+| Directory for this run's artifacts (JSONL log, audit trace). Each run gets its own random subfolder. Defaults to a temp directory. | `--sift-output-dir` | `sift_output_dir` |
+| Write the JSONL log of create/update calls. On by default; --no-sift-log-file disables it (incompatible with --sift-offline). | `--no-sift-log-file` | `sift_log_file` |
+| Write the DEBUG audit trace of plugin behavior, with warnings echoed to stdout. On by default; --no-sift-audit-log disables it. | `--no-sift-audit-log` | `sift_audit_log` |
 | Capture git repo/branch/commit on the report. | `--no-sift-git-metadata` | `sift_git_metadata` |
 | Skip the session-start ping; route create/update through the JSONL log. | `--sift-offline` | `sift_offline` |
 | Disable Sift entirely (no API calls, no log file). Supersedes --sift-offline. | `--sift-disabled` | `sift_disabled` |

--- a/python/docs/guides/pytest_plugin/index.md
+++ b/python/docs/guides/pytest_plugin/index.md
@@ -66,6 +66,14 @@ A `TestReport` shows up in Sift once the session finishes.
     it does not short-circuit on the first failure and skip every measurement
     after it.
 
+!!! tip "Stopping the whole run early"
+    `pytest.fail()` fails a single test. To stop the session,
+    `pytest.exit("...")` ends it and rolls the report up as `FAILED`, while
+    `sift_client.pytest_plugin.abort("...")` ends it and rolls the report up as
+    `ABORTED`, for a system-level stop where the run was cut off rather than a
+    test failing (a real Ctrl-C does the same). See
+    [Pass/Fail Behavior](pass_fail_behavior.md#stopping-a-run-as-aborted).
+
 ## Sensible defaults
 
 With nothing but the `conftest.py` above, you get:

--- a/python/docs/guides/pytest_plugin/pass_fail_behavior.md
+++ b/python/docs/guides/pytest_plugin/pass_fail_behavior.md
@@ -34,32 +34,36 @@ mapping to `FAILED`. A non-assertion exception gets its formatted traceback
 
 ## Hard exits
 
-Hard exits map to `ABORTED`. The step is resolved during fixture teardown, not
-at the instant of the exit:
+A hard exit resolves the cut-off step to `ABORTED`, recorded while pytest runs
+fixture finalizers on the way out. What the containers (class, module, package)
+and the report resolve to depends on why the run stopped:
 
-- When the exit produces a call-phase report (`sys.exit(1)`, `SystemExit`), the
-  plugin reads the status off that report.
-- When a `KeyboardInterrupt` aborts the session before any call-phase report
-  (Ctrl-C, or `raise KeyboardInterrupt` in the body), pytest still runs fixture
-  finalizers as it unwinds. The plugin sees setup completed with no call outcome
-  and resolves the cut-off step to `ABORTED` there.
+- A **failure stop** rolls up `FAILED`. `pytest.exit()`, `sys.exit()` /
+  `SystemExit`, an `assert`, or an exception means the test ended the run on a
+  fault, so the exited step is `ABORTED` (or `FAILED`/`ERROR` for an
+  assert/exception) while its containers and the report read `FAILED`.
+- A **system stop** rolls up `ABORTED`. Ctrl-C / `KeyboardInterrupt`, or the
+  `abort()` helper below, means the run was cut off rather than a test failing,
+  so the exited step, its containers, and the report all read `ABORTED`.
 
-The status only reaches the report if those finalizers run. If the process is
-killed before they do (`SIGKILL`, the OOM killer, power loss), nothing is written
-and the step keeps the `IN_PROGRESS` it was created with. That is the only path
-that leaves a step `IN_PROGRESS` in a finalized report.
+`SystemExit` is read from the call-phase report; the session-stopping exits abort
+before that report fires, so the step resolves during teardown instead. If the
+process dies before finalizers run (`SIGKILL`, OOM, power loss) nothing more is
+written and the step stays `IN_PROGRESS`, the only path that leaves a step
+`IN_PROGRESS` in a finished report.
 
-| Scenario                                       | Trigger                            | Outcome                                          |
-| ---------------------------------------------- | ---------------------------------- | ------------------------------------------------ |
-| `SystemExit` from the test body                | `sys.exit(1)`                      | `ABORTED` (read from the call-phase report)      |
-| `KeyboardInterrupt` from the test body         | `raise KeyboardInterrupt`          | `ABORTED` (resolved during teardown)             |
-| Session-aborting `KeyboardInterrupt`           | Ctrl-C terminates pytest           | `ABORTED` (resolved during teardown)             |
-| Process killed before finalizers run           | `SIGKILL` / OOM / power loss       | `IN_PROGRESS` (nothing written after creation)   |
+| Trigger                          | Exited step        | Containers + report |
+| -------------------------------- | ------------------ | ------------------- |
+| `assert` / exception             | `FAILED` / `ERROR` | `FAILED`            |
+| `sys.exit()` / `SystemExit`      | `ABORTED`          | `FAILED`            |
+| `pytest.exit("...")`             | `ABORTED`          | `FAILED`            |
+| `abort("...")` (Sift)            | `ABORTED`          | `ABORTED`           |
+| Ctrl-C / `KeyboardInterrupt`     | `ABORTED`          | `ABORTED`           |
+| process killed (`SIGKILL`/OOM)   | `IN_PROGRESS`      | `IN_PROGRESS`       |
 
-### Abort propagation through nested substeps
-
-Every step that was open when the abort fired records
-`ABORTED`.
+Within a stop, `ABORTED` is recorded on each step the exit unwinds through: the
+open substeps and the test step. A substep that closed before the exit keeps its
+own status.
 
 ```python title="test_abort.py"
 import sys
@@ -67,15 +71,35 @@ import sys
 
 def test_x(step):
     with step.substep(name="completed_sub"):
-        pass  # closes as PASSED before the abort
+        pass  # closed PASSED before the abort
     with step.substep(name="outer_sub") as outer_sub:
         with outer_sub.substep(name="inner_sub"):
-            sys.exit(1)  # ABORTED applied to inner_sub, outer_sub, and the test step
+            sys.exit(1)
 ```
 
-The Sift report shows `completed_sub` as `PASSED` and the three steps
-still open at the abort (`inner_sub`, `outer_sub`, and the test step
-itself) as `ABORTED`.
+`completed_sub` stays `PASSED`; `inner_sub`, `outer_sub`, and the test step are
+`ABORTED`. The enclosing module reads `FAILED`, since `sys.exit()` is a failure
+stop.
+
+### Stopping a run as aborted
+
+`sift_client.pytest_plugin.abort(reason)` stops the session and records the
+report and the open parent steps as `ABORTED` rather than `FAILED`. Use it for a
+system-level stop where the run was cut off rather than a test failing, such as
+the device under test losing power. A real Ctrl-C does the same automatically.
+
+```python
+from sift_client.pytest_plugin import abort
+
+
+def test_flash(step):
+    if not device_responding():
+        abort("device under test is not responding")
+    ...
+```
+
+For a stop that should read as a failure, use `pytest.exit()`; for a single
+failing test, use `pytest.fail()`.
 
 ## Skips
 
@@ -180,14 +204,20 @@ Every non-`PASSED`/`SKIPPED` step marks its parent as failed. What the
 parent records depends on whether its own scope had an abort and whether
 a child already failed:
 
-- A hard exit (`SystemExit` or an observed `KeyboardInterrupt`) in the
-  step's own scope records `ABORTED`. `ABORTED` propagates through every
-  step the abort passes through on its way up.
-- A child that already recorded a non-`PASSED`/`SKIPPED` outcome marks
-  the parent as `FAILED`. This holds whether or not an exception is still
-  propagating through the parent's scope: only the originating substep
-  records `ERROR`; ancestors inherit `FAILED`. The traceback stays on
-  the originating step's `error_info`.
+- A hard exit (`SystemExit` or an observed `KeyboardInterrupt`) records
+  `ABORTED` on the step in whose scope it fired, and `ABORTED` propagates
+  through every step the exception unwinds through on its way up: the
+  open substeps and the test step. Container parents (class, module,
+  package) are closed out-of-band rather than by the unwinding exception,
+  so they are not on that path. On a failure stop (`pytest.exit()`,
+  `sys.exit`) they inherit `FAILED` like any other non-pass child; on a
+  system stop (Ctrl-C / `KeyboardInterrupt`, or `abort()`) the run is flagged
+  aborted and they resolve `ABORTED` instead. See [Hard exits](#hard-exits).
+- A child that recorded a non-`PASSED`/`SKIPPED` outcome marks the parent
+  as `FAILED`. This holds whether or not an exception is still propagating
+  through the parent's scope: only the originating step records `ERROR` (or
+  `ABORTED`); ancestors that inherit the result take `FAILED`. The
+  traceback stays on the originating step's `error_info`.
 - A step records `ERROR` only when its own scope raised a non-Assertion
   exception AND no child has failed.
 

--- a/python/lib/sift_client/_internal/pytest_plugin/audit_log.py
+++ b/python/lib/sift_client/_internal/pytest_plugin/audit_log.py
@@ -2,9 +2,9 @@
 
 On by default: every session attaches two handlers to the ``sift_client`` root
 logger so plugin-behavior modules AND high-value SDK call sites land in one file
-(a temp file unless ``--sift-audit-log=<path>`` pins one), with warnings also
-echoed to stdout. Pass ``--sift-audit-log=false`` (or set ``sift_audit_log =
-"false"``) to turn it off. The replay subprocess gets its own sibling file via
+(in the run's ``--sift-output-dir``, or a temp dir), with warnings also echoed
+to stdout. Pass ``--no-sift-audit-log`` (or set ``sift_audit_log = false``) to
+turn it off. The replay subprocess gets its own sibling file via
 ``replay_audit_path``.
 
 Handlers are removed at session end (``pytest_unconfigure`` ->
@@ -110,41 +110,17 @@ def replay_audit_path(main_path: Path) -> Path:
     return main_path.with_suffix(".replay" + main_path.suffix)
 
 
-def audit_disabled(value: object) -> bool:
-    """Whether audit logging is explicitly turned off.
+def _make_session_dir(base: Path | None = None) -> Path:
+    """Create and return ``<base>/<random>/`` for this run's artifacts.
 
-    Default on: only ``False`` / ``"false"`` / ``"none"`` disables. Anything
-    else — unset, ``"true"``, or a path — leaves it enabled.
+    ``base`` is the ``--sift-output-dir`` directory when set, else
+    ``<tmpdir>/sift_test_results``. Each run gets its own random subfolder (from
+    ``tempfile.mkdtemp``) so repeated or concurrent runs never collide, and all
+    of a run's artifacts (JSONL log, tracking sidecar, audit log, replay audit
+    log) land inside it together.
     """
-    if value is False:
-        return True
-    return isinstance(value, str) and value.strip().lower() in ("false", "none")
-
-
-def explicit_audit_path(value: object) -> Path | None:
-    """The file path the user pinned, or ``None`` to use a temp default.
-
-    ``"true"`` / ``"1"`` / unset all mean "enabled, no specific path", so the
-    caller falls back to :func:`default_audit_path`.
-    """
-    if not isinstance(value, str):
-        return None
-    text = value.strip()
-    if text.lower() in ("", "true", "1", "false", "none"):
-        return None
-    return Path(text)
-
-
-def _make_session_dir() -> Path:
-    """Create and return ``<tmpdir>/sift_test_results/<random>/``.
-
-    All per-session temp artifacts (JSONL log, tracking sidecar, audit log,
-    replay audit log) land inside this directory so they're easy to locate and
-    clean up together. The random component comes from ``tempfile.mkdtemp`` —
-    the same OS-backed source used by ``NamedTemporaryFile``.
-    """
-    parent = Path(tempfile.gettempdir()) / "sift_test_results"
-    parent.mkdir(exist_ok=True)
+    parent = base if base is not None else Path(tempfile.gettempdir()) / "sift_test_results"
+    parent.mkdir(parents=True, exist_ok=True)
     return Path(tempfile.mkdtemp(dir=parent, prefix=""))
 
 
@@ -198,10 +174,9 @@ def configure_audit_logging(
     """
     from sift_client._internal.pytest_plugin.options import AUDIT_LOG_OPTION
 
-    raw = AUDIT_LOG_OPTION.resolve(config)
-    if audit_disabled(raw):
+    if not AUDIT_LOG_OPTION.resolve(config):
         return None
-    path = explicit_audit_path(raw) or default_audit_path(session_dir=session_dir)
+    path = default_audit_path(session_dir=session_dir)
     attach_file_handler(path)
     logger = logging.getLogger(ROOT_LOGGER)
     if not any(

--- a/python/lib/sift_client/_internal/pytest_plugin/options.py
+++ b/python/lib/sift_client/_internal/pytest_plugin/options.py
@@ -217,22 +217,36 @@ def _walk_toml(data: dict[str, Any], path: tuple[str, ...]) -> Any:
 #     loads .env for local dev; CI sets the same names from its secret store).
 # ---------------------------------------------------------------------------
 
-# Pytest behavior. The CLI flag survives because the per-run override is real.
+# Pytest behavior. The CLI flags survive because the per-run override is real.
+OUTPUT_DIR_OPTION = Option(
+    name="output_dir",
+    category=CAT_BEHAVIOR,
+    help="Directory for this run's artifacts (JSONL log, audit trace). Each run gets "
+    "its own random subfolder. Defaults to a temp directory.",
+    cli="--sift-output-dir",
+    ini="sift_output_dir",
+)
 LOG_FILE_OPTION = Option(
     name="log_file",
     category=CAT_BEHAVIOR,
-    help="Path to the JSONL log of create/update calls (path | true | false | none).",
-    cli="--sift-log-file",
+    help="Write the JSONL log of create/update calls. On by default; "
+    "--no-sift-log-file disables it (incompatible with --sift-offline).",
+    cli="--no-sift-log-file",
+    cli_action="store_false",
     ini="sift_log_file",
+    ini_type="bool",
+    ini_default=True,
 )
 AUDIT_LOG_OPTION = Option(
     name="audit_log",
     category=CAT_BEHAVIOR,
-    help="DEBUG-level audit trace of plugin behavior (path | true | false). On by "
-    "default to a temp file, with warnings echoed to stdout; set a path to pin the "
-    "file, or false to disable.",
-    cli="--sift-audit-log",
+    help="Write the DEBUG audit trace of plugin behavior, with warnings echoed to "
+    "stdout. On by default; --no-sift-audit-log disables it.",
+    cli="--no-sift-audit-log",
+    cli_action="store_false",
     ini="sift_audit_log",
+    ini_type="bool",
+    ini_default=True,
 )
 GIT_METADATA_OPTION = Option(
     name="git_metadata",
@@ -406,6 +420,7 @@ METADATA_OPTION = Option(
 )
 
 PLUGIN_OPTIONS: tuple[Option, ...] = (
+    OUTPUT_DIR_OPTION,
     LOG_FILE_OPTION,
     AUDIT_LOG_OPTION,
     GIT_METADATA_OPTION,

--- a/python/lib/sift_client/_internal/pytest_plugin/report.py
+++ b/python/lib/sift_client/_internal/pytest_plugin/report.py
@@ -55,7 +55,7 @@ logger = logging.getLogger(__name__)
 def resolve_real_report_id(context: Any) -> str | None:
     """Resolve the real server-side report id for the online footer link.
 
-    In synchronous online mode (``--sift-log-file=false``) the report is created
+    In synchronous online mode (``--no-sift-log-file``) the report is created
     directly against the API, so ``report.id_`` is already the real id. In the
     default incremental mode the report is created through the simulate path
     (a client-side UUID) and the background worker maps it to the real id on
@@ -377,41 +377,20 @@ def format_template(
         return fallback
 
 
-def resolve_log_file(pytestconfig: pytest.Config | None) -> str | Path | bool | None:
-    """Determine log_file value from CLI flag or ini key.
+def log_file_enabled(pytestconfig: pytest.Config | None) -> bool:
+    """Whether the JSONL log of create/update calls is written.
 
-    Three signal types arrive here:
-
-    * ``None``: unset; nothing was passed on the CLI and the ini key is
-      absent. Treat as the default "use a temp file."
-    * Python ``False``: an explicit disable, typically set in a conftest via
-      ``config.option.sift_log_file = False``. Return ``None`` so
-      the rest of the pipeline knows to skip logging entirely.
-    * A string (from CLI or ini): interpret ``"true"`` / ``"1"`` as the temp
-      file default, ``"false"`` / ``"none"`` as disable, anything else as a
-      file path.
-
-    Rejects ``--sift-log-file=none`` combined with ``--sift-offline`` since
-    offline mode needs the log file as its sole sink.
+    On by default; ``--no-sift-log-file`` disables it. Offline mode routes every
+    create/update call through the log as its only sink, so disabling the log
+    while offline is a usage error.
     """
-    raw = LOG_FILE_OPTION.resolve(pytestconfig)
-    disabled = raw is False or (isinstance(raw, str) and raw.lower() in ("false", "none"))
-    if disabled and is_offline(pytestconfig):
+    enabled = bool(LOG_FILE_OPTION.resolve(pytestconfig))
+    if not enabled and is_offline(pytestconfig):
         raise pytest.UsageError(
-            "--sift-log-file=none is incompatible with --sift-offline; offline "
-            "mode requires a log file. Pin one with --sift-log-file=<path>, or "
-            "drop --sift-log-file=none to use a temp file."
+            "--no-sift-log-file is incompatible with --sift-offline; offline mode "
+            "requires the JSONL log as its only sink. Drop one of the two flags."
         )
-    if raw is False:
-        return None
-    if not raw:
-        return True
-    lower = str(raw).lower()
-    if lower in ("true", "1"):
-        return True
-    if lower in ("false", "none"):
-        return None
-    return Path(raw)
+    return enabled
 
 
 def report_context_impl(
@@ -458,15 +437,16 @@ def report_context_impl(
         "pytest_command": command,
     }
     # Mode → ReportContext flags:
-    #   online (default): log_file=<temp or user path>, replay_log_file=True
-    #   --sift-offline:   log_file=<temp or user path>, replay_log_file=False
-    #   --sift-disabled:  log_file=False,               replay_log_file=False
+    #   online (default): log_file=<path in session dir>, replay_log_file=True
+    #   --sift-offline:   log_file=<path in session dir>, replay_log_file=False
+    #   --sift-disabled / --no-sift-log-file: log_file=False, replay_log_file=False
     disabled = sift_client._simulate
     offline = False if disabled else is_offline(pytestconfig)
-    log_file: str | Path | bool | None = False if disabled else resolve_log_file(pytestconfig)
-    # When the log would use a default temp file and the plugin already created
-    # a session dir, pin the JSONL inside that dir so it lands alongside the
-    # audit log rather than having ReportContext mint a separate session dir.
+    log_file: str | Path | bool = False if disabled else log_file_enabled(pytestconfig)
+    # Place the JSONL inside the run's session dir so it lands alongside the
+    # audit log. pytest_configure created the dir whenever the log is enabled; if
+    # one isn't present (e.g. ReportContext used outside pytest), log_file stays
+    # True and ReportContext mints its own dir.
     if log_file is True and pytestconfig is not None:
         from sift_client.pytest_plugin import SIFT_SESSION_DIR_STASH_KEY
 

--- a/python/lib/sift_client/_internal/pytest_plugin/terminal.py
+++ b/python/lib/sift_client/_internal/pytest_plugin/terminal.py
@@ -152,12 +152,14 @@ def write_report_summary(
     """
     log_file = getattr(context, "log_file", None)
 
+    aborted = bool(getattr(context, "session_aborted", False))
     failed = bool(getattr(context, "any_failures", False))
-    status_word, status_markup = (
-        ("FAILED", {"red": True, "bold": True})
-        if failed
-        else ("PASSED", {"green": True, "bold": True})
-    )
+    if aborted:
+        status_word, status_markup = "ABORTED", {"red": True, "bold": True}
+    elif failed:
+        status_word, status_markup = "FAILED", {"red": True, "bold": True}
+    else:
+        status_word, status_markup = "PASSED", {"green": True, "bold": True}
     # Offline results live only in the local log until replayed, so the status
     # row calls that out instead of repeating the version (already in the header).
     status_context = (

--- a/python/lib/sift_client/_tests/pytest_plugin/_step_status_capture.py
+++ b/python/lib/sift_client/_tests/pytest_plugin/_step_status_capture.py
@@ -103,6 +103,29 @@ _active_log: Path | None = None
 _cached: dict[str, CapturedStep] | None = None
 
 
+def run_jsonl(output_dir: Path) -> Path:
+    """The JSONL log for the most recent run under a ``--sift-output-dir``.
+
+    The plugin nests each run in its own random subfolder, so the log lives at
+    ``<output_dir>/<random>/<random>.jsonl``. Returns the newest match (tests
+    that re-run into the same dir get the latest).
+    """
+    path = run_jsonl_or_none(output_dir)
+    if path is None:
+        raise FileNotFoundError(f"no Sift JSONL log under {output_dir}")
+    return path
+
+
+def run_jsonl_or_none(output_dir: Path) -> Path | None:
+    """Like :func:`run_jsonl`, but ``None`` when no run wrote a log.
+
+    A fully-gated-off run (every test ``sift_exclude``-d) never creates a
+    ReportContext, so no JSONL is written; the caller treats that as no steps.
+    """
+    matches = sorted(output_dir.glob("*/*.jsonl"), key=lambda p: p.stat().st_mtime)
+    return matches[-1] if matches else None
+
+
 def set_log(path: Path) -> None:
     """Point subsequent queries at a new log file. Clears the parse cache."""
     global _active_log, _cached

--- a/python/lib/sift_client/_tests/pytest_plugin/step_status_states.md
+++ b/python/lib/sift_client/_tests/pytest_plugin/step_status_states.md
@@ -85,6 +85,9 @@ be traced back to its row here without rereading the scenario:
 | `API-04` | Failed measurement on a substep   | `with step.substep(...) as s: s.measure(... out-of-bounds)`               | `FAILED` — propagates from substep to parent                                                                                |
 | `API-05` | Manually-skipped substep          | `with step.substep(...) as s: s.current_step.update({"status": SKIPPED})` | Parent step `PASSED` — skip does not propagate as a failure                                                                 |
 | `API-06` | Hard exit inside a nested substep | `with step.substep(...) as s: with s.substep(...): sys.exit(1)`           | Every open step on the unwind path records `ABORTED`; a sibling substep that closed before the abort keeps its prior status |
+| `API-07` | `pytest.exit()` after a failed `report_outcome`, in a class | `step.report_outcome(..., False); pytest.exit(...)`            | Failure stop: leaf `ABORTED`; class and module roll up `FAILED`; the failed substep keeps `FAILED`                          |
+| `API-08` | Session-aborting `KeyboardInterrupt` in a class | `step.report_outcome(..., False); raise KeyboardInterrupt`               | System stop: leaf, class, and module all `ABORTED` (the run was cut off, not failed); the failed substep keeps `FAILED`     |
+| `API-09` | Sift `abort()` helper in a class | `from sift_client.pytest_plugin import abort; abort(...)`                          | System stop: leaf, class, module, and the report all `ABORTED`, even with no failing check                                  |
 
 ## Out of scope
 
@@ -93,9 +96,6 @@ Scenarios deliberately not covered by this suite:
 - **Timeout** — needs `pytest-timeout` or a manual signal harness.
 - **Signal (SIGKILL / SIGTERM)** — cannot be caught from inside the process;
   needs a subprocess-level harness.
-- **`pytest.exit("...")`** — niche; the "aborts subsequent tests" behavior
-  is hard to characterize cleanly because each `pytester` invocation is
-  its own session.
 - **`os._exit()`** — bypasses Python cleanup entirely; can't be tested
   in-process because it would kill the outer pytest run. Guaranteed
   data-loss case alongside `SystemExit` / `SIGKILL`.

--- a/python/lib/sift_client/_tests/pytest_plugin/test_configuration.py
+++ b/python/lib/sift_client/_tests/pytest_plugin/test_configuration.py
@@ -49,26 +49,26 @@ class TestResolvedSettings:
 class TestIniConfiguration:
     """`addini` keys configure the plugin via pyproject.toml / pytest.ini."""
 
-    def test_ini_log_file_none(
+    def test_ini_log_file_disabled(
         self,
         pytester: pytest.Pytester,
         write_probe_conftest: Callable[[str], None],
     ) -> None:
         write_probe_conftest(
             """
-            from sift_client._internal.pytest_plugin.report import resolve_log_file
-            print("RESOLVED:", resolve_log_file(config))
+            from sift_client._internal.pytest_plugin.report import log_file_enabled
+            print("ENABLED:", log_file_enabled(config))
             """,
         )
         pytester.makepyprojecttoml(
             """
             [tool.pytest.ini_options]
-            sift_log_file = "none"
+            sift_log_file = false
             """
         )
         pytester.makepyfile("def test_noop(): pass")
         result = pytester.runpytest_subprocess("-s", "--co")
-        result.stdout.fnmatch_lines(["RESOLVED: None"])
+        result.stdout.fnmatch_lines(["ENABLED: False"])
 
     def test_python_false_disables_log_file(
         self,
@@ -78,43 +78,41 @@ class TestIniConfiguration:
         """`config.option.sift_log_file = False` disables logging.
 
         Conftests use this pattern (see lib/sift_client/_tests/util/conftest.py)
-        to opt their subtree out of log-file mode. Regression test for the
-        resolver case where Python `False` was previously confused with `None`
-        and silently kept the temp-file default.
+        to opt their subtree out of log-file mode.
         """
         write_probe_conftest(
             """
             config.option.sift_log_file = False
-            from sift_client._internal.pytest_plugin.report import resolve_log_file
-            print("RESOLVED:", resolve_log_file(config))
+            from sift_client._internal.pytest_plugin.report import log_file_enabled
+            print("ENABLED:", log_file_enabled(config))
             """,
         )
         pytester.makepyfile("def test_noop(): pass")
         result = pytester.runpytest_subprocess("-s", "--co")
-        result.stdout.fnmatch_lines(["RESOLVED: None"])
+        result.stdout.fnmatch_lines(["ENABLED: False"])
 
-    def test_ini_log_file_path(
+    def test_ini_output_dir(
         self,
         pytester: pytest.Pytester,
         tmp_path: Path,
         write_probe_conftest: Callable[[str], None],
     ) -> None:
-        log_path = tmp_path / "sift-run.jsonl"
+        out_dir = tmp_path / "artifacts"
         write_probe_conftest(
             """
-            from sift_client._internal.pytest_plugin.report import resolve_log_file
-            print("RESOLVED:", resolve_log_file(config))
+            from sift_client._internal.pytest_plugin.options import OUTPUT_DIR_OPTION
+            print("RESOLVED:", OUTPUT_DIR_OPTION.resolve(config))
             """,
         )
         pytester.makepyprojecttoml(
             f"""
             [tool.pytest.ini_options]
-            sift_log_file = "{log_path}"
+            sift_output_dir = "{out_dir}"
             """
         )
         pytester.makepyfile("def test_noop(): pass")
         result = pytester.runpytest_subprocess("-s", "--co")
-        result.stdout.fnmatch_lines([f"RESOLVED: {log_path}"])
+        result.stdout.fnmatch_lines([f"RESOLVED: {out_dir}"])
 
     def test_ini_offline_true(
         self,
@@ -181,26 +179,24 @@ class TestIniConfiguration:
     def test_cli_overrides_ini(
         self,
         pytester: pytest.Pytester,
-        tmp_path: Path,
         write_probe_conftest: Callable[[str], None],
     ) -> None:
         """A CLI flag takes precedence over the matching ini key."""
-        cli_path = tmp_path / "cli-wins.jsonl"
         write_probe_conftest(
             """
-            from sift_client._internal.pytest_plugin.report import resolve_log_file
-            print("RESOLVED:", resolve_log_file(config))
+            from sift_client._internal.pytest_plugin.report import log_file_enabled
+            print("ENABLED:", log_file_enabled(config))
             """,
         )
         pytester.makepyprojecttoml(
             """
             [tool.pytest.ini_options]
-            sift_log_file = "none"
+            sift_log_file = true
             """
         )
         pytester.makepyfile("def test_noop(): pass")
-        result = pytester.runpytest_subprocess("-s", "--co", f"--sift-log-file={cli_path}")
-        result.stdout.fnmatch_lines([f"RESOLVED: {cli_path}"])
+        result = pytester.runpytest_subprocess("-s", "--co", "--no-sift-log-file")
+        result.stdout.fnmatch_lines(["ENABLED: False"])
 
     def test_cli_offline_flag(
         self,
@@ -262,8 +258,8 @@ class TestIniConfiguration:
         write_probe_conftest(
             """
             from sift_client._internal.pytest_plugin.modes import is_disabled, is_offline
-            from sift_client._internal.pytest_plugin.report import resolve_log_file
-            print("RESOLVED:", resolve_log_file(config))
+            from sift_client._internal.pytest_plugin.report import log_file_enabled
+            print("ENABLED:", log_file_enabled(config))
             print("OFFLINE:", is_offline(config))
             print("DISABLED:", is_disabled(config))
             print("INI_GIT:", config.getini("sift_git_metadata"))
@@ -273,7 +269,7 @@ class TestIniConfiguration:
         result = pytester.runpytest_subprocess("-s", "--co")
         result.stdout.fnmatch_lines(
             [
-                "RESOLVED: True",
+                "ENABLED: True",
                 "OFFLINE: False",
                 "DISABLED: False",
                 "INI_GIT: True",

--- a/python/lib/sift_client/_tests/pytest_plugin/test_disabled.py
+++ b/python/lib/sift_client/_tests/pytest_plugin/test_disabled.py
@@ -113,20 +113,20 @@ class TestDisabledMode:
         result = pytester.runpytest_subprocess("--sift-disabled")
         result.assert_outcomes(passed=1)
 
-    def test_disabled_writes_no_log_file_even_when_path_pinned(
+    def test_disabled_writes_no_log_file(
         self,
         pytester: pytest.Pytester,
         tmp_path: Path,
         clear_sift_env: None,
         write_plugin_conftest: Callable[[], None],
     ) -> None:
-        """Disabled mode skips the log-file pipeline even when a path is pinned."""
-        log_path = tmp_path / "should-not-exist.jsonl"
+        """Disabled mode skips the log-file pipeline; no JSONL lands in the output dir."""
+        out_dir = tmp_path / "sift-out"
         write_plugin_conftest()
         pytester.makepyfile("def test_runs(step): step.measure(name='v', value=1.0)")
-        result = pytester.runpytest_subprocess("--sift-disabled", f"--sift-log-file={log_path}")
+        result = pytester.runpytest_subprocess("--sift-disabled", f"--sift-output-dir={out_dir}")
         result.assert_outcomes(passed=1)
-        assert not log_path.exists(), f"log file unexpectedly created at {log_path}"
+        assert not list(out_dir.glob("*/*.jsonl")), "disabled mode unexpectedly wrote a JSONL log"
 
     def test_disabled_skips_client_has_connection_and_sift_client(
         self,

--- a/python/lib/sift_client/_tests/pytest_plugin/test_hierarchy.py
+++ b/python/lib/sift_client/_tests/pytest_plugin/test_hierarchy.py
@@ -54,14 +54,14 @@ def _base_ini_lines(log_path: Path) -> list[str]:
     return [
         "[pytest]",
         "sift_offline = true",
-        f"sift_log_file = {log_path}",
+        f"sift_output_dir = {log_path}",
         "sift_git_metadata = false",
     ]
 
 
 @pytest.fixture
-def log_file(pytester: pytest.Pytester) -> Path:
-    path = pytester.path / "sift.log"
+def out_dir(pytester: pytest.Pytester) -> Path:
+    path = pytester.path / "sift-out"
     pytester.makeconftest(_INNER_CONFTEST)
     pytester.makefile(".ini", pytest="\n".join(_base_ini_lines(path)) + "\n")
     return path
@@ -86,7 +86,7 @@ def _ancestor_names(steps: list[dict], leaf: dict) -> list[str]:
     return chain
 
 
-def test_class_methods_cluster_under_class_step(pytester: pytest.Pytester, log_file: Path) -> None:
+def test_class_methods_cluster_under_class_step(pytester: pytest.Pytester, out_dir: Path) -> None:
     pytester.makepyfile(
         test_klass=dedent(
             """
@@ -101,7 +101,7 @@ def test_class_methods_cluster_under_class_step(pytester: pytest.Pytester, log_f
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     assert len(by_name["TestFoo"]) == 1
     class_id = by_name["TestFoo"][0]["id"]
@@ -110,7 +110,7 @@ def test_class_methods_cluster_under_class_step(pytester: pytest.Pytester, log_f
 
 
 def test_collection_skipped_method_nests_under_its_class(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """A collection-time skipped method nests under its class parent.
 
@@ -137,7 +137,7 @@ def test_collection_skipped_method_nests_under_its_class(
     )
     result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
     result.assert_outcomes(passed=1, skipped=1)
-    by_name = _by_name(capture.load_steps(log_file))
+    by_name = _by_name(capture.load_steps(capture.run_jsonl(out_dir)))
     assert len(by_name["TestFoo"]) == 1
     class_id = by_name["TestFoo"][0]["id"]
     assert by_name["test_run"][0]["parent_step_id"] == class_id
@@ -145,7 +145,7 @@ def test_collection_skipped_method_nests_under_its_class(
     assert by_name["test_skipped"][0]["statuses"][-1] == TestStatus.SKIPPED
 
 
-def test_nested_classes_produce_nested_steps(pytester: pytest.Pytester, log_file: Path) -> None:
+def test_nested_classes_produce_nested_steps(pytester: pytest.Pytester, out_dir: Path) -> None:
     pytester.makepyfile(
         test_nested=dedent(
             """
@@ -158,7 +158,7 @@ def test_nested_classes_produce_nested_steps(pytester: pytest.Pytester, log_file
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=1)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     assert len(by_name["TestOuter"]) == 1
     assert len(by_name["TestInner"]) == 1
@@ -171,7 +171,7 @@ def test_nested_classes_produce_nested_steps(pytester: pytest.Pytester, log_file
     ]
 
 
-def test_class_parametrize_nests_under_class(pytester: pytest.Pytester, log_file: Path) -> None:
+def test_class_parametrize_nests_under_class(pytester: pytest.Pytester, out_dir: Path) -> None:
     pytester.makepyfile(
         test_cp=dedent(
             """
@@ -186,7 +186,7 @@ def test_class_parametrize_nests_under_class(pytester: pytest.Pytester, log_file
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     class_id = by_name["TestFoo"][0]["id"]
     test_a_id = by_name["test_a"][0]["id"]
@@ -195,7 +195,7 @@ def test_class_parametrize_nests_under_class(pytester: pytest.Pytester, log_file
     assert by_name["v=2"][0]["parent_step_id"] == test_a_id
 
 
-def test_two_sibling_classes_in_module(pytester: pytest.Pytester, log_file: Path) -> None:
+def test_two_sibling_classes_in_module(pytester: pytest.Pytester, out_dir: Path) -> None:
     pytester.makepyfile(
         test_sib=dedent(
             """
@@ -211,7 +211,7 @@ def test_two_sibling_classes_in_module(pytester: pytest.Pytester, log_file: Path
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     mod_id = by_name["test_sib.py"][0]["id"]
     assert by_name["TestA"][0]["parent_step_id"] == mod_id
@@ -221,7 +221,7 @@ def test_two_sibling_classes_in_module(pytester: pytest.Pytester, log_file: Path
     assert len(by_name["TestB"]) == 1
 
 
-def test_mixed_class_and_free_function(pytester: pytest.Pytester, log_file: Path) -> None:
+def test_mixed_class_and_free_function(pytester: pytest.Pytester, out_dir: Path) -> None:
     pytester.makepyfile(
         test_mix=dedent(
             """
@@ -236,7 +236,7 @@ def test_mixed_class_and_free_function(pytester: pytest.Pytester, log_file: Path
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     mod_id = by_name["test_mix.py"][0]["id"]
     # Class method parents to TestA; free function parents directly to module.
@@ -246,7 +246,7 @@ def test_mixed_class_and_free_function(pytester: pytest.Pytester, log_file: Path
 
 
 def test_class_with_all_excluded_methods_no_class_step(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     pytester.makepyfile(
         test_excl=dedent(
@@ -266,14 +266,15 @@ def test_class_with_all_excluded_methods_no_class_step(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2)
-    steps = capture.load_steps(log_file)
+    jsonl = capture.run_jsonl_or_none(out_dir)
+    steps = capture.load_steps(jsonl) if jsonl else []
     by_name = _by_name(steps)
     assert "TestFoo" not in by_name
     assert "test_a" not in by_name
     assert "test_b" not in by_name
 
 
-def test_sift_exclude_on_class_propagates(pytester: pytest.Pytester, log_file: Path) -> None:
+def test_sift_exclude_on_class_propagates(pytester: pytest.Pytester, out_dir: Path) -> None:
     pytester.makepyfile(
         test_clsexcl=dedent(
             """
@@ -291,14 +292,15 @@ def test_sift_exclude_on_class_propagates(pytester: pytest.Pytester, log_file: P
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2)
-    steps = capture.load_steps(log_file)
+    jsonl = capture.run_jsonl_or_none(out_dir)
+    steps = capture.load_steps(jsonl) if jsonl else []
     by_name = _by_name(steps)
     assert "TestFoo" not in by_name
     assert "test_a" not in by_name
 
 
 def test_class_docstring_becomes_step_description(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     pytester.makepyfile(
         test_doc=dedent(
@@ -313,7 +315,7 @@ def test_class_docstring_becomes_step_description(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=1)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     # The fake records step creation but not all fields — check the class
     # step was recorded, then read the description via the FakeStep's
@@ -324,7 +326,7 @@ def test_class_docstring_becomes_step_description(
 
 
 def test_two_class_chains_keep_parametrize_isolated(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     pytester.makepyfile(
         test_trans=dedent(
@@ -345,7 +347,7 @@ def test_two_class_chains_keep_parametrize_isolated(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     # Each class opens exactly once; parametrize parents under the right class.
     assert len(by_name["TestA"]) == 1
@@ -432,7 +434,7 @@ def test_finalize_parents_continues_past_failing_exit(clean_parent_registries) -
 
 
 def test_failing_test_in_class_does_not_orphan_class_step(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """A failing class method must not block the class step from cleaning up.
 
@@ -458,7 +460,7 @@ def test_failing_test_in_class_does_not_orphan_class_step(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2, failed=1)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     assert len(by_name["TestFoo"]) == 1
     assert len(by_name["TestBar"]) == 1
@@ -475,7 +477,7 @@ def test_failing_test_in_class_does_not_orphan_class_step(
 
 
 def test_failing_parametrized_method_in_class_closes_full_chain(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """A failing parametrized class method must not orphan its parametrize parents."""
     pytester.makepyfile(
@@ -496,7 +498,7 @@ def test_failing_parametrized_method_in_class_closes_full_chain(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2, failed=1)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     foo_id = by_name["TestFoo"][0]["id"]
     test_a_id = by_name["test_a"][0]["id"]
@@ -512,18 +514,18 @@ def test_failing_parametrized_method_in_class_closes_full_chain(
 # ---------------------------------------------------------------------------
 
 
-def _write_ini(pytester: pytest.Pytester, log_file: Path, **overrides: object) -> None:
+def _write_ini(pytester: pytest.Pytester, out_dir: Path, **overrides: object) -> None:
     """Write a pytest.ini with the given sift_* overrides, preserving the
-    offline/log/git-metadata defaults the ``log_file`` fixture installs.
+    offline/log/git-metadata defaults the ``out_dir`` fixture installs.
     """
-    lines = _base_ini_lines(log_file)
+    lines = _base_ini_lines(out_dir)
     for key, value in overrides.items():
         lines.append(f"{key} = {value}")
     pytester.makefile(".ini", pytest="\n".join(lines) + "\n")
 
 
-def test_sift_class_step_false_skips_class_steps(pytester: pytest.Pytester, log_file: Path) -> None:
-    _write_ini(pytester, log_file, sift_class_step="false")
+def test_sift_class_step_false_skips_class_steps(pytester: pytest.Pytester, out_dir: Path) -> None:
+    _write_ini(pytester, out_dir, sift_class_step="false")
     pytester.makepyfile(
         test_noclass=dedent(
             """
@@ -538,7 +540,8 @@ def test_sift_class_step_false_skips_class_steps(pytester: pytest.Pytester, log_
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2)
-    steps = capture.load_steps(log_file)
+    jsonl = capture.run_jsonl_or_none(out_dir)
+    steps = capture.load_steps(jsonl) if jsonl else []
     by_name = _by_name(steps)
     assert "TestFoo" not in by_name
     mod_id = by_name["test_noclass.py"][0]["id"]
@@ -547,9 +550,9 @@ def test_sift_class_step_false_skips_class_steps(pytester: pytest.Pytester, log_
 
 
 def test_sift_module_step_false_skips_module_step(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
-    _write_ini(pytester, log_file, sift_module_step="false")
+    _write_ini(pytester, out_dir, sift_module_step="false")
     pytester.makepyfile(
         test_nomod=dedent(
             """
@@ -561,7 +564,7 @@ def test_sift_module_step_false_skips_module_step(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=1)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     assert "test_nomod.py" not in by_name
     # TestFoo attaches to the report root (no parent recorded by the fake).
@@ -570,9 +573,9 @@ def test_sift_module_step_false_skips_module_step(
 
 
 def test_sift_parametrize_nesting_false_keeps_flat_leaves(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
-    _write_ini(pytester, log_file, sift_parametrize_nesting="false")
+    _write_ini(pytester, out_dir, sift_parametrize_nesting="false")
     pytester.makepyfile(
         test_flat=dedent(
             """
@@ -586,7 +589,7 @@ def test_sift_parametrize_nesting_false_keeps_flat_leaves(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     # No parametrize parent step.
     assert "test_a" not in by_name
@@ -600,7 +603,7 @@ def test_sift_parametrize_nesting_false_keeps_flat_leaves(
 
 
 def test_sift_module_step_false_still_drains_across_modules(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """sift_module_step=false must not merge same-named classes across modules.
 
@@ -608,7 +611,7 @@ def test_sift_module_step_false_still_drains_across_modules(
     (even when it's not rendered as a step), so two modules each declaring
     ``class TestFoo`` produce two distinct ``TestFoo`` frames in the diff.
     """
-    _write_ini(pytester, log_file, sift_module_step="false")
+    _write_ini(pytester, out_dir, sift_module_step="false")
     pytester.makepyfile(
         test_a=dedent(
             """
@@ -627,7 +630,7 @@ def test_sift_module_step_false_still_drains_across_modules(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     # Two distinct TestFoo class steps — one per module — not a shared frame.
     assert len(by_name["TestFoo"]) == 2
@@ -641,7 +644,7 @@ def test_sift_module_step_false_still_drains_across_modules(
 
 
 def test_package_step_default_opens_for_init_dirs(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """Default: a directory with ``__init__.py`` produces a parent package step."""
     pytester.mkpydir("pkg_a")
@@ -655,7 +658,7 @@ def test_package_step_default_opens_for_init_dirs(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=1)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     assert "pkg_a" in by_name
     pkg_id = by_name["pkg_a"][0]["id"]
@@ -664,7 +667,7 @@ def test_package_step_default_opens_for_init_dirs(
 
 
 def test_same_named_packages_in_different_dirs_do_not_merge(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """Two packages with the same display name but different paths must stay distinct.
 
@@ -699,7 +702,7 @@ def test_same_named_packages_in_different_dirs_do_not_merge(
     # name on disk don't collide during sys.path-based import.
     result = pytester.runpytest_inprocess("-v", "--import-mode=importlib")
     result.assert_outcomes(passed=2)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     # Two distinct ``utils`` package steps — one per project.
     assert len(by_name["utils"]) == 2
@@ -713,10 +716,10 @@ def test_same_named_packages_in_different_dirs_do_not_merge(
 
 
 def test_sift_package_step_false_skips_package_steps(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """With ``sift_package_step=false`` the directory step is suppressed."""
-    _write_ini(pytester, log_file, sift_package_step="false")
+    _write_ini(pytester, out_dir, sift_package_step="false")
     pytester.mkpydir("pkg_a")
     (pytester.path / "pkg_a" / "test_x.py").write_text(
         dedent(
@@ -728,7 +731,7 @@ def test_sift_package_step_false_skips_package_steps(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=1)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     assert "pkg_a" not in by_name
     # The module step still opens and is now the top-level frame.
@@ -736,11 +739,11 @@ def test_sift_package_step_false_skips_package_steps(
 
 
 def test_all_three_flags_false_matches_legacy_behavior(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     _write_ini(
         pytester,
-        log_file,
+        out_dir,
         sift_module_step="false",
         sift_class_step="false",
         sift_parametrize_nesting="false",
@@ -759,7 +762,7 @@ def test_all_three_flags_false_matches_legacy_behavior(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     # No module, class, or parametrize parents — just bracket-mangled leaves.
     assert "test_legacy.py" not in by_name
@@ -777,7 +780,7 @@ def test_all_three_flags_false_matches_legacy_behavior(
 
 
 def test_single_parametrize_clusters_under_originalname(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     pytester.makepyfile(
         test_rail=dedent(
@@ -792,7 +795,7 @@ def test_single_parametrize_clusters_under_originalname(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     # Module step + one shared `test_rail` parent + two leaves.
     assert len(by_name["test_rail.py"]) == 1
@@ -805,7 +808,7 @@ def test_single_parametrize_clusters_under_originalname(
 
 
 def test_stacked_parametrize_nests_outer_to_inner(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     pytester.makepyfile(
         test_iso=dedent(
@@ -821,7 +824,7 @@ def test_stacked_parametrize_nests_outer_to_inner(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=4)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     # One `test_iso` parent, two `voltage='…'` parents, four `component='…'` leaves.
     assert len(by_name["test_iso"]) == 1
@@ -843,7 +846,7 @@ def test_stacked_parametrize_nests_outer_to_inner(
         assert leaf["parent_step_id"] in voltage_ids
 
 
-def test_fixture_parametrization_participates(pytester: pytest.Pytester, log_file: Path) -> None:
+def test_fixture_parametrization_participates(pytester: pytest.Pytester, out_dir: Path) -> None:
     pytester.makepyfile(
         test_widget=dedent(
             """
@@ -860,7 +863,7 @@ def test_fixture_parametrization_participates(pytester: pytest.Pytester, log_fil
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     assert len(by_name["test_widget"]) == 1
     parent_id = by_name["test_widget"][0]["id"]
@@ -869,7 +872,7 @@ def test_fixture_parametrization_participates(pytester: pytest.Pytester, log_fil
 
 
 def test_module_boundary_isolates_parametrize_stack(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     pytester.makepyfile(
         test_a=dedent(
@@ -893,7 +896,7 @@ def test_module_boundary_isolates_parametrize_stack(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=4)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     # Each module step contains its own `test_one`/`test_two` parametrize subtree.
     mod_a = by_name["test_a.py"][0]
@@ -902,7 +905,7 @@ def test_module_boundary_isolates_parametrize_stack(
     assert by_name["test_two"][0]["parent_step_id"] == mod_b["id"]
 
 
-def test_leaf_parent_chain_terminates_at_report(pytester: pytest.Pytester, log_file: Path) -> None:
+def test_leaf_parent_chain_terminates_at_report(pytester: pytest.Pytester, out_dir: Path) -> None:
     pytester.makepyfile(
         test_chain=dedent(
             """
@@ -917,7 +920,7 @@ def test_leaf_parent_chain_terminates_at_report(pytester: pytest.Pytester, log_f
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=1)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     leaf = next(s for s in steps if s["name"].startswith("b="))
     chain = _ancestor_names(steps, leaf)
     # leaf b=… → a=… → test_chain → test_chain.py (module step) → root
@@ -930,7 +933,7 @@ def test_leaf_parent_chain_terminates_at_report(pytester: pytest.Pytester, log_f
 
 
 def test_interleaved_execution_does_not_duplicate_parents(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """Sibling methods need not run contiguously to share one class parent.
 
@@ -941,7 +944,7 @@ def test_interleaved_execution_does_not_duplicate_parents(
     right class.
     """
     # Overwrite the conftest with one that registers the plugin AND reorders
-    # items so the two classes interleave. The log_file fixture's pytest.ini
+    # items so the two classes interleave. The out_dir fixture's pytest.ini
     # (offline + log path) still applies.
     pytester.makeconftest(
         dedent(
@@ -980,7 +983,7 @@ def test_interleaved_execution_does_not_duplicate_parents(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=4)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     # Each class opens exactly once despite the interleaved run order.
     assert len(by_name["TestA"]) == 1
@@ -999,7 +1002,7 @@ def test_interleaved_execution_does_not_duplicate_parents(
 
 
 def test_parent_status_passed_when_all_children_pass(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     pytester.makepyfile(
         test_ok=dedent(
@@ -1015,13 +1018,13 @@ def test_parent_status_passed_when_all_children_pass(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2)
-    by_name = _by_name(capture.load_steps(log_file))
+    by_name = _by_name(capture.load_steps(capture.run_jsonl(out_dir)))
     assert by_name["TestFoo"][0]["statuses"][-1] == TestStatus.PASSED
     assert by_name["test_ok.py"][0]["statuses"][-1] == TestStatus.PASSED
 
 
 def test_parent_status_failed_propagates_up_and_isolates_siblings(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """A failing leaf marks its class and the module FAILED, but a sibling class
     whose tests all pass stays PASSED.
@@ -1044,14 +1047,14 @@ def test_parent_status_failed_propagates_up_and_isolates_siblings(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2, failed=1)
-    by_name = _by_name(capture.load_steps(log_file))
+    by_name = _by_name(capture.load_steps(capture.run_jsonl(out_dir)))
     assert by_name["TestFoo"][0]["statuses"][-1] == TestStatus.FAILED
     assert by_name["test_fail.py"][0]["statuses"][-1] == TestStatus.FAILED
     assert by_name["TestBar"][0]["statuses"][-1] == TestStatus.PASSED
 
 
 def test_parent_status_failure_propagates_through_parametrize(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """One failing parametrization fails the whole chain: parametrize parent →
     class → module.
@@ -1071,14 +1074,14 @@ def test_parent_status_failure_propagates_through_parametrize(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=1, failed=1)
-    by_name = _by_name(capture.load_steps(log_file))
+    by_name = _by_name(capture.load_steps(capture.run_jsonl(out_dir)))
     assert by_name["test_a"][0]["statuses"][-1] == TestStatus.FAILED
     assert by_name["TestFoo"][0]["statuses"][-1] == TestStatus.FAILED
     assert by_name["test_pfail.py"][0]["statuses"][-1] == TestStatus.FAILED
 
 
 def test_parent_opens_in_progress_and_resolves_exactly_once(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """A parent is created IN_PROGRESS and gets exactly one terminal status at
     session end — it is never reopened, even as later siblings run under it.
@@ -1101,7 +1104,7 @@ def test_parent_opens_in_progress_and_resolves_exactly_once(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2)
-    by_name = _by_name(capture.load_steps(log_file))
+    by_name = _by_name(capture.load_steps(capture.run_jsonl(out_dir)))
     # Created in-progress, resolved once — no intermediate churn, no reopen.
     assert by_name["TestFoo"][0]["statuses"] == [TestStatus.IN_PROGRESS, TestStatus.PASSED]
     assert by_name["test_once.py"][0]["statuses"] == [TestStatus.IN_PROGRESS, TestStatus.PASSED]
@@ -1112,7 +1115,7 @@ def test_parent_opens_in_progress_and_resolves_exactly_once(
 # ---------------------------------------------------------------------------
 
 
-def test_parent_timing_spans_its_children(pytester: pytest.Pytester, log_file: Path) -> None:
+def test_parent_timing_spans_its_children(pytester: pytest.Pytester, out_dir: Path) -> None:
     """A parent's [start, end] window covers its whole subtree: it starts no
     later than its first child and ends exactly at its last child's finish.
     """
@@ -1132,7 +1135,7 @@ def test_parent_timing_spans_its_children(pytester: pytest.Pytester, log_file: P
     )
     result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
     result.assert_outcomes(passed=2)
-    by_name = _by_name(capture.load_steps(log_file))
+    by_name = _by_name(capture.load_steps(capture.run_jsonl(out_dir)))
     klass = by_name["TestFoo"][0]
     module = by_name["test_span.py"][0]
     leaves = [by_name["test_a"][0], by_name["test_b"][0]]
@@ -1150,7 +1153,7 @@ def test_parent_timing_spans_its_children(pytester: pytest.Pytester, log_file: P
 
 
 def test_parent_end_time_reflects_a_later_child_under_interleaving(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """When a parent's children run non-contiguously, its end_time tracks the
     LAST child to finish — even one that runs after a different parent's child.
@@ -1194,7 +1197,7 @@ def test_parent_end_time_reflects_a_later_child_under_interleaving(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=3)
-    by_name = _by_name(capture.load_steps(log_file))
+    by_name = _by_name(capture.load_steps(capture.run_jsonl(out_dir)))
     a_end = by_name["TestA"][0]["end_time"]
     a1_end = by_name["test_a1"][0]["end_time"]
     a2_end = by_name["test_a2"][0]["end_time"]
@@ -1245,7 +1248,7 @@ def pytest_collection_modifyitems(config, items):
 """
 
 
-def test_parent_closes_mid_session_not_at_end(pytester: pytest.Pytester, log_file: Path) -> None:
+def test_parent_closes_mid_session_not_at_end(pytester: pytest.Pytester, out_dir: Path) -> None:
     """A container resolves as soon as its last child finishes — before the next
     container even opens — rather than all flipping at session end.
     """
@@ -1267,7 +1270,7 @@ def test_parent_closes_mid_session_not_at_end(pytester: pytest.Pytester, log_fil
     )
     result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
     result.assert_outcomes(passed=3)
-    events = capture.log_events(log_file)
+    events = capture.log_events(capture.run_jsonl(out_dir))
     # TestFoo reaches a terminal status before TestBar is even created.
     assert _index(events, "UpdateTestStep", "TestFoo", terminal=True) < _index(
         events, "CreateTestStep", "TestBar"
@@ -1275,7 +1278,7 @@ def test_parent_closes_mid_session_not_at_end(pytester: pytest.Pytester, log_fil
 
 
 def test_failing_parent_resolves_failed_mid_session(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """Early close carries status too: a class with a failing test resolves FAILED
     as soon as its subtree finishes, before the next class opens.
@@ -1295,13 +1298,13 @@ def test_failing_parent_resolves_failed_mid_session(
     )
     result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
     result.assert_outcomes(passed=1, failed=1)
-    events = capture.log_events(log_file)
+    events = capture.log_events(capture.run_jsonl(out_dir))
     foo_failed = _index(events, "UpdateTestStep", "TestFoo", status=TestStatus.FAILED)
     assert foo_failed < _index(events, "CreateTestStep", "TestBar")
 
 
 def test_close_is_completion_driven_not_order_driven(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """A single-child container closes the moment that child finishes, even though
     a sibling container's test (collected earlier) runs afterward.
@@ -1329,7 +1332,7 @@ def test_close_is_completion_driven_not_order_driven(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=3)
-    events = capture.log_events(log_file)
+    events = capture.log_events(capture.run_jsonl(out_dir))
     # TestB resolves before test_a2 is even created.
     assert _index(events, "UpdateTestStep", "TestB", terminal=True) < _index(
         events, "CreateTestStep", "test_a2"
@@ -1337,7 +1340,7 @@ def test_close_is_completion_driven_not_order_driven(
 
 
 def test_excluded_sibling_does_not_stall_parent_close(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """A ``sift_exclude``-d method is not counted toward its class's descendants,
     so the class still closes promptly once its included tests finish.
@@ -1367,7 +1370,7 @@ def test_excluded_sibling_does_not_stall_parent_close(
     )
     result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
     result.assert_outcomes(passed=3)
-    events = capture.log_events(log_file)
+    events = capture.log_events(capture.run_jsonl(out_dir))
     assert _index(events, "UpdateTestStep", "TestFoo", terminal=True) < _index(
         events, "CreateTestStep", "TestBar"
     )
@@ -1388,7 +1391,7 @@ def outer(request):
 
 
 def test_session_fixture_param_promoted_above_module(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """A session-scoped autouse fixture with params must appear above the module."""
     pytester.makeconftest(_SESSION_FIXTURE_CONFTEST)
@@ -1405,7 +1408,7 @@ def test_session_fixture_param_promoted_above_module(
     )
     result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
     result.assert_outcomes(passed=4)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
 
     assert len(by_name["outer=10"]) == 1
@@ -1423,7 +1426,7 @@ def test_session_fixture_param_promoted_above_module(
 
 
 def test_two_outer_param_variants_produce_distinct_module_steps(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """The same module must not be shared across outer-param universes."""
     pytester.makeconftest(_SESSION_FIXTURE_CONFTEST)
@@ -1437,7 +1440,7 @@ def test_two_outer_param_variants_produce_distinct_module_steps(
     )
     result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
     result.assert_outcomes(passed=2)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
 
     # Two distinct module steps, one per outer-param universe.
@@ -1455,7 +1458,7 @@ def test_two_outer_param_variants_produce_distinct_module_steps(
 
 
 def test_inner_parametrize_still_works_inside_outer_param(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """Inner mark-parametrize nesting must still work within each outer-param universe."""
     pytester.makeconftest(_SESSION_FIXTURE_CONFTEST)
@@ -1472,7 +1475,7 @@ def test_inner_parametrize_still_works_inside_outer_param(
     )
     result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
     result.assert_outcomes(passed=4)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
 
     # Two outer universes → two `test_inner` parametrize parents.
@@ -1486,7 +1489,7 @@ def test_inner_parametrize_still_works_inside_outer_param(
         assert leaf["parent_step_id"] in test_inner_ids
 
 
-def test_no_outer_param_unaffected(pytester: pytest.Pytester, log_file: Path) -> None:
+def test_no_outer_param_unaffected(pytester: pytest.Pytester, out_dir: Path) -> None:
     """Tests without any session-scoped fixture params produce the normal tree."""
     pytester.makepyfile(
         test_plain=dedent(
@@ -1501,7 +1504,7 @@ def test_no_outer_param_unaffected(pytester: pytest.Pytester, log_file: Path) ->
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
 
     # Module step is a root (no outer param wrapper).
@@ -1512,7 +1515,7 @@ def test_no_outer_param_unaffected(pytester: pytest.Pytester, log_file: Path) ->
     assert by_name["test_plain"][0]["parent_step_id"] == mod_id
 
 
-def test_outer_param_subtree_closes_mid_session(pytester: pytest.Pytester, log_file: Path) -> None:
+def test_outer_param_subtree_closes_mid_session(pytester: pytest.Pytester, out_dir: Path) -> None:
     """The outer-param step resolves as soon as all its tests finish — not at session end."""
     pytester.makeconftest(_SESSION_FIXTURE_CONFTEST)
     pytester.makepyfile(
@@ -1528,7 +1531,7 @@ def test_outer_param_subtree_closes_mid_session(pytester: pytest.Pytester, log_f
     )
     result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
     result.assert_outcomes(passed=4)
-    events = capture.log_events(log_file)
+    events = capture.log_events(capture.run_jsonl(out_dir))
     # The first outer-param step must resolve before the second outer-param step is created.
     assert _index(events, "UpdateTestStep", "outer=10", terminal=True) < _index(
         events, "CreateTestStep", "outer=20"
@@ -1540,7 +1543,7 @@ def test_outer_param_subtree_closes_mid_session(pytester: pytest.Pytester, log_f
 # ---------------------------------------------------------------------------
 
 
-def test_explicit_list_ids_on_inner_parametrize(pytester: pytest.Pytester, log_file: Path) -> None:
+def test_explicit_list_ids_on_inner_parametrize(pytester: pytest.Pytester, out_dir: Path) -> None:
     """An explicit ``ids=[...]`` list labels the parametrize steps, not ``name=value``."""
     pytester.makepyfile(
         test_lid=dedent(
@@ -1555,7 +1558,7 @@ def test_explicit_list_ids_on_inner_parametrize(pytester: pytest.Pytester, log_f
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2)
-    by_name = _by_name(capture.load_steps(log_file))
+    by_name = _by_name(capture.load_steps(capture.run_jsonl(out_dir)))
     # Friendly IDs are the leaf names; the structured fallback never appears.
     assert "one" in by_name
     assert "two" in by_name
@@ -1567,7 +1570,7 @@ def test_explicit_list_ids_on_inner_parametrize(pytester: pytest.Pytester, log_f
 
 
 def test_callable_id_factory_on_inner_parametrize(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """A callable ``ids=`` factory is invoked per value, just as pytest does."""
     pytester.makepyfile(
@@ -1586,14 +1589,14 @@ def test_callable_id_factory_on_inner_parametrize(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2)
-    by_name = _by_name(capture.load_steps(log_file))
+    by_name = _by_name(capture.load_steps(capture.run_jsonl(out_dir)))
     assert "ch_0" in by_name
     assert "ch_1" in by_name
     assert "v=0" not in by_name
 
 
 def test_explicit_ids_on_session_fixture_label_outer_param(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """A session fixture's explicit ``ids`` label the promoted outer-param steps."""
     pytester.makeconftest(
@@ -1619,7 +1622,7 @@ def test_explicit_ids_on_session_fixture_label_outer_param(
     )
     result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
     result.assert_outcomes(passed=2)
-    by_name = _by_name(capture.load_steps(log_file))
+    by_name = _by_name(capture.load_steps(capture.run_jsonl(out_dir)))
     assert "lo" in by_name
     assert "hi" in by_name
     assert "outer=24" not in by_name
@@ -1630,7 +1633,7 @@ def test_explicit_ids_on_session_fixture_label_outer_param(
 
 
 def test_auto_generated_ids_fall_back_to_name_value(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """With no author-supplied ``ids``, steps use the structured ``name=value`` label."""
     pytester.makepyfile(
@@ -1646,13 +1649,13 @@ def test_auto_generated_ids_fall_back_to_name_value(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=2)
-    by_name = _by_name(capture.load_steps(log_file))
+    by_name = _by_name(capture.load_steps(capture.run_jsonl(out_dir)))
     assert "v=1" in by_name
     assert "v=2" in by_name
 
 
 def test_combined_axis_ids_fall_back_to_name_value(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """A combined ``"a,b"`` axis can't attribute its shared ID, so each frame uses
     ``name=value`` rather than mislabelling both with the same combined ID.
@@ -1670,7 +1673,7 @@ def test_combined_axis_ids_fall_back_to_name_value(
     )
     result = pytester.runpytest_inprocess("-v")
     result.assert_outcomes(passed=1)
-    by_name = _by_name(capture.load_steps(log_file))
+    by_name = _by_name(capture.load_steps(capture.run_jsonl(out_dir)))
     # The shared "combined" ID is not adopted for either per-arg frame.
     assert "combined" not in by_name
     assert "a=1" in by_name
@@ -1683,7 +1686,7 @@ def test_combined_axis_ids_fall_back_to_name_value(
 
 
 def test_class_scoped_fixture_param_lifts_above_method(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """A class-scoped parametrized fixture nests ABOVE the method; the method's own
     function param stays inside it (the inversion fix).
@@ -1706,7 +1709,7 @@ def test_class_scoped_fixture_param_lifts_above_method(
     )
     result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
     result.assert_outcomes(passed=4)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     # cfix lifts between the class and the method.
     assert len(by_name["cfix='A'"]) == 1
@@ -1739,7 +1742,7 @@ _MODULE_FIXTURE_SRC = dedent(
 
 
 def test_module_scoped_fixture_param_lifts_above_functions(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """A module-scoped parametrized fixture nests above the functions in the module,
     and two functions sharing it group under ONE param step per value (not split).
@@ -1747,7 +1750,7 @@ def test_module_scoped_fixture_param_lifts_above_functions(
     pytester.makepyfile(test_ms=_MODULE_FIXTURE_SRC)
     result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
     result.assert_outcomes(passed=4)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     mod_id = by_name["test_ms.py"][0]["id"]
     # One mfix step per value, each under the module (shared by both functions).
@@ -1763,7 +1766,7 @@ def test_module_scoped_fixture_param_lifts_above_functions(
 
 
 def test_module_scoped_param_step_early_closes_when_shared_subtree_done(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """A shared module-scoped param step resolves once all its tests finish, before
     the next param value's step opens.
@@ -1771,13 +1774,13 @@ def test_module_scoped_param_step_early_closes_when_shared_subtree_done(
     pytester.makepyfile(test_msc=_MODULE_FIXTURE_SRC)
     result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
     result.assert_outcomes(passed=4)
-    events = capture.log_events(log_file)
+    events = capture.log_events(capture.run_jsonl(out_dir))
     assert _index(events, "UpdateTestStep", "mfix='M1'", terminal=True) < _index(
         events, "CreateTestStep", "mfix='M2'"
     )
 
 
-def test_mark_scope_class_lifts_to_class(pytester: pytest.Pytester, log_file: Path) -> None:
+def test_mark_scope_class_lifts_to_class(pytester: pytest.Pytester, out_dir: Path) -> None:
     """A ``@pytest.mark.parametrize(..., scope="class")`` lifts to the class level."""
     pytester.makepyfile(
         test_msk=dedent(
@@ -1793,7 +1796,7 @@ def test_mark_scope_class_lifts_to_class(pytester: pytest.Pytester, log_file: Pa
     )
     result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
     result.assert_outcomes(passed=2)
-    by_name = _by_name(capture.load_steps(log_file))
+    by_name = _by_name(capture.load_steps(capture.run_jsonl(out_dir)))
     class_id = by_name["TestFoo"][0]["id"]
     # cv lifts to sit directly under the class, above the method.
     assert by_name["cv=1"][0]["parent_step_id"] == class_id
@@ -1802,7 +1805,7 @@ def test_mark_scope_class_lifts_to_class(pytester: pytest.Pytester, log_file: Pa
     assert by_name["test_a"][0]["parent_step_id"] in {cv1_id, by_name["cv=2"][0]["id"]}
 
 
-def test_mark_scope_session_lifts_to_root(pytester: pytest.Pytester, log_file: Path) -> None:
+def test_mark_scope_session_lifts_to_root(pytester: pytest.Pytester, out_dir: Path) -> None:
     """A ``@pytest.mark.parametrize(..., scope="session")`` lifts above the module
     (closes the gap where mark-scoped session params were treated as function-scoped).
     """
@@ -1819,14 +1822,14 @@ def test_mark_scope_session_lifts_to_root(pytester: pytest.Pytester, log_file: P
     )
     result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
     result.assert_outcomes(passed=2)
-    by_name = _by_name(capture.load_steps(log_file))
+    by_name = _by_name(capture.load_steps(capture.run_jsonl(out_dir)))
     # sx steps are roots, each scoping its own module subtree.
     assert by_name["sx=7"][0]["parent_step_id"] is None
     assert by_name["sx=8"][0]["parent_step_id"] is None
     assert len(by_name["test_mss.py"]) == 2
 
 
-def test_bare_class_mark_stays_under_method(pytester: pytest.Pytester, log_file: Path) -> None:
+def test_bare_class_mark_stays_under_method(pytester: pytest.Pytester, out_dir: Path) -> None:
     """A class-level mark WITHOUT ``scope=`` is function-scoped, so it stays under the
     method — not lifted to the class.
     """
@@ -1844,7 +1847,7 @@ def test_bare_class_mark_stays_under_method(pytester: pytest.Pytester, log_file:
     )
     result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
     result.assert_outcomes(passed=2)
-    by_name = _by_name(capture.load_steps(log_file))
+    by_name = _by_name(capture.load_steps(capture.run_jsonl(out_dir)))
     method_id = by_name["test_a"][0]["id"]
     class_id = by_name["TestFoo"][0]["id"]
     # cv parents to the method, and the method parents directly to the class.
@@ -1855,7 +1858,7 @@ def test_bare_class_mark_stays_under_method(pytester: pytest.Pytester, log_file:
 
 
 def test_nested_class_fixture_anchors_to_defining_class(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """A class-scoped fixture defined on the OUTER class anchors there, not under the
     innermost nested class.
@@ -1878,7 +1881,7 @@ def test_nested_class_fixture_anchors_to_defining_class(
     )
     result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
     result.assert_outcomes(passed=2)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     outer_id = by_name["TestOuter"][0]["id"]
     # cfix sits directly under TestOuter (its defining class), above TestInner.
@@ -1889,12 +1892,12 @@ def test_nested_class_fixture_anchors_to_defining_class(
 
 
 def test_class_param_falls_through_when_class_step_disabled(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """With ``sift_class_step=false`` the class step is suppressed, but a class-scoped
     param still renders and attaches to the module (nearest rendered ancestor).
     """
-    _write_ini(pytester, log_file, sift_class_step="false")
+    _write_ini(pytester, out_dir, sift_class_step="false")
     pytester.makepyfile(
         test_cft=dedent(
             """
@@ -1912,7 +1915,7 @@ def test_class_param_falls_through_when_class_step_disabled(
     )
     result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
     result.assert_outcomes(passed=2)
-    by_name = _by_name(capture.load_steps(log_file))
+    by_name = _by_name(capture.load_steps(capture.run_jsonl(out_dir)))
     assert "TestFoo" not in by_name
     mod_id = by_name["test_cft.py"][0]["id"]
     # The class param falls through to the module step.
@@ -1925,7 +1928,7 @@ def test_class_param_falls_through_when_class_step_disabled(
 
 
 def test_collection_skipped_param_item_uses_cleaned_leaf_name(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """A collection-skipped item under a scope-promoted param keeps the cleaned leaf
     name (no parametrize bracket), matching how a run sibling is named, and still
@@ -1964,7 +1967,7 @@ def test_collection_skipped_param_item_uses_cleaned_leaf_name(
     )
     result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
     result.assert_outcomes(passed=2, skipped=2)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     # Cleaned leaf name (no ``[10]`` bracket), one per outer-param universe.
     assert len(by_name["test_skipped"]) == 2
@@ -2096,7 +2099,7 @@ def test_introspection_failure_is_audit_logged() -> None:
 
 
 def test_internals_failure_does_not_break_collection(
-    pytester: pytest.Pytester, log_file: Path, monkeypatch: pytest.MonkeyPatch
+    pytester: pytest.Pytester, out_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """End-to-end: a forced internals failure degrades, it does not error the run.
 
@@ -2124,11 +2127,11 @@ def test_internals_failure_does_not_break_collection(
     # The degradation is surfaced, not silent.
     assert "scope-aware parametrize placement" in result.stdout.str()
     # A report was still produced; the module-scoped param simply wasn't promoted.
-    assert capture.load_steps(log_file)
+    assert capture.load_steps(capture.run_jsonl(out_dir))
 
 
 def test_indirect_parametrize_lifts_to_fixture_scope(
-    pytester: pytest.Pytester, log_file: Path
+    pytester: pytest.Pytester, out_dir: Path
 ) -> None:
     """An ``indirect=True`` axis routed through a module-scoped fixture lifts to
     the module level. Scope comes from the fixture's public ``fixturedef.scope``,
@@ -2151,7 +2154,7 @@ def test_indirect_parametrize_lifts_to_fixture_scope(
     )
     result = pytester.runpytest_inprocess("-v", "-p", "no:randomly")
     result.assert_outcomes(passed=2)
-    steps = capture.load_steps(log_file)
+    steps = capture.load_steps(capture.run_jsonl(out_dir))
     by_name = _by_name(steps)
     mod_id = by_name["test_ind.py"][0]["id"]
     # One param step per value, lifted to module scope (under the module step).

--- a/python/lib/sift_client/_tests/pytest_plugin/test_hierarchy.py
+++ b/python/lib/sift_client/_tests/pytest_plugin/test_hierarchy.py
@@ -299,9 +299,7 @@ def test_sift_exclude_on_class_propagates(pytester: pytest.Pytester, out_dir: Pa
     assert "test_a" not in by_name
 
 
-def test_class_docstring_becomes_step_description(
-    pytester: pytest.Pytester, out_dir: Path
-) -> None:
+def test_class_docstring_becomes_step_description(pytester: pytest.Pytester, out_dir: Path) -> None:
     pytester.makepyfile(
         test_doc=dedent(
             '''
@@ -549,9 +547,7 @@ def test_sift_class_step_false_skips_class_steps(pytester: pytest.Pytester, out_
     assert by_name["test_b"][0]["parent_step_id"] == mod_id
 
 
-def test_sift_module_step_false_skips_module_step(
-    pytester: pytest.Pytester, out_dir: Path
-) -> None:
+def test_sift_module_step_false_skips_module_step(pytester: pytest.Pytester, out_dir: Path) -> None:
     _write_ini(pytester, out_dir, sift_module_step="false")
     pytester.makepyfile(
         test_nomod=dedent(
@@ -643,9 +639,7 @@ def test_sift_module_step_false_still_drains_across_modules(
     assert test_x_parent != test_y_parent
 
 
-def test_package_step_default_opens_for_init_dirs(
-    pytester: pytest.Pytester, out_dir: Path
-) -> None:
+def test_package_step_default_opens_for_init_dirs(pytester: pytest.Pytester, out_dir: Path) -> None:
     """Default: a directory with ``__init__.py`` produces a parent package step."""
     pytester.mkpydir("pkg_a")
     (pytester.path / "pkg_a" / "test_x.py").write_text(
@@ -807,9 +801,7 @@ def test_single_parametrize_clusters_under_originalname(
     assert by_name["v=5.0"][0]["parent_step_id"] == test_rail_id
 
 
-def test_stacked_parametrize_nests_outer_to_inner(
-    pytester: pytest.Pytester, out_dir: Path
-) -> None:
+def test_stacked_parametrize_nests_outer_to_inner(pytester: pytest.Pytester, out_dir: Path) -> None:
     pytester.makepyfile(
         test_iso=dedent(
             """
@@ -1569,9 +1561,7 @@ def test_explicit_list_ids_on_inner_parametrize(pytester: pytest.Pytester, out_d
     assert by_name["two"][0]["parent_step_id"] == parent_id
 
 
-def test_callable_id_factory_on_inner_parametrize(
-    pytester: pytest.Pytester, out_dir: Path
-) -> None:
+def test_callable_id_factory_on_inner_parametrize(pytester: pytest.Pytester, out_dir: Path) -> None:
     """A callable ``ids=`` factory is invoked per value, just as pytest does."""
     pytester.makepyfile(
         test_cid=dedent(

--- a/python/lib/sift_client/_tests/pytest_plugin/test_offline.py
+++ b/python/lib/sift_client/_tests/pytest_plugin/test_offline.py
@@ -3,13 +3,15 @@
 Offline mode routes every create/update through the JSONL log file without
 contacting Sift. The session-start ping is skipped, the import worker is not
 spawned, and missing ``SIFT_*`` env vars are tolerated (placeholders are
-filled). Offline + ``--sift-log-file=none`` is rejected as a
+filled). Offline + ``--no-sift-log-file`` is rejected as a
 usage error since the log file is the sole sink in this mode.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable
+
+from sift_client._tests.pytest_plugin._step_status_capture import run_jsonl
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -43,10 +45,10 @@ class TestOfflineMode:
         pytester: pytest.Pytester,
         write_plugin_conftest: Callable[[], None],
     ) -> None:
-        """``--sift-log-file=none`` + ``--sift-offline`` is a usage error."""
+        """``--no-sift-log-file`` + ``--sift-offline`` is a usage error."""
         write_plugin_conftest()
         pytester.makepyfile("def test_should_not_run(): pass")
-        result = pytester.runpytest_subprocess("--sift-offline", "--sift-log-file=none")
+        result = pytester.runpytest_subprocess("--sift-offline", "--no-sift-log-file")
         assert result.ret != 0
         combined = "\n".join(result.outlines + result.errlines)
         assert "incompatible with --sift-offline" in combined, combined
@@ -83,8 +85,8 @@ class TestOfflineMode:
         clear_sift_env: None,
         write_plugin_conftest: Callable[[], None],
     ) -> None:
-        """Offline mode populates the pinned JSONL file with create/update entries."""
-        log_path = tmp_path / "run.jsonl"
+        """Offline mode populates the JSONL file in the output dir with create/update entries."""
+        out_dir = tmp_path / "sift-out"
         write_plugin_conftest()
         pytester.makepyfile(
             """
@@ -94,8 +96,9 @@ class TestOfflineMode:
                 ) is True
             """
         )
-        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-log-file={log_path}")
+        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-output-dir={out_dir}")
         result.assert_outcomes(passed=1)
+        log_path = run_jsonl(out_dir)
         assert log_path.exists(), f"offline mode did not create {log_path}"
         content = log_path.read_text()
         assert content.strip(), "log file is empty"

--- a/python/lib/sift_client/_tests/pytest_plugin/test_pass_fail.py
+++ b/python/lib/sift_client/_tests/pytest_plugin/test_pass_fail.py
@@ -55,19 +55,24 @@ _WARMUP = "def test_sift_warmup(): pass\n\n"
 
 def _run(pytester, body: str) -> None:
     pytester.makepyfile(_WARMUP + textwrap.dedent(body))
-    log_path = pytester.path / "sift.log"
-    capture.set_log(log_path)
-    pytester.runpytest_inprocess(
-        "--sift-offline",
-        f"--sift-log-file={log_path}",
-        "--no-sift-git-metadata",
-        # Pin the inner session to definition order so ``test_sift_warmup`` runs
-        # before a marker-skipped ``test_x`` (see ``_WARMUP``). ``-p no:randomly``
-        # is a no-op when pytest-randomly isn't installed, and keeps these tests
-        # deterministic when it is.
-        "-p",
-        "no:randomly",
-    )
+    out_dir = pytester.path / "sift-out"
+    # ``finally`` so the log is located even when the inner run raises
+    # KeyboardInterrupt out of the in-process session (the abort tests rely on
+    # this); the JSONL is written incrementally, so it exists by then.
+    try:
+        pytester.runpytest_inprocess(
+            "--sift-offline",
+            f"--sift-output-dir={out_dir}",
+            "--no-sift-git-metadata",
+            # Pin the inner session to definition order so ``test_sift_warmup``
+            # runs before a marker-skipped ``test_x`` (see ``_WARMUP``). ``-p
+            # no:randomly`` is a no-op when pytest-randomly isn't installed, and
+            # keeps these tests deterministic when it is.
+            "-p",
+            "no:randomly",
+        )
+    finally:
+        capture.set_log(capture.run_jsonl(out_dir))
 
 
 # ---------------------------------------------------------------------------
@@ -652,3 +657,91 @@ def test_abort_inside_substep_marks_every_open_step_aborted(inner):
     assert outer_sub.statuses[-1] == TestStatus.ABORTED
     assert inner_sub.statuses[-1] == TestStatus.ABORTED
     assert completed_sub.statuses[-1] == TestStatus.PASSED
+
+
+def test_session_abort_rolls_up_to_parents(inner):
+    # Case: API-07
+    _run(
+        inner,
+        """
+        import pytest
+        class TestFlash:
+            def test_flash(self, step):
+                step.report_outcome(name="flight check", result=False, reason="flash failed")
+                pytest.exit("flash failed; aborting session")
+        """,
+    )
+    # pytest.exit() aborts the whole session, so the leaf's fixture teardown is
+    # deferred to session unwind. The report-tree parents must resolve *after*
+    # that teardown, not before it: the leaf aborts and that result must roll up
+    # to the enclosing class and module rather than leaving them green. ABORTED
+    # stays on the leaf (the scope the exit fired in); the out-of-band container
+    # parents inherit FAILED, like any other non-pass child.
+    leaf = capture.test_step("test_flash")
+    substep = next(iter(capture.steps_by_name("flight check")), None)
+    klass = next(iter(capture.steps_by_name("TestFlash")), None)
+    assert leaf is not None
+    assert substep is not None
+    assert klass is not None
+    assert leaf.statuses[-1] == TestStatus.ABORTED
+    assert substep.statuses[-1] == TestStatus.FAILED
+    assert klass.statuses[-1] == TestStatus.FAILED
+    # The module step is the shallowest; it inherits the failure too.
+    module = min(capture._steps().values(), key=lambda s: s.step_path.count("."))
+    assert module.statuses[-1] == TestStatus.FAILED
+
+
+def test_keyboard_interrupt_rolls_up_to_parents(inner):
+    # Case: API-08
+    try:
+        _run(
+            inner,
+            """
+            class TestFlash:
+                def test_flash(self, step):
+                    step.report_outcome(name="flight check", result=False, reason="flash failed")
+                    raise KeyboardInterrupt
+            """,
+        )
+    except KeyboardInterrupt:
+        pass
+    # A real Ctrl-C is a system stop, not a failure: the plugin flags the session
+    # aborted (via pytest_keyboard_interrupt), so the leaf, the class, and the
+    # module all resolve to ABORTED. The failed substep keeps its own FAILED.
+    leaf = capture.test_step("test_flash")
+    substep = next(iter(capture.steps_by_name("flight check")), None)
+    klass = next(iter(capture.steps_by_name("TestFlash")), None)
+    assert leaf is not None
+    assert substep is not None
+    assert klass is not None
+    assert leaf.statuses[-1] == TestStatus.ABORTED
+    assert substep.statuses[-1] == TestStatus.FAILED
+    assert klass.statuses[-1] == TestStatus.ABORTED
+    module = min(capture._steps().values(), key=lambda s: s.step_path.count("."))
+    assert module.statuses[-1] == TestStatus.ABORTED
+
+
+def test_abort_helper_rolls_up_aborted(inner):
+    # Case: API-09
+    _run(
+        inner,
+        """
+        from sift_client.pytest_plugin import abort
+        class TestFlash:
+            def test_flash(self, step):
+                step.report_outcome(name="flight check", result=True)
+                abort("device under test lost power")
+        """,
+    )
+    # sift abort() is an explicit system stop: the leaf and every container, plus
+    # the report, resolve to ABORTED rather than FAILED, even though no check
+    # failed. (Contrast test_session_abort_rolls_up_to_parents, where a plain
+    # pytest.exit rolls the containers up as FAILED.)
+    leaf = capture.test_step("test_flash")
+    klass = next(iter(capture.steps_by_name("TestFlash")), None)
+    assert leaf is not None
+    assert klass is not None
+    assert leaf.statuses[-1] == TestStatus.ABORTED
+    assert klass.statuses[-1] == TestStatus.ABORTED
+    module = min(capture._steps().values(), key=lambda s: s.step_path.count("."))
+    assert module.statuses[-1] == TestStatus.ABORTED

--- a/python/lib/sift_client/_tests/pytest_plugin/test_report_fields.py
+++ b/python/lib/sift_client/_tests/pytest_plugin/test_report_fields.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Callable
 from google.protobuf import json_format
 from sift.metadata.v1.metadata_pb2 import MetadataValue
 
+from sift_client._tests.pytest_plugin._step_status_capture import run_jsonl
 from sift_client.util.metadata import metadata_proto_to_dict
 
 if TYPE_CHECKING:
@@ -51,7 +52,7 @@ class TestReportFields:
         write_plugin_conftest: Callable[[], None],
     ) -> None:
         """Every report-content field resolves from ``[tool.sift.pytest.report]``."""
-        log_path = tmp_path / "run.jsonl"
+        out_dir = tmp_path / "sift-out"
         write_plugin_conftest()
         pytester.makepyprojecttoml(
             """
@@ -64,7 +65,8 @@ class TestReportFields:
             """
         )
         pytester.makepyfile("def test_one(step): pass")
-        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-log-file={log_path}")
+        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-output-dir={out_dir}")
+        log_path = run_jsonl(out_dir)
         result.assert_outcomes(passed=1)
         report = _create_report_dict(log_path.read_text())
         assert report["testCase"] == "case-from-toml"
@@ -81,7 +83,7 @@ class TestReportFields:
         write_plugin_conftest: Callable[[], None],
     ) -> None:
         """``test_case`` accepts the same template placeholders as ``name``."""
-        log_path = tmp_path / "run.jsonl"
+        out_dir = tmp_path / "sift-out"
         write_plugin_conftest()
         pytester.makepyprojecttoml(
             """
@@ -90,7 +92,8 @@ class TestReportFields:
             """
         )
         pytester.makepyfile("def test_one(step): pass")
-        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-log-file={log_path}")
+        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-output-dir={out_dir}")
+        log_path = run_jsonl(out_dir)
         result.assert_outcomes(passed=1)
         report = _create_report_dict(log_path.read_text())
         assert report["testCase"].startswith("case-"), report["testCase"]
@@ -109,10 +112,11 @@ class TestReportFields:
         order or which path form was typed; the value is anchored to the
         rootdir (project) name.
         """
-        log_path = tmp_path / "run.jsonl"
+        out_dir = tmp_path / "sift-out"
         write_plugin_conftest()
         pytester.makepyfile(test_demo="def test_one(step): pass")
-        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-log-file={log_path}")
+        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-output-dir={out_dir}")
+        log_path = run_jsonl(out_dir)
         result.assert_outcomes(passed=1)
         report = _create_report_dict(log_path.read_text())
         assert report["testCase"] == f"{pytester.path.name}/test_demo.py::test_one", report[
@@ -127,14 +131,15 @@ class TestReportFields:
         write_plugin_conftest: Callable[[], None],
     ) -> None:
         """A parametrized single test drops the ``[param]`` suffix from the key."""
-        log_path = tmp_path / "run.jsonl"
+        out_dir = tmp_path / "sift-out"
         write_plugin_conftest()
         pytester.makepyfile(
             test_demo=(
                 "import pytest\n@pytest.mark.parametrize('v', [12])\ndef test_p(step, v): pass\n"
             )
         )
-        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-log-file={log_path}")
+        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-output-dir={out_dir}")
+        log_path = run_jsonl(out_dir)
         result.assert_outcomes(passed=1)
         report = _create_report_dict(log_path.read_text())
         assert report["testCase"] == f"{pytester.path.name}/test_demo.py::test_p", report[
@@ -149,10 +154,11 @@ class TestReportFields:
         write_plugin_conftest: Callable[[], None],
     ) -> None:
         """Multiple tests in one file -> the default target is that file (anchored)."""
-        log_path = tmp_path / "run.jsonl"
+        out_dir = tmp_path / "sift-out"
         write_plugin_conftest()
         pytester.makepyfile(test_demo="def test_a(step): pass\ndef test_b(step): pass")
-        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-log-file={log_path}")
+        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-output-dir={out_dir}")
+        log_path = run_jsonl(out_dir)
         result.assert_outcomes(passed=2)
         report = _create_report_dict(log_path.read_text())
         assert report["testCase"] == f"{pytester.path.name}/test_demo.py", report["testCase"]
@@ -165,12 +171,13 @@ class TestReportFields:
         write_plugin_conftest: Callable[[], None],
     ) -> None:
         """Tests across several files -> the default target is their common directory (anchored)."""
-        log_path = tmp_path / "run.jsonl"
+        out_dir = tmp_path / "sift-out"
         write_plugin_conftest()
         suite = pytester.mkdir("suite")
         (suite / "test_a.py").write_text("def test_a(step): pass\n")
         (suite / "test_b.py").write_text("def test_b(step): pass\n")
-        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-log-file={log_path}")
+        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-output-dir={out_dir}")
+        log_path = run_jsonl(out_dir)
         result.assert_outcomes(passed=2)
         report = _create_report_dict(log_path.read_text())
         assert report["testCase"] == f"{pytester.path.name}/suite", report["testCase"]
@@ -183,11 +190,12 @@ class TestReportFields:
         write_plugin_conftest: Callable[[], None],
     ) -> None:
         """Tests spanning the rootdir -> the default target is the bare project name."""
-        log_path = tmp_path / "run.jsonl"
+        out_dir = tmp_path / "sift-out"
         write_plugin_conftest()
         # Two files directly under rootdir -> common path is rootdir itself.
         pytester.makepyfile(test_a="def test_a(step): pass", test_b="def test_b(step): pass")
-        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-log-file={log_path}")
+        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-output-dir={out_dir}")
+        log_path = run_jsonl(out_dir)
         result.assert_outcomes(passed=2)
         report = _create_report_dict(log_path.read_text())
         assert report["testCase"] == pytester.path.name, report["testCase"]
@@ -201,7 +209,7 @@ class TestReportFields:
         write_plugin_conftest: Callable[[], None],
     ) -> None:
         """An env var wins over a value set in ``[tool.sift.pytest.report]``."""
-        log_path = tmp_path / "run.jsonl"
+        out_dir = tmp_path / "sift-out"
         monkeypatch.setenv("SIFT_REPORT_SYSTEM_OPERATOR", "env-wins")
         write_plugin_conftest()
         pytester.makepyprojecttoml(
@@ -211,7 +219,8 @@ class TestReportFields:
             """
         )
         pytester.makepyfile("def test_one(step): pass")
-        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-log-file={log_path}")
+        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-output-dir={out_dir}")
+        log_path = run_jsonl(out_dir)
         result.assert_outcomes(passed=1)
         report = _create_report_dict(log_path.read_text())
         assert report["systemOperator"] == "env-wins"
@@ -224,7 +233,7 @@ class TestReportFields:
         write_plugin_conftest: Callable[[], None],
     ) -> None:
         """``[tool.sift.pytest.report.metadata]`` keeps TOML types end-to-end."""
-        log_path = tmp_path / "run.jsonl"
+        out_dir = tmp_path / "sift-out"
         write_plugin_conftest()
         pytester.makepyprojecttoml(
             """
@@ -235,7 +244,8 @@ class TestReportFields:
             """
         )
         pytester.makepyfile("def test_one(step): pass")
-        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-log-file={log_path}")
+        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-output-dir={out_dir}")
+        log_path = run_jsonl(out_dir)
         result.assert_outcomes(passed=1)
         pairs = _metadata_pairs(_create_report_dict(log_path.read_text()))
         assert pairs.get("build_id") == "v1.2.3"

--- a/python/lib/sift_client/_tests/pytest_plugin/test_report_name.py
+++ b/python/lib/sift_client/_tests/pytest_plugin/test_report_name.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable
 
+from sift_client._tests.pytest_plugin._step_status_capture import run_jsonl
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -34,7 +36,7 @@ class TestReportName:
         write_plugin_conftest: Callable[[], None],
     ) -> None:
         """``[tool.sift.pytest.report] name`` renders placeholders into the report name."""
-        log_path = tmp_path / "run.jsonl"
+        out_dir = tmp_path / "sift-out"
         write_plugin_conftest()
         pytester.makepyprojecttoml(
             """
@@ -43,7 +45,8 @@ class TestReportName:
             """
         )
         pytester.makepyfile("def test_one(step): pass")
-        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-log-file={log_path}")
+        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-output-dir={out_dir}")
+        log_path = run_jsonl(out_dir)
         result.assert_outcomes(passed=1)
         line = _create_report_line(log_path.read_text())
         assert '"name":"TomlReport-1"' in line, line
@@ -56,10 +59,11 @@ class TestReportName:
         write_plugin_conftest: Callable[[], None],
     ) -> None:
         """The full pytest invocation is stored on the report metadata."""
-        log_path = tmp_path / "run.jsonl"
+        out_dir = tmp_path / "sift-out"
         write_plugin_conftest()
         pytester.makepyfile("def test_one(step): pass")
-        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-log-file={log_path}")
+        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-output-dir={out_dir}")
+        log_path = run_jsonl(out_dir)
         result.assert_outcomes(passed=1)
         line = _create_report_line(log_path.read_text())
         assert '"pytest_command"' in line, line
@@ -79,7 +83,7 @@ class TestReportName:
         checkout, so ``{git_branch}`` resolves to an empty string rather than
         triggering the unknown-placeholder fallback.
         """
-        log_path = tmp_path / "run.jsonl"
+        out_dir = tmp_path / "sift-out"
         write_plugin_conftest()
         pytester.makepyprojecttoml(
             """
@@ -88,7 +92,8 @@ class TestReportName:
             """
         )
         pytester.makepyfile("def test_one(step): pass")
-        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-log-file={log_path}")
+        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-output-dir={out_dir}")
+        log_path = run_jsonl(out_dir)
         result.assert_outcomes(passed=1)
         combined = "\n".join(result.outlines + result.errlines)
         assert "Invalid sift_report_name template" not in combined, combined
@@ -103,7 +108,7 @@ class TestReportName:
         write_plugin_conftest: Callable[[], None],
     ) -> None:
         """An unknown placeholder warns and falls back without aborting the session."""
-        log_path = tmp_path / "run.jsonl"
+        out_dir = tmp_path / "sift-out"
         write_plugin_conftest()
         pytester.makepyprojecttoml(
             """
@@ -112,7 +117,8 @@ class TestReportName:
             """
         )
         pytester.makepyfile("def test_one(step): pass")
-        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-log-file={log_path}")
+        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-output-dir={out_dir}")
+        log_path = run_jsonl(out_dir)
         result.assert_outcomes(passed=1)
         combined = "\n".join(result.outlines + result.errlines)
         assert "Invalid sift_report_name template" in combined, combined

--- a/python/lib/sift_client/_tests/pytest_plugin/test_terminal_output.py
+++ b/python/lib/sift_client/_tests/pytest_plugin/test_terminal_output.py
@@ -18,6 +18,7 @@ from sift_client._internal.pytest_plugin.terminal import (
     measurement_segments,
     step_count_segments,
 )
+from sift_client._tests.pytest_plugin._step_status_capture import run_jsonl
 from sift_client.sift_types.test_report import TestStatus
 
 if TYPE_CHECKING:
@@ -61,7 +62,7 @@ class TestResolveRealReportId:
     """``resolve_real_report_id`` maps the footer to the real server report id."""
 
     def test_synchronous_online_uses_report_id_directly(self) -> None:
-        # No log file, non-simulated report (``--sift-log-file=false`` path).
+        # No log file, non-simulated report (``--no-sift-log-file`` path).
         context = SimpleNamespace(
             report=SimpleNamespace(id_="real-123", is_simulated=False),
             log_file=None,
@@ -160,10 +161,11 @@ class TestOfflineFooter:
         write_plugin_conftest: Callable[[], None],
     ) -> None:
         """Offline footer points at the saved log file and the replay command."""
-        log_path = tmp_path / "run.jsonl"
+        out_dir = tmp_path / "sift-out"
         write_plugin_conftest()
         pytester.makepyfile("def test_runs(step): step.measure(name='v', value=1.0)")
-        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-log-file={log_path}")
+        result = pytester.runpytest_subprocess("--sift-offline", f"--sift-output-dir={out_dir}")
+        log_path = run_jsonl(out_dir)
         result.assert_outcomes(passed=1)
         result.stdout.fnmatch_lines(
             [
@@ -186,10 +188,10 @@ class TestOfflineFooter:
         write_plugin_conftest: Callable[[], None],
     ) -> None:
         """``--sift-open-report`` is a no-op offline (no resolvable URL) and never errors."""
-        log_path = tmp_path / "run.jsonl"
+        out_dir = tmp_path / "sift-out"
         write_plugin_conftest()
         pytester.makepyfile("def test_runs(step): step.measure(name='v', value=1.0)")
         result = pytester.runpytest_subprocess(
-            "--sift-offline", f"--sift-log-file={log_path}", "--sift-open-report"
+            "--sift-offline", f"--sift-output-dir={out_dir}", "--sift-open-report"
         )
         result.assert_outcomes(passed=1)

--- a/python/lib/sift_client/pytest_plugin.py
+++ b/python/lib/sift_client/pytest_plugin.py
@@ -18,17 +18,15 @@ import platform
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Generator
+from typing import Any, Generator, NoReturn
 
 import pytest
 
 from sift_client import SiftClient, SiftConnectionConfig
 from sift_client._internal.pytest_plugin.audit_log import (
     _make_session_dir,
-    audit_disabled,
     configure_audit_logging,
     detach_audit_handlers,
-    explicit_audit_path,
     log_event,
     render_report_tree,
     replay_audit_path,
@@ -45,7 +43,9 @@ from sift_client._internal.pytest_plugin.options import (
     APP_URL_OPTION,
     AUDIT_LOG_OPTION,
     GRPC_URI_OPTION,
+    LOG_FILE_OPTION,
     OPEN_OPTION,
+    OUTPUT_DIR_OPTION,
     REST_URI_OPTION,
     register_options,
     resolved_settings,
@@ -97,6 +97,7 @@ __all__ = [
     "ReportContext",
     "SiftPytestPluginWarning",
     "SiftPytestStepDrainWarning",
+    "abort",
     "client_has_connection",
     "report_context",
     "sift_client",
@@ -144,6 +145,35 @@ SIFT_AUDIT_LOG_STASH_KEY = pytest.StashKey[Path]()
 # ``<tmpdir>/sift_test_results/<random>/``. Read by ``report_context_impl``
 # to place the JSONL log alongside the audit log.
 SIFT_SESSION_DIR_STASH_KEY = pytest.StashKey[Path]()
+
+
+# ---------------------------------------------------------------------------
+# Public actions.
+# ---------------------------------------------------------------------------
+
+
+def abort(reason: str, returncode: int | None = None) -> NoReturn:
+    """Stop the pytest session and record the report and open parent steps as
+    ``ABORTED`` rather than ``FAILED``.
+
+    Use this for a system-level stop where the run was cut off rather than a test
+    failing, such as the device under test going away or a rig fault that makes
+    the remaining tests meaningless. The step that calls it and any open substeps
+    resolve to ``ABORTED``, and the enclosing class, module, package, and the
+    report inherit ``ABORTED`` too.
+
+    For a stop that should read as a failure, use ``pytest.exit`` (the default,
+    which rolls up ``FAILED``); for a single failing test, use ``pytest.fail``. A
+    real Ctrl-C / ``KeyboardInterrupt`` is treated the same as ``abort`` without
+    needing this call.
+
+    Args:
+        reason: Message shown by pytest and recorded as the stop reason.
+        returncode: Process exit code to pass through to ``pytest.exit``.
+    """
+    if REPORT_CONTEXT is not None:
+        REPORT_CONTEXT.session_aborted = True
+    pytest.exit(reason, returncode=returncode)
 
 
 # ---------------------------------------------------------------------------
@@ -427,14 +457,16 @@ def pytest_configure(config: pytest.Config) -> None:
         "sift_exclude: force the Sift autouse fixtures to skip this test "
         "regardless of the `sift_autouse` ini default.",
     )
-    # Create a session dir when audit logging is enabled and at its default path
-    # (not explicitly set by the user). This groups all temp artifacts —
-    # JSONL log, tracking sidecar, audit log, replay audit log — under one
-    # directory: ``<tmpdir>/sift_test_results/<random>/``.
-    raw_audit = AUDIT_LOG_OPTION.resolve(config)
+    # Create this run's artifact directory when either the JSONL log or the audit
+    # trace is enabled. Everything (JSONL log, tracking sidecar, audit log, replay
+    # audit log) lands inside it: ``<output-dir>/<random>/``, where the base is
+    # ``--sift-output-dir`` if set, else a temp directory. Each run gets its own
+    # random subfolder so repeated or concurrent runs never collide.
     session_dir: Path | None = None
-    if not audit_disabled(raw_audit) and explicit_audit_path(raw_audit) is None:
-        session_dir = _make_session_dir()
+    if AUDIT_LOG_OPTION.resolve(config) or LOG_FILE_OPTION.resolve(config):
+        output_dir = OUTPUT_DIR_OPTION.resolve(config)
+        base = Path(output_dir) if output_dir else None
+        session_dir = _make_session_dir(base)
         config.stash[SIFT_SESSION_DIR_STASH_KEY] = session_dir
 
     # Audit trace (on by default): attaches DEBUG file + WARNING stdout handlers
@@ -566,14 +598,38 @@ def pytest_runtest_logfinish(nodeid: str, location: tuple[str, int | None, str])
     release_finished_leaf(nodeid)
 
 
-def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+def pytest_keyboard_interrupt(excinfo: pytest.ExceptionInfo[BaseException]) -> None:
+    """Mark the session aborted for a real Ctrl-C / ``KeyboardInterrupt``.
+
+    pytest calls this for both ``KeyboardInterrupt`` and its own ``Exit``; only a
+    genuine interrupt (an operator or system stop) should roll up ABORTED. A
+    ``pytest.exit()`` raises ``Exit`` and is left in the FAILED bucket; the
+    ``abort()`` helper sets the flag itself before exiting, so it is unaffected by
+    the ``Exit`` case here.
+    """
+    if REPORT_CONTEXT is not None and excinfo.type is KeyboardInterrupt:
+        REPORT_CONTEXT.session_aborted = True
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
     """Close any report-tree parents still open at session end (innermost first).
 
     Normally a no-op: ``report_context_impl`` finalizes the parents inside the
     ``ReportContext`` block so their updates reach the log before the import
     worker drains, and most parents already closed early as their subtrees
     finished. This is the idempotent backstop for anything still open.
+
+    Runs as a hookwrapper so the drain happens *after* pytest's own
+    ``pytest_sessionfinish`` (``SetupState.teardown_exact``), which finalizes the
+    still-open leaf step and the session-scoped ``report_context`` fixture. On a
+    session abort (``pytest.exit``) the leaf's fixture teardown is deferred to
+    that point; finalizing parents before it would close them while their
+    descendant is still unresolved, so the abort/failure would not roll up. The
+    ``yield`` lets that teardown run first, leaving this call the no-op backstop
+    it is meant to be.
     """
+    yield
     finalize_parents()
 
 

--- a/python/lib/sift_client/scripts/import_test_result_log.py
+++ b/python/lib/sift_client/scripts/import_test_result_log.py
@@ -38,7 +38,7 @@ def _cleanup_temp_log(log_file: str) -> None:
 
     Called only when audit logging is off: without an audit trail there's no
     reason to retain the buffer, so default temp artifacts are reclaimed
-    immediately. An explicit ``--sift-log-file`` (not under the temp dir) is
+    immediately. An explicit ``--sift-output-dir`` (not under the temp dir) is
     the user's to keep and is never touched.
 
     Session-dir layout (``<tmpdir>/sift_test_results/<random>/``): the whole

--- a/python/lib/sift_client/util/test_results/__init__.py
+++ b/python/lib/sift_client/util/test_results/__init__.py
@@ -71,7 +71,7 @@ Override it by defining your own `sift_client` fixture in your conftest.
 
 Note: FedRAMP users: results are buffered to a temp file and uploaded by a
 subprocess at session end (no API calls during the run). Disable the buffer
-entirely with `--sift-log-file=false` for inline uploads.
+entirely with `--no-sift-log-file` for inline uploads.
 
 ### Controlling which tests produce reports
 
@@ -116,9 +116,11 @@ CLI options registered by the plugin:
   returns a real pass/fail boolean. Returned entities expose
   ``is_simulated == True``. Also honored via the `SIFT_DISABLED` env
   var. Supersedes every other flag.
-- `--sift-log-file`: Path to write the JSONL log file. `true`
-  (default) auto-creates a temp file. `false` or `none` disables logging.
-  Any other value is treated as a file path.
+- `--sift-output-dir`: Directory for this run's artifacts (JSONL log, audit
+  trace). Each run gets its own random subfolder. Defaults to a temp directory.
+- `--no-sift-log-file`: Disable the JSONL log (written by default). Incompatible
+  with `--sift-offline`, which needs the log as its only sink.
+- `--no-sift-audit-log`: Disable the DEBUG audit trace (written by default).
 - `--no-sift-git-metadata`: Exclude git metadata (repo, branch,
   commit) from the test report. Included by default.
 

--- a/python/lib/sift_client/util/test_results/context_manager.py
+++ b/python/lib/sift_client/util/test_results/context_manager.py
@@ -138,6 +138,17 @@ def _git_metadata() -> dict[str, str] | None:
         return None
 
 
+def _is_session_exit(exc_value: BaseException | None) -> bool:
+    """True for pytest's session-stopping ``Exit`` (``pytest.exit`` / sift ``abort``).
+
+    Matched by type name and module so this framework-agnostic module needs no
+    pytest import. ``SystemExit`` and ``KeyboardInterrupt`` are handled by their
+    own ``isinstance`` checks at the call site.
+    """
+    cls = type(exc_value)
+    return cls.__name__ == "Exit" and cls.__module__ == "_pytest.outcomes"
+
+
 class ReportContext(AbstractContextManager):
     """Context manager for a new TestReport. See usage example in __init__.py."""
 
@@ -159,6 +170,12 @@ class ReportContext(AbstractContextManager):
     # last-descendant-finish rather than wall-clock at session end.
     parent_end_times: dict[str, datetime]
     any_failures: bool
+    # Set when the run was stopped as a system-level abort (Ctrl-C, or the
+    # pytest plugin's ``abort()`` helper) rather than a failure. Parents and the
+    # report that close out-of-band during the unwind then resolve to ABORTED
+    # instead of FAILED. A plain ``pytest.exit()`` leaves this False, so it stays
+    # in the FAILED bucket.
+    session_aborted: bool
     # Every step created in this report (including hierarchy/parametrize
     # parents), retained after close so end-of-run summaries can tally final
     # statuses. ``update`` mutates step instances in place, so these references
@@ -233,6 +250,7 @@ class ReportContext(AbstractContextManager):
         self.open_step_results = {}
         self.parent_end_times = {}
         self.any_failures = False
+        self.session_aborted = False
         self.created_steps = []
         self.created_measurements = []
         self.replay_incomplete = False
@@ -328,7 +346,9 @@ class ReportContext(AbstractContextManager):
         update = {
             "end_time": datetime.now(timezone.utc),
         }
-        if self.any_failures or exc_type:
+        if self.session_aborted:
+            update["status"] = TestStatus.ABORTED
+        elif self.any_failures or exc_type:
             update["status"] = TestStatus.FAILED
         else:
             update["status"] = TestStatus.PASSED
@@ -345,7 +365,7 @@ class ReportContext(AbstractContextManager):
             #      Healthy worker with a large backlog; kill and surface
             #      replay instructions. 30 seconds is enough for a normal
             #      test suite to drain; pathological backlogs should opt
-            #      into inline mode (`--sift-log-file=false`) instead.
+            #      into inline mode (`--no-sift-log-file`) instead.
             #   3. Exited with non-zero. Connection failures and API call
             #      errors land here — the worker's replay loop has no retry,
             #      so the first failed RPC crashes the subprocess. Surface
@@ -543,6 +563,17 @@ class ReportContext(AbstractContextManager):
         if not outcome:
             self.open_step_results[step.step_path] = False
             self.any_failures = True
+            # Diagnostic: a failure recorded on this step's OWN scope (a failing
+            # report_outcome or an out-of-bounds measure), as distinct from one
+            # inherited from a child (which shows up as a step.propagate line).
+            # Lets a reader tell why a later step.resolve marks the step failed.
+            log_event(
+                logger,
+                logging.DEBUG,
+                "step.outcome",
+                step_path=step.step_path,
+                result="fail",
+            )
 
     def record_measurement(self, measurement: TestMeasurement) -> None:
         """Retain a recorded measurement for end-of-run summaries."""
@@ -557,7 +588,21 @@ class ReportContext(AbstractContextManager):
         self.any_failures = True
         path_parts = step.step_path.split(".")
         if len(path_parts) > 1:
-            self.open_step_results[".".join(path_parts[:-1])] = False
+            parent_path = ".".join(path_parts[:-1])
+            self.open_step_results[parent_path] = False
+            # Diagnostic: a teardown-phase failure fires after the step's own
+            # __exit__ has resolved, so it never runs through
+            # propagate_step_result. Log the parent roll-up here so it is traced
+            # like every other failure that reaches a parent.
+            log_event(
+                logger,
+                logging.DEBUG,
+                "step.propagate",
+                step_path=step.step_path,
+                status=step.status.name,
+                signal="teardown_fail",
+                parent=parent_path,
+            )
 
     def propagate_step_result(self, step: TestStep, status: TestStatus) -> bool:
         """Propagate this step's final status to the parent step.
@@ -573,7 +618,24 @@ class ReportContext(AbstractContextManager):
             self.open_step_results[step.step_path] = False
             path_parts = step.step_path.split(".")
             if len(path_parts) > 1:
-                self.open_step_results[".".join(path_parts[:-1])] = False
+                parent_path = ".".join(path_parts[:-1])
+                self.open_step_results[parent_path] = False
+                # Diagnostic: record the child→parent roll-up so the parent's
+                # eventual ``cause=child_failed`` can be traced back to the step
+                # that triggered it. The parent inherits a not-pass signal only;
+                # ABORTED stays on the step in whose scope the exit fired (and the
+                # substeps the exception unwinds through), so an aborted child
+                # still rolls up to its container parent as FAILED. ``signal``
+                # records the child's own terminal kind for the trace.
+                log_event(
+                    logger,
+                    logging.DEBUG,
+                    "step.propagate",
+                    step_path=step.step_path,
+                    status=status.name,
+                    signal="abort" if status == TestStatus.ABORTED else "fail",
+                    parent=parent_path,
+                )
         return succeeded
 
     def note_close(self, step: TestStep) -> None:
@@ -742,7 +804,43 @@ class NewStep(AbstractContextManager):
         header = f"{message} ({len(details)}):" if details else message
         pytest.fail("\n".join([header, *details]), pytrace=False)
 
-    def update_step_from_result(
+    def _log_resolve(self, step: TestStep, status: TestStatus, cause: str) -> None:
+        """Emit the ``step.resolve`` audit line: how this step's status was derived.
+
+        For ``cause=child_failed`` the failure bucket is split at log time into
+        ``measurement_failed`` (a failing measure on this step), ``own_failure``
+        (a failing report_outcome / manual record_step_outcome, which are not
+        distinguishable), or ``child_failed`` (a descendant failed, with ``from=``
+        naming the direct children and their statuses). Other causes log as-is.
+        The whole thing is guarded so the child scan only runs when audit is on.
+        """
+        if not logger.isEnabledFor(logging.DEBUG):
+            return
+        fields: dict[str, object] = {
+            "name": step.name,
+            "step_path": step.step_path,
+            "status": status.name,
+        }
+        if cause == "child_failed":
+            prefix = step.step_path + "."
+            child_depth = step.step_path.count(".") + 1
+            contributors = [
+                f"{s.step_path}:{s.status.name}"
+                for s in self.report_context.created_steps
+                if s.step_path.startswith(prefix)
+                and s.step_path.count(".") == child_depth
+                and s.status not in (TestStatus.PASSED, TestStatus.SKIPPED, TestStatus.IN_PROGRESS)
+            ]
+            if contributors:
+                fields["from"] = ",".join(contributors)
+            elif self._failed_measurement_count > 0:
+                cause = "measurement_failed"
+            else:
+                cause = "own_failure"
+        fields["cause"] = cause
+        log_event(logger, logging.DEBUG, "step.resolve", **fields)
+
+    def _update_step_from_result(
         self,
         exc: type[Exception] | None,
         exc_value: Exception | None,
@@ -779,10 +877,14 @@ class NewStep(AbstractContextManager):
                 # UI can show what was asserted.
                 self.report_context.record_step_outcome(False, current_step)
                 error_info = format_assertion_message(exc, exc_value)
-            elif isinstance(exc_value, (KeyboardInterrupt, SystemExit)):
-                # Hard exit propagating through the substep stack: record as
-                # ABORTED so every in-progress step on the way out reflects
-                # the abort rather than coercing to ERROR.
+            elif isinstance(exc_value, (KeyboardInterrupt, SystemExit)) or _is_session_exit(
+                exc_value
+            ):
+                # Hard exit propagating through the step stack: a SystemExit /
+                # KeyboardInterrupt, or pytest's session-stopping Exit
+                # (pytest.exit / sift abort). Record ABORTED so every in-progress
+                # step the exit unwinds through reflects the cut-off rather than
+                # coercing to ERROR.
                 aborted = True
                 error_info = format_truncated_traceback(exc, exc_value, tb)
             else:
@@ -792,10 +894,11 @@ class NewStep(AbstractContextManager):
         # Status is the governor: anything other than IN_PROGRESS was set
         # deliberately (manual override, plugin pre-resolution, etc.) and must
         # not be silently overwritten by side-channel signals. When the step is
-        # still IN_PROGRESS, resolve from independent state: aborts first, then
-        # a child-failed signal (parents inherit FAILED, not the originating
-        # ERROR), then the step's own captured exception, then the children-pass
-        # default. error_info is diagnostic and never drives status.
+        # still IN_PROGRESS, resolve from independent state: the step's own abort
+        # first, then a child-failed signal (parents inherit FAILED, not the
+        # originating ERROR or ABORTED), then the step's own captured exception,
+        # then the children-pass default. error_info is diagnostic and never
+        # drives status.
         status = current_step.status
         if status == TestStatus.IN_PROGRESS:
             children_passed = self.report_context.open_step_results.get(
@@ -803,12 +906,30 @@ class NewStep(AbstractContextManager):
             )
             if aborted:
                 status = TestStatus.ABORTED
+                cause = "own_abort"
+            elif self.report_context.session_aborted:
+                # The run was stopped as a system abort (Ctrl-C / sift abort).
+                # A parent closing out-of-band during the unwind inherits
+                # ABORTED rather than FAILED, so the abort reaches the
+                # containers and report. A plain pytest.exit() leaves the flag
+                # unset and falls through to FAILED below.
+                status = TestStatus.ABORTED
+                cause = "session_aborted"
             elif not children_passed:
                 status = TestStatus.FAILED
+                cause = "child_failed"
             elif errored:
                 status = TestStatus.ERROR
+                cause = "own_error"
             else:
                 status = TestStatus.PASSED
+                cause = "clean"
+        else:
+            # Status was set deliberately upstream (manual override or plugin
+            # pre-resolution) before this resolver ran.
+            cause = "preset"
+
+        self._log_resolve(current_step, status, cause)
 
         # Propagate based on the resolved status; error_info rides along as
         # pure diagnostics and does not affect propagation.
@@ -859,6 +980,10 @@ class NewStep(AbstractContextManager):
                 # The step was never opened; nothing to propagate.
                 return True
             override = getattr(self, "_sift_end_time_override", None)
+            # Status was resolved upstream (pytest phase reports / manual
+            # override); log it like the in-resolver path so every step has a
+            # traceable ``step.resolve`` line.
+            self._log_resolve(current_step, current_step.status, "external")
             result = self.report_context.propagate_step_result(current_step, current_step.status)
             current_step.update(
                 {
@@ -874,7 +999,7 @@ class NewStep(AbstractContextManager):
                 result = self.force_result
             return result
 
-        result = self.update_step_from_result(
+        result = self._update_step_from_result(
             exc, exc_value, tb, end_time=getattr(self, "_sift_end_time_override", None)
         )
 


### PR DESCRIPTION
## Pass/fail behavior

- **Roll-up ordering fix (the core bug).** On a session abort, the report-tree parent steps (class/module/package) were finalized before the cut-off leaf resolved, so they closed `PASSED` even though a descendant aborted or failed. `pytest_sessionfinish` now runs as a hookwrapper that drains open parents *after* pytest's fixture teardown (`yield`, then `finalize_parents()`), so a leaf's result reaches its parents.
- Add `sift_client.pytest_plugin.abort(reason)`: stops the session and records the report and open parent steps as `ABORTED`. A real Ctrl-C / `KeyboardInterrupt` does the same. `pytest.exit()` and ordinary test failures roll up as `FAILED`.
- An open substep interrupted by `pytest.exit()` now resolves `ABORTED` instead of `ERROR`.

## Audit log

- Add `step.outcome`, `step.propagate`, and `step.resolve` (with `cause` and `from=`) events so the audit trace shows why each step resolved to its status: own measurement/outcome failure, inherited child failure, or abort.

## Config (breaking)

- Add `--sift-output-dir` / `sift_output_dir` for the run's artifact directory; each run nests a random subfolder, defaulting to a temp dir.
- Replace the path-valued `--sift-log-file` / `--sift-audit-log` with boolean disable flags `--no-sift-log-file` / `--no-sift-audit-log`. The JSONL log and audit trace are still written by default; these flags turn them off. Pinning an individual log-file path is no longer supported; use `--sift-output-dir`.

## Docs and tests

- Document when to use `abort()` vs `pytest.exit()` vs `pytest.fail()` (overview, pass/fail guide, docstring). Update the settings reference and migrate the plugin test suite to `--sift-output-dir`.
