### PR TITLE
rust(feat): update asset tool mcp

### DIFF
--- a/rust/crates/sift_cli/assets/docs/src/agents/mcp.md
+++ b/rust/crates/sift_cli/assets/docs/src/agents/mcp.md
@@ -41,6 +41,7 @@ not run interactively.
 | `get_data`       | Download channel data for an asset/run to a Parquet file, with optional decimation. |
 | `sql`            | Run SQL over one or more Parquet files; chain after `get_data` for analysis.  |
 | `upload_dataset` | Stream a Parquet dataset into Sift.                                           |
+| `update_asset`   | Update an asset's tags and/or metadata (replace semantics).                   |
 | `create_rule`    | Create a rule from a JSON definition.                                         |
 | `update_rule`    | Update specific fields of a rule; unspecified fields are preserved.          |
 | `archive_rule`   | Archive a rule so it stops evaluating.                                        |

--- a/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
+++ b/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
@@ -21,6 +21,8 @@ to combine them when working with Sift.
    - `get_data`: download channel data for an asset/run to a Parquet file.
    - `sql`: run SQL over one or more Parquet files (chain after `get_data`).
    - `upload_dataset`: stream a Parquet dataset into Sift.
+   - `update_asset`: replace an existing asset's tags and/or metadata (write —
+     replace semantics, so read-modify-write when appending).
    - `create_rule`, `update_rule`, `archive_rule`, `unarchive_rule`: manage rules
      (writes — confirm the change with the user first).
    - `explore_url`: build a Sift Explore deep-link for an asset/run/channel

--- a/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
@@ -35,6 +35,8 @@ to combine them when working with Sift.
    - `get_data`: download channel data for an asset/run to a Parquet file.
    - `sql`: run SQL over one or more Parquet files (chain after `get_data`).
    - `upload_dataset`: stream a Parquet dataset into Sift.
+   - `update_asset`: replace an existing asset's tags and/or metadata (write —
+     replace semantics, so read-modify-write when appending).
    - `create_rule`, `update_rule`, `archive_rule`, `unarchive_rule`: manage rules
      (writes — confirm the change with the user first).
    - `explore_url`: build a Sift Explore deep-link for an asset/run/channel

--- a/rust/crates/sift_mcp/src/service/assets/mod.rs
+++ b/rust/crates/sift_mcp/src/service/assets/mod.rs
@@ -1,11 +1,14 @@
 use crate::policy::{RetryPolicy, with_retry};
 use crate::service::common;
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
+use pbjson_types::FieldMask;
 use sift_rs::{
     SiftChannel,
     assets::v1::{
-        Asset, ListAssetsRequest, ListAssetsResponse, asset_service_client::AssetServiceClient,
+        Asset, ListAssetsRequest, ListAssetsResponse, UpdateAssetRequest,
+        asset_service_client::AssetServiceClient,
     },
+    metadata::v1::MetadataValue,
 };
 
 #[cfg(test)]
@@ -80,5 +83,58 @@ impl AssetService {
         results.truncate(record_limit);
 
         Ok(results)
+    }
+
+    /// Update a subset of an existing asset's fields. Per
+    /// `protos/sift/assets/v1/assets.proto::UpdateAssetRequest`, the updatable
+    /// fields are `tags`, `metadata`, `archived_date`, and `is_archived`. This
+    /// service exposes `tags` and `metadata` only; archive flow has its own
+    /// dedicated RPC and would be a separate tool.
+    ///
+    /// Both `tags` and `metadata` use REPLACE semantics — passing `Some(vec![])`
+    /// clears the field. The caller is responsible for read-modify-write when
+    /// appending.
+    pub async fn update_asset(
+        &self,
+        asset_id: String,
+        tags: Option<Vec<String>>,
+        metadata: Option<Vec<MetadataValue>>,
+    ) -> Result<Asset> {
+        let mut asset = Asset {
+            asset_id,
+            ..Default::default()
+        };
+        let mut paths = Vec::new();
+
+        if let Some(v) = tags {
+            asset.tags = v;
+            paths.push("tags".to_string());
+        }
+        if let Some(v) = metadata {
+            asset.metadata = v;
+            paths.push("metadata".to_string());
+        }
+
+        let grpc_channel = self.channel.clone();
+        let resp = with_retry(&self.policy, move || {
+            let grpc_channel = grpc_channel.clone();
+            let asset = asset.clone();
+            let paths = paths.clone();
+            async move {
+                let mut client = AssetServiceClient::new(grpc_channel);
+                client
+                    .update_asset(UpdateAssetRequest {
+                        asset: Some(asset),
+                        update_mask: Some(FieldMask { paths }),
+                    })
+                    .await
+                    .map(|resp| resp.into_inner())
+            }
+        })
+        .await
+        .context("failed to update asset")?;
+
+        resp.asset
+            .ok_or_else(|| anyhow!("update_asset response missing asset"))
     }
 }

--- a/rust/crates/sift_mcp/src/service/assets/test.rs
+++ b/rust/crates/sift_mcp/src/service/assets/test.rs
@@ -276,7 +276,10 @@ async fn update_asset_tags_only_sets_tags_mask() {
 
     assert_eq!(updated.asset_id, "a1");
     assert_eq!(updated.name, "engine");
-    assert_eq!(updated.tags, vec!["primary".to_string(), "prod".to_string()]);
+    assert_eq!(
+        updated.tags,
+        vec!["primary".to_string(), "prod".to_string()]
+    );
 }
 
 #[tokio::test]
@@ -429,5 +432,8 @@ async fn update_asset_errors_when_response_missing_asset() {
         .await
         .expect_err("expected error");
 
-    assert!(err.to_string().contains("update_asset response missing asset"));
+    assert!(
+        err.to_string()
+            .contains("update_asset response missing asset")
+    );
 }

--- a/rust/crates/sift_mcp/src/service/assets/test.rs
+++ b/rust/crates/sift_mcp/src/service/assets/test.rs
@@ -1,4 +1,11 @@
-use sift_rs::assets::v1::{Asset, ListAssetsResponse, asset_service_server::AssetServiceServer};
+use sift_rs::{
+    assets::v1::{
+        Asset, ListAssetsResponse, UpdateAssetResponse, asset_service_server::AssetServiceServer,
+    },
+    metadata::v1::{
+        MetadataKey, MetadataKeyType, MetadataValue, metadata_value::Value as MetadataValueInner,
+    },
+};
 use sift_test_util::{grpc::memory_sift_channel, mock::assets::v1::MockAssetServiceImpl};
 use tokio::task::JoinHandle;
 use tonic::{Response, Status, transport::Server};
@@ -6,6 +13,18 @@ use tonic::{Response, Status, transport::Server};
 use super::AssetService;
 use crate::policy::RetryPolicy;
 use crate::service::common::PAGE_SIZE;
+
+fn string_metadata(name: &str, value: &str) -> MetadataValue {
+    MetadataValue {
+        key: Some(MetadataKey {
+            name: name.into(),
+            r#type: MetadataKeyType::String.into(),
+            ..Default::default()
+        }),
+        value: Some(MetadataValueInner::StringValue(value.into())),
+        ..Default::default()
+    }
+}
 
 async fn service_with_mock(mock: MockAssetServiceImpl) -> (AssetService, JoinHandle<()>) {
     let (client, server) = tokio::io::duplex(1024);
@@ -221,4 +240,194 @@ async fn list_assets_propagates_grpc_error() {
         .expect_err("expected error");
 
     assert!(err.to_string().contains("failed to query assets"));
+}
+
+#[tokio::test]
+async fn update_asset_tags_only_sets_tags_mask() {
+    let mut mock = MockAssetServiceImpl::new();
+    mock.expect_update_asset()
+        .times(1)
+        .withf(|req| {
+            let req = req.get_ref();
+            let asset = req.asset.as_ref().expect("asset present");
+            let mask = req.update_mask.as_ref().expect("mask present");
+            asset.asset_id == "a1"
+                && asset.tags == vec!["primary".to_string(), "prod".to_string()]
+                && asset.metadata.is_empty()
+                && mask.paths == vec!["tags".to_string()]
+        })
+        .returning(|req| {
+            let req = req.into_inner();
+            let mut asset = req.asset.expect("asset present");
+            asset.name = "engine".into();
+            Ok(Response::new(UpdateAssetResponse { asset: Some(asset) }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let updated = service
+        .update_asset(
+            "a1".to_string(),
+            Some(vec!["primary".into(), "prod".into()]),
+            None,
+        )
+        .await
+        .expect("update_asset failed");
+
+    assert_eq!(updated.asset_id, "a1");
+    assert_eq!(updated.name, "engine");
+    assert_eq!(updated.tags, vec!["primary".to_string(), "prod".to_string()]);
+}
+
+#[tokio::test]
+async fn update_asset_metadata_only_sets_metadata_mask() {
+    let mut mock = MockAssetServiceImpl::new();
+    mock.expect_update_asset()
+        .times(1)
+        .withf(|req| {
+            let req = req.get_ref();
+            let asset = req.asset.as_ref().expect("asset present");
+            let mask = req.update_mask.as_ref().expect("mask present");
+            asset.asset_id == "a2"
+                && asset.tags.is_empty()
+                && asset.metadata.len() == 1
+                && asset
+                    .metadata
+                    .first()
+                    .and_then(|v| v.key.as_ref().map(|k| k.name.as_str()))
+                    == Some("mission")
+                && mask.paths == vec!["metadata".to_string()]
+        })
+        .returning(|req| {
+            let req = req.into_inner();
+            Ok(Response::new(UpdateAssetResponse { asset: req.asset }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let updated = service
+        .update_asset(
+            "a2".to_string(),
+            None,
+            Some(vec![string_metadata("mission", "varda-m6")]),
+        )
+        .await
+        .expect("update_asset failed");
+
+    assert_eq!(updated.asset_id, "a2");
+    assert_eq!(updated.metadata.len(), 1);
+}
+
+#[tokio::test]
+async fn update_asset_both_fields_sets_both_mask_paths_in_order() {
+    let mut mock = MockAssetServiceImpl::new();
+    mock.expect_update_asset()
+        .times(1)
+        .withf(|req| {
+            let mask = req.get_ref().update_mask.as_ref().expect("mask present");
+            mask.paths == vec!["tags".to_string(), "metadata".to_string()]
+        })
+        .returning(|req| {
+            let req = req.into_inner();
+            Ok(Response::new(UpdateAssetResponse { asset: req.asset }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    service
+        .update_asset(
+            "a3".to_string(),
+            Some(vec!["x".into()]),
+            Some(vec![string_metadata("mission", "varda-m6")]),
+        )
+        .await
+        .expect("update_asset failed");
+}
+
+#[tokio::test]
+async fn update_asset_empty_tags_clears_tags_with_mask_set() {
+    // Passing Some(vec![]) explicitly is the agent's way of clearing all tags.
+    // The mask must still include `tags` so the server replaces the field.
+    let mut mock = MockAssetServiceImpl::new();
+    mock.expect_update_asset()
+        .times(1)
+        .withf(|req| {
+            let req = req.get_ref();
+            let asset = req.asset.as_ref().expect("asset present");
+            let mask = req.update_mask.as_ref().expect("mask present");
+            asset.tags.is_empty() && mask.paths == vec!["tags".to_string()]
+        })
+        .returning(|req| {
+            let req = req.into_inner();
+            Ok(Response::new(UpdateAssetResponse { asset: req.asset }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    service
+        .update_asset("a4".to_string(), Some(vec![]), None)
+        .await
+        .expect("update_asset failed");
+}
+
+#[tokio::test]
+async fn update_asset_no_fields_sends_empty_mask() {
+    // Tool handler validates this case before calling the service, but the
+    // service contract is to send whatever the caller provided. Verify the
+    // request carries an empty mask and an asset with only the id set.
+    let mut mock = MockAssetServiceImpl::new();
+    mock.expect_update_asset()
+        .times(1)
+        .withf(|req| {
+            let req = req.get_ref();
+            let asset = req.asset.as_ref().expect("asset present");
+            let mask = req.update_mask.as_ref().expect("mask present");
+            asset.asset_id == "a5"
+                && asset.tags.is_empty()
+                && asset.metadata.is_empty()
+                && mask.paths.is_empty()
+        })
+        .returning(|req| {
+            let req = req.into_inner();
+            Ok(Response::new(UpdateAssetResponse { asset: req.asset }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    service
+        .update_asset("a5".to_string(), None, None)
+        .await
+        .expect("update_asset failed");
+}
+
+#[tokio::test]
+async fn update_asset_propagates_grpc_error() {
+    let mut mock = MockAssetServiceImpl::new();
+    mock.expect_update_asset()
+        .returning(|_| Err(Status::not_found("asset missing")));
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let err = service
+        .update_asset("missing".to_string(), Some(vec!["x".into()]), None)
+        .await
+        .expect_err("expected error");
+
+    assert!(err.to_string().contains("failed to update asset"));
+}
+
+#[tokio::test]
+async fn update_asset_errors_when_response_missing_asset() {
+    let mut mock = MockAssetServiceImpl::new();
+    mock.expect_update_asset()
+        .returning(|_| Ok(Response::new(UpdateAssetResponse { asset: None })));
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let err = service
+        .update_asset("a6".to_string(), Some(vec!["x".into()]), None)
+        .await
+        .expect_err("expected error");
+
+    assert!(err.to_string().contains("update_asset response missing asset"));
 }

--- a/rust/crates/sift_mcp/src/tool/assets/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/assets/mod.rs
@@ -113,10 +113,7 @@ impl SiftMcpServer {
         ",
         annotations(title = "assets_router/update_asset", read_only_hint = false)
     )]
-    pub async fn update_asset(
-        &self,
-        params: Parameters<UpdateAssetParams>,
-    ) -> error::McpResult {
+    pub async fn update_asset(&self, params: Parameters<UpdateAssetParams>) -> error::McpResult {
         let Parameters(UpdateAssetParams {
             asset_id,
             tags,
@@ -124,7 +121,10 @@ impl SiftMcpServer {
         }) = params;
 
         if asset_id.is_empty() {
-            return Err(ErrorData::invalid_params("`asset_id` must not be empty", None));
+            return Err(ErrorData::invalid_params(
+                "`asset_id` must not be empty",
+                None,
+            ));
         }
         if tags.is_none() && metadata.is_none() {
             return Err(ErrorData::invalid_params(
@@ -133,8 +133,7 @@ impl SiftMcpServer {
             ));
         }
 
-        let metadata =
-            metadata.map(|m| m.into_iter().map(MetadataValue::from).collect::<Vec<_>>());
+        let metadata = metadata.map(|m| m.into_iter().map(MetadataValue::from).collect::<Vec<_>>());
 
         let asset = self
             .asset_service

--- a/rust/crates/sift_mcp/src/tool/assets/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/assets/mod.rs
@@ -1,10 +1,25 @@
-use rmcp::{handler::server::wrapper::Parameters, model::CallToolResult, tool, tool_router};
+use rmcp::{
+    ErrorData,
+    handler::server::wrapper::Parameters,
+    model::{CallToolResult, Content},
+    schemars::{self, JsonSchema},
+    tool, tool_router,
+};
+use serde::Deserialize;
+use sift_rs::metadata::v1::MetadataValue;
 
 use crate::{
     error::{self, from_anyhow},
     server::SiftMcpServer,
-    tool::common::ListParams,
+    tool::{common::ListParams, data::MetadataEntry},
 };
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UpdateAssetParams {
+    asset_id: String,
+    tags: Option<Vec<String>>,
+    metadata: Option<Vec<MetadataEntry>>,
+}
 
 #[cfg(test)]
 mod test;
@@ -56,5 +71,89 @@ impl SiftMcpServer {
             .map_err(from_anyhow)?;
 
         Ok(CallToolResult::structured(out))
+    }
+
+    #[tool(
+        name = "update_asset",
+        description = "
+            Update an existing asset's tags and/or metadata. Wraps `assets/v1 UpdateAsset`.
+
+            Output:
+              - `{ \"asset\": Asset, \"next_step\": string }`. The returned `Asset` is the
+                post-update state from the server.
+
+            Parameters:
+              - `asset_id`: required; the id of the asset to update.
+              - `tags`: optional; REPLACES the asset's full tag list with this array. To add a
+                single tag, first read the current tags via `list_assets` filtered by
+                `asset_id == \"<id>\"` and send the union. Pass `[]` to clear all tags.
+              - `metadata`: optional; REPLACES the asset's full metadata list. Each entry is
+                `{ \"name\": \"<key>\", \"value\": <scalar> }` where `value` is a string,
+                number, or boolean. Pass `[]` to clear. The key must already exist in the
+                organization's metadata schema (managed via the `metadata/v1` service); this
+                tool attaches values to existing keys, it does not create new keys.
+
+              At least one of `tags` or `metadata` must be set; otherwise the update is a no-op
+              and the tool returns `INVALID_PARAMS`.
+
+            Errors:
+              - `INVALID_PARAMS` if `asset_id` is empty or neither `tags` nor `metadata` is
+                provided.
+              - `RESOURCE_NOT_FOUND` if no asset matches `asset_id`.
+              - `INTERNAL_ERROR` for upstream gRPC failures (e.g. server rejecting a metadata
+                key that does not exist).
+
+            Guidance:
+              - This is a write. CONFIRM the target asset and the full proposed `tags` /
+                `metadata` lists with the user before invoking — silent truncation is the most
+                common foot-gun because the operation is REPLACE, not merge.
+              - For appends, always read-modify-write: list the asset by id, append your new
+                entry to the existing collection, then call this tool with the union.
+              - The asset proto has no `description` field — there is no equivalent to update.
+        ",
+        annotations(title = "assets_router/update_asset", read_only_hint = false)
+    )]
+    pub async fn update_asset(
+        &self,
+        params: Parameters<UpdateAssetParams>,
+    ) -> error::McpResult {
+        let Parameters(UpdateAssetParams {
+            asset_id,
+            tags,
+            metadata,
+        }) = params;
+
+        if asset_id.is_empty() {
+            return Err(ErrorData::invalid_params("`asset_id` must not be empty", None));
+        }
+        if tags.is_none() && metadata.is_none() {
+            return Err(ErrorData::invalid_params(
+                "at least one of `tags` or `metadata` must be provided",
+                None,
+            ));
+        }
+
+        let metadata =
+            metadata.map(|m| m.into_iter().map(MetadataValue::from).collect::<Vec<_>>());
+
+        let asset = self
+            .asset_service
+            .update_asset(asset_id, tags, metadata)
+            .await
+            .map_err(from_anyhow)?;
+
+        let next_step = format!(
+            "Updated asset `{}` ({}). Surface the new state to the user and confirm the change \
+             matches their intent. Remember: tags and metadata are REPLACE operations — verify \
+             nothing was unintentionally dropped.",
+            asset.name, asset.asset_id,
+        );
+
+        let mut result = CallToolResult::structured(serde_json::json!({
+            "asset": asset,
+            "next_step": next_step,
+        }));
+        result.content = vec![Content::text(next_step)];
+        Ok(result)
     }
 }


### PR DESCRIPTION
# Description
adds `update_asset` tool. With this tool you can update metadata and tags on an asset. Will be helpful when building skills for specific workflows, like merging assets.

# Validation
- Unit tests
- E2E testing locally with moving and merging assets