### PR TITLE
python(feat): add time range to reports.create_from_rules

### DIFF
--- a/python/lib/sift_client/_tests/resources/test_reports.py
+++ b/python/lib/sift_client/_tests/resources/test_reports.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -217,6 +218,32 @@ class TestReportsWaitUntilComplete:
 
         reports_api_async_mock_client.client.async_.jobs.get.assert_awaited_once_with(job_id=job_id)
         reports_api_async_mock_client.client.async_.jobs.wait_until_complete.assert_not_awaited()
+
+
+class TestReportsCreateFromRules:
+    """Unit tests for ReportsAPIAsync.create_from_rules argument forwarding."""
+
+    @pytest.mark.asyncio
+    async def test_forwards_time_range_to_evaluate_rules(self, reports_api_async_mock_client):
+        evaluate_rules = AsyncMock(return_value=(0, None, None))
+        reports_api_async_mock_client._rules_low_level_client.evaluate_rules = evaluate_rules
+        start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+        await reports_api_async_mock_client.create_from_rules(
+            name="report",
+            run="run-1",
+            rules=["rule-1"],
+            start_time=start,
+            end_time=end,
+        )
+
+        evaluate_rules.assert_awaited_once()
+        kwargs = evaluate_rules.await_args.kwargs
+        assert kwargs["start_time"] == start
+        assert kwargs["end_time"] == end
+        assert kwargs["run_id"] == "run-1"
+        assert kwargs["rule_ids"] == ["rule-1"]
 
 
 @pytest.mark.integration

--- a/python/lib/sift_client/resources/reports.py
+++ b/python/lib/sift_client/resources/reports.py
@@ -200,6 +200,8 @@ class ReportsAPIAsync(ResourceBase):
         run: Run | str | None = None,
         organization_id: str | None = None,
         rules: list[Rule] | list[str],
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
     ) -> Job | None:
         """Create a new report from rules.
 
@@ -208,6 +210,10 @@ class ReportsAPIAsync(ResourceBase):
             run: The run or run ID to associate with the report.
             organization_id: The organization ID.
             rules: List of rules or rule IDs to include in the report.
+            start_time: Start of the time range to evaluate rules over. Ignored unless end_time
+                is also set and a run is provided.
+            end_time: End of the time range to evaluate rules over. Ignored unless start_time
+                is also set and a run is provided.
 
         Returns:
             The Job for the pending report, or None if no report was created.
@@ -215,6 +221,8 @@ class ReportsAPIAsync(ResourceBase):
         _annotation_count, _report_id, job = await self._rules_low_level_client.evaluate_rules(
             run_id=run._id_or_error if isinstance(run, Run) else run,
             organization_id=organization_id,
+            start_time=start_time,
+            end_time=end_time,
             rule_ids=[rule._id_or_error if isinstance(rule, Rule) else rule for rule in rules]
             or [],
             report_name=name,
@@ -237,8 +245,10 @@ class ReportsAPIAsync(ResourceBase):
             run: The run or run ID to associate with the report.
             organization_id: The organization ID.
             name: Optional name for the report.
-            start_time: Optional start time to evaluate rules against.
-            end_time: Optional end time to evaluate rules against.
+            start_time: Start of the time range to evaluate rules over. Ignored unless end_time
+                is also set and a run is provided.
+            end_time: End of the time range to evaluate rules over. Ignored unless start_time
+                is also set and a run is provided.
 
         Returns:
             The Job for the pending report, or None if no report was created.

--- a/python/lib/sift_client/resources/runs.py
+++ b/python/lib/sift_client/resources/runs.py
@@ -217,15 +217,24 @@ class RunsAPIAsync(ResourceBase):
     ) -> Run:
         """Create a new run.
 
-        Note on assets: You do not need to provide asset info when creating a run.
-        If you pass a Run to future ingestion configs associated with assets, the association will happen automatically then.
-        However, if you do pass assets and set associate_new_data=True, future ingested data that falls within the Run's time period will be associated with the Run. Even if that data's timestamp is in the past, if it has not been ingested yet and the Run's timestamp envelopes it, it will be associated with the Run. This may be useful if you want to capture a time range for a specific asset or won't know about this Run when ingesting to that asset.
-        If the data has already been ingested, leave associate_new_data=False.
+        The behavior depends on the arguments:
+
+        - No assets: a standard run. Assets are associated later, automatically, when the run is
+          used in their ingestion configs, so asset info is not needed up front.
+        - assets, associate_new_data=False (default): an adhoc run over the assets' existing data
+          within the run's time period. Nothing is imported.
+        - assets, associate_new_data=True: a standard run that also captures data ingested later.
+          Data is associated when it lands in one of the assets within the run's time period,
+          even if its timestamp is in the past.
 
         Args:
-            create: The Run definition to create.
-            assets: List of assets to associate with the run. Note: if you are associating new data, you must provide assets/asset names.
-            associate_new_data: If True, future ingested data that falls within the Run's time period will be associated with the Run. Even if that data's timestamp is in the past, if it has not been ingested yet and the Run's timestamp envelopes it, it will be associated with the Run.
+            create: The run definition. For an adhoc run, set start_time and stop_time to bound
+                the window.
+            assets: Assets to associate with the run; required when associate_new_data is True.
+                Asset objects work in either mode. A bare string is read as an asset ID for an
+                adhoc run, and as an asset name when associate_new_data is True.
+            associate_new_data: If True, associate data ingested after the run is created that
+                falls within its time period. Requires assets.
 
         Returns:
             The created Run.

--- a/python/lib/sift_client/resources/sync_stubs/__init__.pyi
+++ b/python/lib/sift_client/resources/sync_stubs/__init__.pyi
@@ -1679,15 +1679,24 @@ class RunsAPI:
     ) -> Run:
         """Create a new run.
 
-        Note on assets: You do not need to provide asset info when creating a run.
-        If you pass a Run to future ingestion configs associated with assets, the association will happen automatically then.
-        However, if you do pass assets and set associate_new_data=True, future ingested data that falls within the Run's time period will be associated with the Run. Even if that data's timestamp is in the past, if it has not been ingested yet and the Run's timestamp envelopes it, it will be associated with the Run. This may be useful if you want to capture a time range for a specific asset or won't know about this Run when ingesting to that asset.
-        If the data has already been ingested, leave associate_new_data=False.
+        The behavior depends on the arguments:
+
+        - No assets: a standard run. Assets are associated later, automatically, when the run is
+          used in their ingestion configs, so asset info is not needed up front.
+        - assets, associate_new_data=False (default): an adhoc run over the assets' existing data
+          within the run's time period. Nothing is imported.
+        - assets, associate_new_data=True: a standard run that also captures data ingested later.
+          Data is associated when it lands in one of the assets within the run's time period,
+          even if its timestamp is in the past.
 
         Args:
-            create: The Run definition to create.
-            assets: List of assets to associate with the run. Note: if you are associating new data, you must provide assets/asset names.
-            associate_new_data: If True, future ingested data that falls within the Run's time period will be associated with the Run. Even if that data's timestamp is in the past, if it has not been ingested yet and the Run's timestamp envelopes it, it will be associated with the Run.
+            create: The run definition. For an adhoc run, set start_time and stop_time to bound
+                the window.
+            assets: Assets to associate with the run; required when associate_new_data is True.
+                Asset objects work in either mode. A bare string is read as an asset ID for an
+                adhoc run, and as an asset name when associate_new_data is True.
+            associate_new_data: If True, associate data ingested after the run is created that
+                falls within its time period. Requires assets.
 
         Returns:
             The created Run.

--- a/python/lib/sift_client/resources/sync_stubs/__init__.pyi
+++ b/python/lib/sift_client/resources/sync_stubs/__init__.pyi
@@ -1204,8 +1204,10 @@ class ReportsAPI:
             run: The run or run ID to associate with the report.
             organization_id: The organization ID.
             name: Optional name for the report.
-            start_time: Optional start time to evaluate rules against.
-            end_time: Optional end time to evaluate rules against.
+            start_time: Start of the time range to evaluate rules over. Ignored unless end_time
+                is also set and a run is provided.
+            end_time: End of the time range to evaluate rules over. Ignored unless start_time
+                is also set and a run is provided.
 
         Returns:
             The Job for the pending report, or None if no report was created.
@@ -1240,6 +1242,8 @@ class ReportsAPI:
         run: Run | str | None = None,
         organization_id: str | None = None,
         rules: list[Rule] | list[str],
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
     ) -> Job | None:
         """Create a new report from rules.
 
@@ -1248,6 +1252,10 @@ class ReportsAPI:
             run: The run or run ID to associate with the report.
             organization_id: The organization ID.
             rules: List of rules or rule IDs to include in the report.
+            start_time: Start of the time range to evaluate rules over. Ignored unless end_time
+                is also set and a run is provided.
+            end_time: End of the time range to evaluate rules over. Ignored unless start_time
+                is also set and a run is provided.
 
         Returns:
             The Job for the pending report, or None if no report was created.


### PR DESCRIPTION
## Summary
Add optional `start_time`/`end_time` to `reports.create_from_rules`, matching `create_from_applicable_rules`. Also clarifies the `Runs.create()` docstring around adhoc runs. 

## Validation
- Unit test covers the new time-range forwarding, existing reports tests pass.

