### PR TITLE
Rust(feat): test results mcp

### DIFF
--- a/rust/crates/sift_cli/assets/docs/src/agents/mcp.md
+++ b/rust/crates/sift_cli/assets/docs/src/agents/mcp.md
@@ -49,6 +49,8 @@ not run interactively.
 | `list_test_measurements` | List test measurements, with filtering and ordering.                  |
 | `count_test_steps` | Count test steps matching a filter, without fetching them.                  |
 | `count_test_measurements` | Count test measurements matching a filter, without fetching them.    |
+| `create_test_report` | Create a test report with its steps and measurements from a JSON document.  |
+| `append_test_measurements` | Append measurements to an existing test step.                          |
 | `get_data`       | Download channel data for an asset/run to a Parquet file, with optional decimation. |
 | `sql`            | Run SQL over one or more Parquet files; chain after `get_data` for analysis.  |
 | `upload_dataset` | Stream a Parquet dataset into Sift.                                           |

--- a/rust/crates/sift_cli/assets/docs/src/agents/mcp.md
+++ b/rust/crates/sift_cli/assets/docs/src/agents/mcp.md
@@ -44,6 +44,11 @@ not run interactively.
 | `update_annotation` | Update an annotation's fields (replace semantics for collections).         |
 | `list_rules`     | List rules, with filtering and ordering.                                      |
 | `list_rule_versions` | List the version history of a single rule.                                |
+| `list_test_reports` | List test reports (test-results runs), with filtering and ordering.        |
+| `list_test_steps` | List test steps within a report, with filtering and ordering.                |
+| `list_test_measurements` | List test measurements, with filtering and ordering.                  |
+| `count_test_steps` | Count test steps matching a filter, without fetching them.                  |
+| `count_test_measurements` | Count test measurements matching a filter, without fetching them.    |
 | `get_data`       | Download channel data for an asset/run to a Parquet file, with optional decimation. |
 | `sql`            | Run SQL over one or more Parquet files; chain after `get_data` for analysis.  |
 | `upload_dataset` | Stream a Parquet dataset into Sift.                                           |

--- a/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
+++ b/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
@@ -22,6 +22,9 @@ to combine them when working with Sift.
    - `list_test_reports`, `list_test_steps`, `list_test_measurements`: inspect
      test-results data (reports own steps own measurements); `count_test_steps`,
      `count_test_measurements`: totals matching a filter without fetching rows.
+   - `create_test_report`, `append_test_measurements`: create a test report with
+     its step/measurement tree, or add measurements to an existing step (writes —
+     confirm with the user first).
    - `get_data`: download channel data for an asset/run to a Parquet file.
    - `sql`: run SQL over one or more Parquet files (chain after `get_data`).
    - `upload_dataset`: stream a Parquet dataset into Sift.

--- a/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
+++ b/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
@@ -19,6 +19,9 @@ to combine them when working with Sift.
    - `list_assets`, `list_runs`, `list_channels`, `list_reports`, `list_rules`,
      `list_rule_versions`, `list_annotations`: discover what exists.
    - `list_report_rule_summaries`: per-rule pass/fail/open breakdown for a report.
+   - `list_test_reports`, `list_test_steps`, `list_test_measurements`: inspect
+     test-results data (reports own steps own measurements); `count_test_steps`,
+     `count_test_measurements`: totals matching a filter without fetching rows.
    - `get_data`: download channel data for an asset/run to a Parquet file.
    - `sql`: run SQL over one or more Parquet files (chain after `get_data`).
    - `upload_dataset`: stream a Parquet dataset into Sift.

--- a/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
@@ -33,6 +33,9 @@ to combine them when working with Sift.
    - `list_assets`, `list_runs`, `list_channels`, `list_reports`, `list_rules`,
      `list_rule_versions`, `list_annotations`: discover what exists.
    - `list_report_rule_summaries`: per-rule pass/fail/open breakdown for a report.
+   - `list_test_reports`, `list_test_steps`, `list_test_measurements`: inspect
+     test-results data (reports own steps own measurements); `count_test_steps`,
+     `count_test_measurements`: totals matching a filter without fetching rows.
    - `get_data`: download channel data for an asset/run to a Parquet file.
    - `sql`: run SQL over one or more Parquet files (chain after `get_data`).
    - `upload_dataset`: stream a Parquet dataset into Sift.

--- a/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
@@ -36,6 +36,9 @@ to combine them when working with Sift.
    - `list_test_reports`, `list_test_steps`, `list_test_measurements`: inspect
      test-results data (reports own steps own measurements); `count_test_steps`,
      `count_test_measurements`: totals matching a filter without fetching rows.
+   - `create_test_report`, `append_test_measurements`: create a test report with
+     its step/measurement tree, or add measurements to an existing step (writes —
+     confirm with the user first).
    - `get_data`: download channel data for an asset/run to a Parquet file.
    - `sql`: run SQL over one or more Parquet files (chain after `get_data`).
    - `upload_dataset`: stream a Parquet dataset into Sift.

--- a/rust/crates/sift_mcp/src/server/mod.rs
+++ b/rust/crates/sift_mcp/src/server/mod.rs
@@ -13,7 +13,7 @@ use crate::policy::RetryPolicy;
 use crate::service::{
     annotations::AnnotationService, assets::AssetService, channels::ChannelService,
     data::DataService, ingest::IngestService, ping::PingService, reports::ReportService,
-    rules::RuleService, runs::RunService, url::UrlService,
+    rules::RuleService, runs::RunService, test_reports::TestReportService, url::UrlService,
 };
 
 #[derive(Clone)]
@@ -31,6 +31,7 @@ pub struct SiftMcpServer {
     pub run_service: RunService,
     pub report_service: ReportService,
     pub rule_service: RuleService,
+    pub test_report_service: TestReportService,
 }
 
 #[tool_handler(
@@ -55,6 +56,7 @@ impl SiftMcpServer {
         tool_router.merge(Self::ping_router());
         tool_router.merge(Self::rules_router());
         tool_router.merge(Self::annotations_router());
+        tool_router.merge(Self::test_reports_router());
 
         let prompt_router = Self::prompt_router();
 
@@ -69,7 +71,8 @@ impl SiftMcpServer {
         let ping_service = PingService::new(channel.clone(), retry_policy.clone());
         let run_service = RunService::new(channel.clone(), retry_policy.clone());
         let report_service = ReportService::new(channel.clone(), retry_policy.clone());
-        let rule_service = RuleService::new(channel.clone(), retry_policy);
+        let rule_service = RuleService::new(channel.clone(), retry_policy.clone());
+        let test_report_service = TestReportService::new(channel.clone(), retry_policy);
 
         Self {
             annotation_service,
@@ -82,6 +85,7 @@ impl SiftMcpServer {
             run_service,
             report_service,
             rule_service,
+            test_report_service,
             tool_router,
             prompt_router,
         }

--- a/rust/crates/sift_mcp/src/service/mod.rs
+++ b/rust/crates/sift_mcp/src/service/mod.rs
@@ -7,6 +7,7 @@ pub mod ping;
 pub mod reports;
 pub mod rules;
 pub mod runs;
+pub mod test_reports;
 pub mod url;
 
 pub(crate) mod common;

--- a/rust/crates/sift_mcp/src/service/test_reports/mod.rs
+++ b/rust/crates/sift_mcp/src/service/test_reports/mod.rs
@@ -1,18 +1,32 @@
+use std::collections::HashMap;
+
 use crate::policy::{RetryPolicy, with_retry};
 use crate::service::common;
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use sift_rs::{
     SiftChannel,
     test_reports::v1::{
-        CountTestMeasurementsRequest, CountTestStepsRequest, ListTestMeasurementsRequest,
-        ListTestMeasurementsResponse, ListTestReportsRequest, ListTestReportsResponse,
-        ListTestStepsRequest, ListTestStepsResponse, TestMeasurement, TestReport, TestStep,
+        CountTestMeasurementsRequest, CountTestStepsRequest, CreateTestMeasurementsRequest,
+        CreateTestStepRequest, ListTestMeasurementsRequest, ListTestMeasurementsResponse,
+        ListTestReportsRequest, ListTestReportsResponse, ListTestStepsRequest,
+        ListTestStepsResponse, TestMeasurement, TestReport, TestStep,
         test_report_service_client::TestReportServiceClient,
     },
 };
 
+pub mod spec;
+use spec::{BuiltReport, BuiltStep};
+
 #[cfg(test)]
 mod test;
+
+/// Summary of a report created by [`TestReportService::create_test_report`].
+#[derive(Debug)]
+pub struct CreatedReport {
+    pub test_report_id: String,
+    pub steps_created: usize,
+    pub measurements_created: usize,
+}
 
 #[derive(Clone)]
 pub struct TestReportService {
@@ -229,5 +243,163 @@ impl TestReportService {
         .context("failed to count test measurements")?;
 
         Ok(resp.count)
+    }
+
+    /// Create a full report tree: the report, then each step (parent before child, linking
+    /// `parent_step_id` from the server-assigned ids), then all measurements in one batch.
+    ///
+    /// These RPCs are not transactional. On a mid-sequence failure the report (and any steps
+    /// already created) remain; the returned error names the created `test_report_id` so the
+    /// caller can inspect or clean up.
+    pub async fn create_test_report(&self, report: BuiltReport) -> Result<CreatedReport> {
+        let BuiltReport { request, steps } = report;
+
+        let channel = self.channel.clone();
+        let report_resp = with_retry(&self.policy, move || {
+            let channel = channel.clone();
+            let request = request.clone();
+            async move {
+                let mut client = TestReportServiceClient::new(channel);
+                client
+                    .create_test_report(request)
+                    .await
+                    .map(|resp| resp.into_inner())
+            }
+        })
+        .await
+        .context("failed to create test report")?;
+
+        let test_report_id = report_resp
+            .test_report
+            .ok_or_else(|| anyhow!("create test report response missing report"))?
+            .test_report_id;
+
+        let mut path_to_id: HashMap<String, String> = HashMap::new();
+        let mut measurements: Vec<TestMeasurement> = Vec::new();
+        let mut steps_created = 0usize;
+
+        for built in steps {
+            let BuiltStep {
+                step_path,
+                parent_path,
+                mut step,
+                measurements: step_measurements,
+            } = built;
+
+            step.test_report_id = test_report_id.clone();
+            step.parent_step_id = match parent_path {
+                Some(parent) => path_to_id
+                    .get(&parent)
+                    .cloned()
+                    .ok_or_else(|| anyhow!("internal: parent path `{parent}` not created yet"))?,
+                None => String::new(),
+            };
+
+            let channel = self.channel.clone();
+            let report_id = test_report_id.clone();
+            let path = step_path.clone();
+            let step_resp = with_retry(&self.policy, move || {
+                let channel = channel.clone();
+                let step = step.clone();
+                async move {
+                    let mut client = TestReportServiceClient::new(channel);
+                    client
+                        .create_test_step(CreateTestStepRequest {
+                            test_step: Some(step),
+                        })
+                        .await
+                        .map(|resp| resp.into_inner())
+                }
+            })
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to create test step `{path}` for report `{report_id}` \
+                     ({steps_created} step(s) already created)"
+                )
+            })?;
+
+            let step_id = step_resp
+                .test_step
+                .ok_or_else(|| anyhow!("create test step response missing step"))?
+                .test_step_id;
+            path_to_id.insert(step_path, step_id.clone());
+            steps_created += 1;
+
+            for mut measurement in step_measurements {
+                measurement.test_step_id = step_id.clone();
+                measurement.test_report_id = test_report_id.clone();
+                measurements.push(measurement);
+            }
+        }
+
+        let measurements_created = if measurements.is_empty() {
+            0
+        } else {
+            let channel = self.channel.clone();
+            let report_id = test_report_id.clone();
+            let count = measurements.len();
+            let resp = with_retry(&self.policy, move || {
+                let channel = channel.clone();
+                let measurements = measurements.clone();
+                async move {
+                    let mut client = TestReportServiceClient::new(channel);
+                    client
+                        .create_test_measurements(CreateTestMeasurementsRequest {
+                            test_measurements: measurements,
+                        })
+                        .await
+                        .map(|resp| resp.into_inner())
+                }
+            })
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to create {count} test measurement(s) for report `{report_id}` \
+                     (report and all steps already created)"
+                )
+            })?;
+            resp.measurements_created_count as usize
+        };
+
+        Ok(CreatedReport {
+            test_report_id,
+            steps_created,
+            measurements_created,
+        })
+    }
+
+    /// Append measurements to an existing step. Sets `test_report_id`/`test_step_id` on each and
+    /// sends one batch. The report and step must already exist; the server rejects unknown ids
+    /// (surfaced as `INVALID_PARAMS`/`RESOURCE_NOT_FOUND`). Returns the count created.
+    pub async fn append_test_measurements(
+        &self,
+        test_report_id: String,
+        test_step_id: String,
+        mut measurements: Vec<TestMeasurement>,
+    ) -> Result<usize> {
+        for measurement in &mut measurements {
+            measurement.test_report_id = test_report_id.clone();
+            measurement.test_step_id = test_step_id.clone();
+        }
+
+        let channel = self.channel.clone();
+        let resp = with_retry(&self.policy, move || {
+            let channel = channel.clone();
+            let measurements = measurements.clone();
+            async move {
+                let mut client = TestReportServiceClient::new(channel);
+                client
+                    .create_test_measurements(CreateTestMeasurementsRequest {
+                        test_measurements: measurements,
+                    })
+                    .await
+                    .map(|resp| resp.into_inner())
+            }
+        })
+        .await
+        .context("failed to append test measurements")?;
+
+        Ok(resp.measurements_created_count as usize)
     }
 }

--- a/rust/crates/sift_mcp/src/service/test_reports/mod.rs
+++ b/rust/crates/sift_mcp/src/service/test_reports/mod.rs
@@ -1,0 +1,233 @@
+use crate::policy::{RetryPolicy, with_retry};
+use crate::service::common;
+use anyhow::{Context, Result};
+use sift_rs::{
+    SiftChannel,
+    test_reports::v1::{
+        CountTestMeasurementsRequest, CountTestStepsRequest, ListTestMeasurementsRequest,
+        ListTestMeasurementsResponse, ListTestReportsRequest, ListTestReportsResponse,
+        ListTestStepsRequest, ListTestStepsResponse, TestMeasurement, TestReport, TestStep,
+        test_report_service_client::TestReportServiceClient,
+    },
+};
+
+#[cfg(test)]
+mod test;
+
+#[derive(Clone)]
+pub struct TestReportService {
+    channel: SiftChannel,
+    policy: RetryPolicy,
+}
+
+impl TestReportService {
+    pub fn new(channel: SiftChannel, policy: RetryPolicy) -> Self {
+        Self { channel, policy }
+    }
+
+    pub async fn list_test_reports(
+        &self,
+        filter: String,
+        order_by: Option<String>,
+        limit: Option<u32>,
+    ) -> Result<Vec<TestReport>> {
+        let (page_size, record_limit) = common::paging(limit);
+        let order_by = order_by.unwrap_or_default();
+        let mut page_token = String::new();
+        let mut results = Vec::new();
+
+        loop {
+            let channel = self.channel.clone();
+            let filter = filter.clone();
+            let order_by = order_by.clone();
+            let token = page_token.clone();
+
+            let resp = with_retry(&self.policy, move || {
+                let channel = channel.clone();
+                let filter = filter.clone();
+                let order_by = order_by.clone();
+                let token = token.clone();
+                async move {
+                    let mut client = TestReportServiceClient::new(channel);
+                    client
+                        .list_test_reports(ListTestReportsRequest {
+                            page_size,
+                            page_token: token,
+                            filter,
+                            order_by,
+                        })
+                        .await
+                        .map(|resp| resp.into_inner())
+                }
+            })
+            .await
+            .context("failed to query test reports")?;
+
+            let ListTestReportsResponse {
+                test_reports,
+                next_page_token,
+            } = resp;
+            if test_reports.is_empty() {
+                break;
+            }
+            results.extend(test_reports);
+            if results.len() >= record_limit || next_page_token.is_empty() {
+                break;
+            }
+            page_token = next_page_token;
+        }
+
+        results.truncate(record_limit);
+        Ok(results)
+    }
+
+    pub async fn list_test_steps(
+        &self,
+        filter: String,
+        order_by: Option<String>,
+        limit: Option<u32>,
+    ) -> Result<Vec<TestStep>> {
+        let (page_size, record_limit) = common::paging(limit);
+        let order_by = order_by.unwrap_or_default();
+        let mut page_token = String::new();
+        let mut results = Vec::new();
+
+        loop {
+            let channel = self.channel.clone();
+            let filter = filter.clone();
+            let order_by = order_by.clone();
+            let token = page_token.clone();
+
+            let resp = with_retry(&self.policy, move || {
+                let channel = channel.clone();
+                let filter = filter.clone();
+                let order_by = order_by.clone();
+                let token = token.clone();
+                async move {
+                    let mut client = TestReportServiceClient::new(channel);
+                    client
+                        .list_test_steps(ListTestStepsRequest {
+                            page_size,
+                            page_token: token,
+                            filter,
+                            order_by,
+                        })
+                        .await
+                        .map(|resp| resp.into_inner())
+                }
+            })
+            .await
+            .context("failed to query test steps")?;
+
+            let ListTestStepsResponse {
+                test_steps,
+                next_page_token,
+            } = resp;
+            if test_steps.is_empty() {
+                break;
+            }
+            results.extend(test_steps);
+            if results.len() >= record_limit || next_page_token.is_empty() {
+                break;
+            }
+            page_token = next_page_token;
+        }
+
+        results.truncate(record_limit);
+        Ok(results)
+    }
+
+    pub async fn list_test_measurements(
+        &self,
+        filter: String,
+        order_by: Option<String>,
+        limit: Option<u32>,
+    ) -> Result<Vec<TestMeasurement>> {
+        let (page_size, record_limit) = common::paging(limit);
+        let order_by = order_by.unwrap_or_default();
+        let mut page_token = String::new();
+        let mut results = Vec::new();
+
+        loop {
+            let channel = self.channel.clone();
+            let filter = filter.clone();
+            let order_by = order_by.clone();
+            let token = page_token.clone();
+
+            let resp = with_retry(&self.policy, move || {
+                let channel = channel.clone();
+                let filter = filter.clone();
+                let order_by = order_by.clone();
+                let token = token.clone();
+                async move {
+                    let mut client = TestReportServiceClient::new(channel);
+                    client
+                        .list_test_measurements(ListTestMeasurementsRequest {
+                            page_size,
+                            page_token: token,
+                            filter,
+                            order_by,
+                        })
+                        .await
+                        .map(|resp| resp.into_inner())
+                }
+            })
+            .await
+            .context("failed to query test measurements")?;
+
+            let ListTestMeasurementsResponse {
+                test_measurements,
+                next_page_token,
+            } = resp;
+            if test_measurements.is_empty() {
+                break;
+            }
+            results.extend(test_measurements);
+            if results.len() >= record_limit || next_page_token.is_empty() {
+                break;
+            }
+            page_token = next_page_token;
+        }
+
+        results.truncate(record_limit);
+        Ok(results)
+    }
+
+    pub async fn count_test_steps(&self, filter: String) -> Result<i64> {
+        let channel = self.channel.clone();
+        let resp = with_retry(&self.policy, move || {
+            let channel = channel.clone();
+            let filter = filter.clone();
+            async move {
+                let mut client = TestReportServiceClient::new(channel);
+                client
+                    .count_test_steps(CountTestStepsRequest { filter })
+                    .await
+                    .map(|resp| resp.into_inner())
+            }
+        })
+        .await
+        .context("failed to count test steps")?;
+
+        Ok(resp.count)
+    }
+
+    pub async fn count_test_measurements(&self, filter: String) -> Result<i64> {
+        let channel = self.channel.clone();
+        let resp = with_retry(&self.policy, move || {
+            let channel = channel.clone();
+            let filter = filter.clone();
+            async move {
+                let mut client = TestReportServiceClient::new(channel);
+                client
+                    .count_test_measurements(CountTestMeasurementsRequest { filter })
+                    .await
+                    .map(|resp| resp.into_inner())
+            }
+        })
+        .await
+        .context("failed to count test measurements")?;
+
+        Ok(resp.count)
+    }
+}

--- a/rust/crates/sift_mcp/src/service/test_reports/mod.rs
+++ b/rust/crates/sift_mcp/src/service/test_reports/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use crate::policy::{RetryPolicy, with_retry};
@@ -34,6 +35,82 @@ pub struct TestReportService {
     policy: RetryPolicy,
 }
 
+/// Canonical proto prefixes for the enum-valued filter fields (`status`, `step_type`,
+/// `measurement_type`).
+const ENUM_VALUE_PREFIXES: [&str; 3] =
+    ["TEST_STATUS_", "TEST_STEP_TYPE_", "TEST_MEASUREMENT_TYPE_"];
+
+/// Rewrite canonical enum names inside a CEL filter to the short form the backend accepts.
+///
+/// The backend's filter evaluator matches enum values by their short, lowercase name
+/// (`status == "failed"`), but every list/count response and tool description uses the canonical
+/// proto name (`TEST_STATUS_FAILED`). A caller who copies a value out of a result and filters on
+/// it would otherwise hit an opaque backend error. Rewriting here lets the documented canonical
+/// form work without changing what the agent is told to send.
+///
+/// This is a client-side shim. The fix belongs in the backend evaluator (accept the canonical
+/// name directly); remove this once that ships.
+///
+/// Only the contents of double-quoted string literals are touched, so field names and operators
+/// are left intact. A literal is rewritten only when it is a prefix followed by a non-empty
+/// uppercase/underscore/digit suffix, which keeps unrelated string values (e.g. metadata) safe.
+fn normalize_enum_filter(filter: &str) -> String {
+    let mut out = String::with_capacity(filter.len());
+    let mut chars = filter.chars();
+
+    while let Some(c) = chars.next() {
+        if c != '"' {
+            out.push(c);
+            continue;
+        }
+
+        // Opening quote: collect the literal's raw contents, preserving escape sequences, up to
+        // the closing quote.
+        out.push('"');
+        let mut content = String::new();
+        let mut closed = false;
+        while let Some(ch) = chars.next() {
+            match ch {
+                '\\' => {
+                    content.push(ch);
+                    if let Some(escaped) = chars.next() {
+                        content.push(escaped);
+                    }
+                }
+                '"' => {
+                    closed = true;
+                    break;
+                }
+                _ => content.push(ch),
+            }
+        }
+
+        out.push_str(&shorten_enum_value(&content));
+        if closed {
+            out.push('"');
+        }
+    }
+
+    out
+}
+
+/// Map a single canonical enum value to its short form, borrowing the input unchanged when it is
+/// not a recognized enum value.
+fn shorten_enum_value(content: &str) -> Cow<'_, str> {
+    for prefix in ENUM_VALUE_PREFIXES {
+        if let Some(rest) = content.strip_prefix(prefix) {
+            let is_enum_suffix = !rest.is_empty()
+                && rest
+                    .bytes()
+                    .all(|b| b.is_ascii_uppercase() || b == b'_' || b.is_ascii_digit());
+            if is_enum_suffix {
+                return Cow::Owned(rest.to_ascii_lowercase());
+            }
+        }
+    }
+    Cow::Borrowed(content)
+}
+
 impl TestReportService {
     pub fn new(channel: SiftChannel, policy: RetryPolicy) -> Self {
         Self { channel, policy }
@@ -45,6 +122,7 @@ impl TestReportService {
         order_by: Option<String>,
         limit: Option<u32>,
     ) -> Result<Vec<TestReport>> {
+        let filter = normalize_enum_filter(&filter);
         let (page_size, record_limit) = common::paging(limit);
         let order_by = order_by.unwrap_or_default();
         let mut page_token = String::new();
@@ -101,6 +179,7 @@ impl TestReportService {
         order_by: Option<String>,
         limit: Option<u32>,
     ) -> Result<Vec<TestStep>> {
+        let filter = normalize_enum_filter(&filter);
         let (page_size, record_limit) = common::paging(limit);
         let order_by = order_by.unwrap_or_default();
         let mut page_token = String::new();
@@ -157,6 +236,7 @@ impl TestReportService {
         order_by: Option<String>,
         limit: Option<u32>,
     ) -> Result<Vec<TestMeasurement>> {
+        let filter = normalize_enum_filter(&filter);
         let (page_size, record_limit) = common::paging(limit);
         let order_by = order_by.unwrap_or_default();
         let mut page_token = String::new();
@@ -208,6 +288,7 @@ impl TestReportService {
     }
 
     pub async fn count_test_steps(&self, filter: String) -> Result<i64> {
+        let filter = normalize_enum_filter(&filter);
         let channel = self.channel.clone();
         let resp = with_retry(&self.policy, move || {
             let channel = channel.clone();
@@ -227,6 +308,7 @@ impl TestReportService {
     }
 
     pub async fn count_test_measurements(&self, filter: String) -> Result<i64> {
+        let filter = normalize_enum_filter(&filter);
         let channel = self.channel.clone();
         let resp = with_retry(&self.policy, move || {
             let channel = channel.clone();

--- a/rust/crates/sift_mcp/src/service/test_reports/spec.rs
+++ b/rust/crates/sift_mcp/src/service/test_reports/spec.rs
@@ -134,9 +134,10 @@ pub fn build(spec: ReportSpec) -> Result<BuiltReport> {
         bail!("report `test_case` must not be empty");
     }
 
-    let start = parse_ts(spec.start_time.as_deref(), "report start_time")?
-        .unwrap_or_else(now_timestamp);
-    let end = parse_ts(spec.end_time.as_deref(), "report end_time")?.unwrap_or_else(|| start.clone());
+    let start =
+        parse_ts(spec.start_time.as_deref(), "report start_time")?.unwrap_or_else(now_timestamp);
+    let end =
+        parse_ts(spec.end_time.as_deref(), "report end_time")?.unwrap_or_else(|| start.clone());
 
     let request = CreateTestReportRequest {
         status: parse_enum::<_>(spec.status.as_deref(), "TEST_STATUS_", "status", |n| {

--- a/rust/crates/sift_mcp/src/service/test_reports/spec.rs
+++ b/rust/crates/sift_mcp/src/service/test_reports/spec.rs
@@ -136,8 +136,7 @@ pub fn build(spec: ReportSpec) -> Result<BuiltReport> {
 
     let start =
         parse_ts(spec.start_time.as_deref(), "report start_time")?.unwrap_or_else(now_timestamp);
-    let end =
-        parse_ts(spec.end_time.as_deref(), "report end_time")?.unwrap_or_else(|| start.clone());
+    let end = parse_ts(spec.end_time.as_deref(), "report end_time")?.unwrap_or(start);
 
     let request = CreateTestReportRequest {
         status: parse_enum::<_>(spec.status.as_deref(), "TEST_STATUS_", "status", |n| {
@@ -147,8 +146,8 @@ pub fn build(spec: ReportSpec) -> Result<BuiltReport> {
         name: spec.name,
         test_system_name: spec.test_system_name,
         test_case: spec.test_case,
-        start_time: Some(start.clone()),
-        end_time: Some(end.clone()),
+        start_time: Some(start),
+        end_time: Some(end),
         metadata: metadata_values(spec.metadata),
         serial_number: spec.serial_number.unwrap_or_default(),
         part_number: spec.part_number.unwrap_or_default(),
@@ -192,10 +191,9 @@ fn build_steps(
         )?
         .unwrap_or(TestStepType::Action as i32);
 
-        let start = parse_ts(spec.start_time.as_deref(), "step start_time")?
-            .unwrap_or_else(|| report_start.clone());
-        let end = parse_ts(spec.end_time.as_deref(), "step end_time")?
-            .unwrap_or_else(|| report_end.clone());
+        let start =
+            parse_ts(spec.start_time.as_deref(), "step start_time")?.unwrap_or(*report_start);
+        let end = parse_ts(spec.end_time.as_deref(), "step end_time")?.unwrap_or(*report_end);
 
         let step = TestStep {
             name: spec.name,
@@ -203,7 +201,7 @@ fn build_steps(
             step_type,
             step_path: step_path.clone(),
             status,
-            start_time: Some(start.clone()),
+            start_time: Some(start),
             end_time: Some(end),
             error_info: spec.error_info.map(|e| ErrorInfo {
                 error_code: e.error_code,
@@ -327,8 +325,8 @@ fn build_measurement(
     )?
     .unwrap_or(default_type as i32);
 
-    let timestamp = parse_ts(spec.timestamp.as_deref(), "measurement timestamp")?
-        .unwrap_or_else(|| step_start.clone());
+    let timestamp =
+        parse_ts(spec.timestamp.as_deref(), "measurement timestamp")?.unwrap_or(*step_start);
 
     Ok(TestMeasurement {
         measurement_type,
@@ -351,15 +349,15 @@ fn build_measurement(
 /// Numeric pass/fail, replicating `util/test_results/bounds.py`: both ends inclusive, an
 /// absent bound is unbounded on that side.
 fn passes_numeric(value: f64, bounds: &NumericBoundsSpec) -> bool {
-    if let Some(min) = bounds.min {
-        if value < min {
-            return false;
-        }
+    if let Some(min) = bounds.min
+        && value < min
+    {
+        return false;
     }
-    if let Some(max) = bounds.max {
-        if value > max {
-            return false;
-        }
+    if let Some(max) = bounds.max
+        && value > max
+    {
+        return false;
     }
     true
 }

--- a/rust/crates/sift_mcp/src/service/test_reports/spec.rs
+++ b/rust/crates/sift_mcp/src/service/test_reports/spec.rs
@@ -1,0 +1,427 @@
+//! Author-facing JSON spec for `create_test_report` and its mapping to proto requests.
+//!
+//! The caller describes a report as a nested tree: each step owns measurements and child
+//! steps. [`build`] validates that tree and lowers it to the flat proto types, computing
+//! `step_path` and recording each step's parent so the service can link `parent_step_id`
+//! once the server assigns ids. The layout mirrors the Python pytest plugin
+//! (`util/test_results/context_manager.py`): roots are `"1"`, `"2"`, …; a child at index `i`
+//! under parent path `P` is `"P.i"`.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Result, anyhow, bail};
+use pbjson_types::Timestamp;
+use serde::Deserialize;
+use sift_rs::{
+    metadata::v1::{
+        MetadataKey, MetadataKeyType, MetadataValue, metadata_value::Value as MetaInner,
+    },
+    test_reports::v1::{
+        CreateTestReportRequest, ErrorInfo, NumericBounds, StringBounds, TestMeasurement,
+        TestMeasurementType, TestStatus, TestStep, TestStepType, test_measurement,
+    },
+    unit::v2::Unit,
+};
+
+/// A scalar metadata value. Untagged so the author writes `"k": "v"`, `"k": 1`, or `"k": true`.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum MetadataScalar {
+    String(String),
+    Number(f64),
+    Boolean(bool),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReportSpec {
+    pub name: String,
+    pub test_system_name: String,
+    pub test_case: String,
+    pub status: Option<String>,
+    pub start_time: Option<String>,
+    pub end_time: Option<String>,
+    pub serial_number: Option<String>,
+    pub part_number: Option<String>,
+    pub system_operator: Option<String>,
+    pub run_id: Option<String>,
+    #[serde(default)]
+    pub metadata: BTreeMap<String, MetadataScalar>,
+    #[serde(default)]
+    pub steps: Vec<StepSpec>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StepSpec {
+    pub name: String,
+    pub status: Option<String>,
+    pub step_type: Option<String>,
+    pub description: Option<String>,
+    pub start_time: Option<String>,
+    pub end_time: Option<String>,
+    pub error_info: Option<ErrorInfoSpec>,
+    #[serde(default)]
+    pub metadata: BTreeMap<String, MetadataScalar>,
+    #[serde(default)]
+    pub measurements: Vec<MeasurementSpec>,
+    #[serde(default)]
+    pub steps: Vec<StepSpec>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ErrorInfoSpec {
+    pub error_code: i32,
+    pub error_message: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MeasurementSpec {
+    pub name: String,
+    pub numeric_value: Option<f64>,
+    pub string_value: Option<String>,
+    pub boolean_value: Option<bool>,
+    pub numeric_bounds: Option<NumericBoundsSpec>,
+    pub string_expected: Option<String>,
+    pub unit: Option<String>,
+    pub passed: Option<bool>,
+    pub measurement_type: Option<String>,
+    pub timestamp: Option<String>,
+    pub description: Option<String>,
+    #[serde(default)]
+    pub channel_names: Vec<String>,
+    #[serde(default)]
+    pub metadata: BTreeMap<String, MetadataScalar>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NumericBoundsSpec {
+    pub min: Option<f64>,
+    pub max: Option<f64>,
+}
+
+/// A fully validated report, ready for the service to write. `request` is the report create
+/// request; `steps` is in pre-order so a parent is always created before its children.
+pub struct BuiltReport {
+    pub request: CreateTestReportRequest,
+    pub steps: Vec<BuiltStep>,
+}
+
+/// One step plus its measurements, with ids left unset. The service fills `test_report_id`,
+/// `parent_step_id` (resolved from `parent_path`), and the measurements' `test_step_id` once
+/// the server returns real ids.
+pub struct BuiltStep {
+    pub step_path: String,
+    pub parent_path: Option<String>,
+    pub step: TestStep,
+    pub measurements: Vec<TestMeasurement>,
+}
+
+/// Validate the author spec and lower it to proto messages. Returns an error (mapped to
+/// `INVALID_PARAMS` by the caller) when a required field is empty, an enum name is unknown, a
+/// timestamp is not RFC3339, or a measurement's value/bounds are inconsistent.
+pub fn build(spec: ReportSpec) -> Result<BuiltReport> {
+    if spec.name.trim().is_empty() {
+        bail!("report `name` must not be empty");
+    }
+    if spec.test_system_name.trim().is_empty() {
+        bail!("report `test_system_name` must not be empty");
+    }
+    if spec.test_case.trim().is_empty() {
+        bail!("report `test_case` must not be empty");
+    }
+
+    let start = parse_ts(spec.start_time.as_deref(), "report start_time")?
+        .unwrap_or_else(now_timestamp);
+    let end = parse_ts(spec.end_time.as_deref(), "report end_time")?.unwrap_or_else(|| start.clone());
+
+    let request = CreateTestReportRequest {
+        status: parse_enum::<_>(spec.status.as_deref(), "TEST_STATUS_", "status", |n| {
+            TestStatus::from_str_name(n).map(|e| e as i32)
+        })?
+        .unwrap_or(TestStatus::Passed as i32),
+        name: spec.name,
+        test_system_name: spec.test_system_name,
+        test_case: spec.test_case,
+        start_time: Some(start.clone()),
+        end_time: Some(end.clone()),
+        metadata: metadata_values(spec.metadata),
+        serial_number: spec.serial_number.unwrap_or_default(),
+        part_number: spec.part_number.unwrap_or_default(),
+        system_operator: spec.system_operator.unwrap_or_default(),
+        run_id: spec.run_id.unwrap_or_default(),
+    };
+
+    let mut steps = Vec::new();
+    build_steps(spec.steps, None, &start, &end, &mut steps)?;
+
+    Ok(BuiltReport { request, steps })
+}
+
+fn build_steps(
+    specs: Vec<StepSpec>,
+    parent_path: Option<&str>,
+    report_start: &Timestamp,
+    report_end: &Timestamp,
+    out: &mut Vec<BuiltStep>,
+) -> Result<()> {
+    for (i, spec) in specs.into_iter().enumerate() {
+        let index = i + 1;
+        let step_path = match parent_path {
+            Some(parent) => format!("{parent}.{index}"),
+            None => index.to_string(),
+        };
+
+        if spec.name.trim().is_empty() {
+            bail!("step `name` must not be empty (at step_path `{step_path}`)");
+        }
+
+        let status = parse_enum(spec.status.as_deref(), "TEST_STATUS_", "step status", |n| {
+            TestStatus::from_str_name(n).map(|e| e as i32)
+        })?
+        .unwrap_or(TestStatus::Passed as i32);
+        let step_type = parse_enum(
+            spec.step_type.as_deref(),
+            "TEST_STEP_TYPE_",
+            "step_type",
+            |n| TestStepType::from_str_name(n).map(|e| e as i32),
+        )?
+        .unwrap_or(TestStepType::Action as i32);
+
+        let start = parse_ts(spec.start_time.as_deref(), "step start_time")?
+            .unwrap_or_else(|| report_start.clone());
+        let end = parse_ts(spec.end_time.as_deref(), "step end_time")?
+            .unwrap_or_else(|| report_end.clone());
+
+        let step = TestStep {
+            name: spec.name,
+            description: spec.description.unwrap_or_default(),
+            step_type,
+            step_path: step_path.clone(),
+            status,
+            start_time: Some(start.clone()),
+            end_time: Some(end),
+            error_info: spec.error_info.map(|e| ErrorInfo {
+                error_code: e.error_code,
+                error_message: e.error_message,
+            }),
+            metadata: metadata_values(spec.metadata),
+            ..Default::default()
+        };
+
+        let measurements = spec
+            .measurements
+            .into_iter()
+            .map(|m| build_measurement(m, &start, &step_path))
+            .collect::<Result<Vec<_>>>()?;
+
+        out.push(BuiltStep {
+            step_path: step_path.clone(),
+            parent_path: parent_path.map(str::to_string),
+            step,
+            measurements,
+        });
+
+        build_steps(spec.steps, Some(&step_path), report_start, report_end, out)?;
+    }
+    Ok(())
+}
+
+/// Build measurements to append to an existing step. Validation and value/bounds/`passed`
+/// derivation match `create_test_report`; timestamps default to now (there is no parent step to
+/// inherit from). `test_step_id`/`test_report_id` are left unset for the service to fill.
+pub fn build_measurements(specs: Vec<MeasurementSpec>) -> Result<Vec<TestMeasurement>> {
+    let default_ts = now_timestamp();
+    specs
+        .into_iter()
+        .map(|spec| build_measurement(spec, &default_ts, "(appended)"))
+        .collect()
+}
+
+fn build_measurement(
+    spec: MeasurementSpec,
+    step_start: &Timestamp,
+    step_path: &str,
+) -> Result<TestMeasurement> {
+    if spec.name.trim().is_empty() {
+        bail!("measurement `name` must not be empty (under step_path `{step_path}`)");
+    }
+
+    // Exactly one value variant.
+    let value_count = spec.numeric_value.is_some() as u8
+        + spec.string_value.is_some() as u8
+        + spec.boolean_value.is_some() as u8;
+    if value_count != 1 {
+        bail!(
+            "measurement `{}` must set exactly one of `numeric_value`, `string_value`, or \
+             `boolean_value` (got {value_count})",
+            spec.name
+        );
+    }
+
+    // Bounds must match the value kind.
+    if spec.numeric_bounds.is_some() && spec.numeric_value.is_none() {
+        bail!(
+            "measurement `{}` has `numeric_bounds` but no `numeric_value`",
+            spec.name
+        );
+    }
+    if spec.string_expected.is_some() && spec.string_value.is_none() {
+        bail!(
+            "measurement `{}` has `string_expected` but no `string_value`",
+            spec.name
+        );
+    }
+
+    let (value, default_type, passed) = if let Some(v) = spec.numeric_value {
+        let passed = match (spec.passed, &spec.numeric_bounds) {
+            (Some(p), _) => p,
+            (None, Some(b)) => passes_numeric(v, b),
+            (None, None) => true,
+        };
+        (
+            test_measurement::Value::NumericValue(v),
+            TestMeasurementType::Double,
+            passed,
+        )
+    } else if let Some(s) = spec.string_value.clone() {
+        let passed = match (spec.passed, &spec.string_expected) {
+            (Some(p), _) => p,
+            (None, Some(expected)) => &s == expected,
+            (None, None) => true,
+        };
+        (
+            test_measurement::Value::StringValue(s),
+            TestMeasurementType::String,
+            passed,
+        )
+    } else {
+        let b = spec.boolean_value.unwrap();
+        (
+            test_measurement::Value::BooleanValue(b),
+            TestMeasurementType::Boolean,
+            spec.passed.unwrap_or(true),
+        )
+    };
+
+    let bounds = match (spec.numeric_bounds, spec.string_expected) {
+        (Some(b), _) => Some(test_measurement::Bounds::NumericBounds(NumericBounds {
+            min: b.min,
+            max: b.max,
+        })),
+        (None, Some(expected)) => Some(test_measurement::Bounds::StringBounds(StringBounds {
+            expected_value: expected,
+        })),
+        (None, None) => None,
+    };
+
+    let measurement_type = parse_enum(
+        spec.measurement_type.as_deref(),
+        "TEST_MEASUREMENT_TYPE_",
+        "measurement_type",
+        |n| TestMeasurementType::from_str_name(n).map(|e| e as i32),
+    )?
+    .unwrap_or(default_type as i32);
+
+    let timestamp = parse_ts(spec.timestamp.as_deref(), "measurement timestamp")?
+        .unwrap_or_else(|| step_start.clone());
+
+    Ok(TestMeasurement {
+        measurement_type,
+        name: spec.name,
+        unit: spec.unit.map(|abbreviated_name| Unit {
+            abbreviated_name,
+            ..Default::default()
+        }),
+        passed,
+        timestamp: Some(timestamp),
+        description: spec.description.unwrap_or_default(),
+        channel_names: spec.channel_names,
+        metadata: metadata_values(spec.metadata),
+        value: Some(value),
+        bounds,
+        ..Default::default()
+    })
+}
+
+/// Numeric pass/fail, replicating `util/test_results/bounds.py`: both ends inclusive, an
+/// absent bound is unbounded on that side.
+fn passes_numeric(value: f64, bounds: &NumericBoundsSpec) -> bool {
+    if let Some(min) = bounds.min {
+        if value < min {
+            return false;
+        }
+    }
+    if let Some(max) = bounds.max {
+        if value > max {
+            return false;
+        }
+    }
+    true
+}
+
+/// Resolve an optional enum string to its `i32` tag. Accepts a bare name (`"PASSED"`) or the
+/// fully-qualified one (`"TEST_STATUS_PASSED"`), case-insensitively. `None` input → `Ok(None)`.
+fn parse_enum<F>(raw: Option<&str>, prefix: &str, field: &str, lookup: F) -> Result<Option<i32>>
+where
+    F: Fn(&str) -> Option<i32>,
+{
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    let upper = raw.trim().to_uppercase();
+    let qualified = if upper.starts_with(prefix) {
+        upper
+    } else {
+        format!("{prefix}{upper}")
+    };
+    lookup(&qualified)
+        .map(Some)
+        .ok_or_else(|| anyhow!("unknown `{field}` value `{raw}`"))
+}
+
+fn parse_ts(raw: Option<&str>, field: &str) -> Result<Option<Timestamp>> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    let dt = chrono::DateTime::parse_from_rfc3339(raw.trim())
+        .map_err(|e| anyhow!("`{field}` is not a valid RFC3339 timestamp: {e}"))?;
+    Ok(Some(Timestamp {
+        seconds: dt.timestamp(),
+        nanos: dt.timestamp_subsec_nanos() as i32,
+    }))
+}
+
+fn now_timestamp() -> Timestamp {
+    let now = chrono::Utc::now();
+    Timestamp {
+        seconds: now.timestamp(),
+        nanos: now.timestamp_subsec_nanos() as i32,
+    }
+}
+
+fn metadata_values(map: BTreeMap<String, MetadataScalar>) -> Vec<MetadataValue> {
+    map.into_iter()
+        .map(|(name, scalar)| {
+            let (key_type, value) = match scalar {
+                MetadataScalar::String(s) => (MetadataKeyType::String, MetaInner::StringValue(s)),
+                MetadataScalar::Number(n) => (MetadataKeyType::Number, MetaInner::NumberValue(n)),
+                MetadataScalar::Boolean(b) => {
+                    (MetadataKeyType::Boolean, MetaInner::BooleanValue(b))
+                }
+            };
+            MetadataValue {
+                key: Some(MetadataKey {
+                    name,
+                    r#type: key_type.into(),
+                    ..Default::default()
+                }),
+                value: Some(value),
+                ..Default::default()
+            }
+        })
+        .collect()
+}

--- a/rust/crates/sift_mcp/src/service/test_reports/test.rs
+++ b/rust/crates/sift_mcp/src/service/test_reports/test.rs
@@ -1,15 +1,23 @@
 use sift_rs::test_reports::v1::{
-    CountTestMeasurementsResponse, CountTestStepsResponse, ListTestMeasurementsResponse,
-    ListTestReportsResponse, ListTestStepsResponse, TestMeasurement, TestReport, TestStep,
+    CountTestMeasurementsResponse, CountTestStepsResponse, CreateTestMeasurementsResponse,
+    CreateTestReportResponse, CreateTestStepResponse, ListTestMeasurementsResponse,
+    ListTestReportsResponse, ListTestStepsResponse, TestMeasurement, TestMeasurementType,
+    TestReport, TestStatus, TestStep, TestStepType, test_measurement,
     test_report_service_server::TestReportServiceServer,
 };
 use sift_test_util::{grpc::memory_sift_channel, mock::test_reports::v1::MockTestReportServiceImpl};
 use tokio::task::JoinHandle;
 use tonic::{Response, Status, transport::Server};
 
+use super::spec;
 use super::TestReportService;
 use crate::policy::RetryPolicy;
 use crate::service::common::PAGE_SIZE;
+
+fn built_from_json(json: &str) -> spec::BuiltReport {
+    let parsed = serde_json::from_str(json).expect("spec should parse");
+    spec::build(parsed).expect("spec should build")
+}
 
 async fn service_with_mock(
     mock: MockTestReportServiceImpl,
@@ -276,4 +284,289 @@ async fn count_test_measurements_returns_count() {
         .expect("count_test_measurements failed");
 
     assert_eq!(count, 3);
+}
+
+// --- spec::build (pure validation + mapping) ---
+
+#[test]
+fn build_computes_step_paths_and_parent_links() {
+    let built = built_from_json(
+        r#"{
+            "name": "r", "test_system_name": "rig", "test_case": "tc",
+            "steps": [
+                { "name": "first" },
+                { "name": "second", "steps": [ { "name": "child" } ] }
+            ]
+        }"#,
+    );
+
+    let paths: Vec<(&str, Option<&str>)> = built
+        .steps
+        .iter()
+        .map(|s| (s.step_path.as_str(), s.parent_path.as_deref()))
+        .collect();
+    // Pre-order, with computed paths and parent links.
+    assert_eq!(
+        paths,
+        vec![("1", None), ("2", None), ("2.1", Some("2"))]
+    );
+    assert_eq!(built.steps[2].step.step_path, "2.1");
+}
+
+#[test]
+fn build_defaults_status_and_step_type() {
+    let built = built_from_json(
+        r#"{ "name": "r", "test_system_name": "rig", "test_case": "tc",
+             "steps": [ { "name": "s" } ] }"#,
+    );
+    assert_eq!(built.request.status, TestStatus::Passed as i32);
+    assert_eq!(built.steps[0].step.status, TestStatus::Passed as i32);
+    assert_eq!(built.steps[0].step.step_type, TestStepType::Action as i32);
+}
+
+#[test]
+fn build_computes_passed_from_numeric_bounds() {
+    let built = built_from_json(
+        r#"{ "name": "r", "test_system_name": "rig", "test_case": "tc",
+             "steps": [ { "name": "s", "measurements": [
+                { "name": "in",  "numeric_value": 3.3, "numeric_bounds": { "min": 3.0, "max": 3.6 } },
+                { "name": "out", "numeric_value": 9.9, "numeric_bounds": { "min": 3.0, "max": 3.6 } }
+             ] } ] }"#,
+    );
+    let ms = &built.steps[0].measurements;
+    assert!(ms[0].passed, "in-bounds should pass");
+    assert!(!ms[1].passed, "out-of-bounds should fail");
+    assert_eq!(ms[0].measurement_type, TestMeasurementType::Double as i32);
+    match &ms[0].value {
+        Some(test_measurement::Value::NumericValue(v)) => assert_eq!(*v, 3.3),
+        _ => panic!("expected numeric value"),
+    }
+}
+
+#[test]
+fn build_explicit_passed_overrides_bounds() {
+    let built = built_from_json(
+        r#"{ "name": "r", "test_system_name": "rig", "test_case": "tc",
+             "steps": [ { "name": "s", "measurements": [
+                { "name": "m", "numeric_value": 9.9, "numeric_bounds": { "max": 1.0 }, "passed": true }
+             ] } ] }"#,
+    );
+    assert!(built.steps[0].measurements[0].passed);
+}
+
+#[test]
+fn build_derives_string_and_boolean_types() {
+    let built = built_from_json(
+        r#"{ "name": "r", "test_system_name": "rig", "test_case": "tc",
+             "steps": [ { "name": "s", "measurements": [
+                { "name": "str", "string_value": "ok", "string_expected": "ok" },
+                { "name": "bool", "boolean_value": true }
+             ] } ] }"#,
+    );
+    let ms = &built.steps[0].measurements;
+    assert_eq!(ms[0].measurement_type, TestMeasurementType::String as i32);
+    assert!(ms[0].passed, "string equal to expected should pass");
+    assert_eq!(ms[1].measurement_type, TestMeasurementType::Boolean as i32);
+}
+
+#[test]
+fn build_rejects_wrong_value_count() {
+    let zero = serde_json::from_str(
+        r#"{ "name": "r", "test_system_name": "rig", "test_case": "tc",
+             "steps": [ { "name": "s", "measurements": [ { "name": "m" } ] } ] }"#,
+    )
+    .unwrap();
+    assert!(spec::build(zero).is_err(), "zero values must be rejected");
+
+    let two = serde_json::from_str(
+        r#"{ "name": "r", "test_system_name": "rig", "test_case": "tc",
+             "steps": [ { "name": "s", "measurements": [
+                { "name": "m", "numeric_value": 1.0, "boolean_value": true } ] } ] }"#,
+    )
+    .unwrap();
+    assert!(spec::build(two).is_err(), "two values must be rejected");
+}
+
+#[test]
+fn build_rejects_unknown_enum_and_bad_timestamp() {
+    let bad_status = serde_json::from_str(
+        r#"{ "name": "r", "test_system_name": "rig", "test_case": "tc", "status": "NOPE" }"#,
+    )
+    .unwrap();
+    assert!(spec::build(bad_status).is_err());
+
+    let bad_ts = serde_json::from_str(
+        r#"{ "name": "r", "test_system_name": "rig", "test_case": "tc", "start_time": "not-a-time" }"#,
+    )
+    .unwrap();
+    assert!(spec::build(bad_ts).is_err());
+}
+
+#[test]
+fn build_rejects_empty_required_field() {
+    let empty_name = serde_json::from_str(
+        r#"{ "name": "", "test_system_name": "rig", "test_case": "tc" }"#,
+    )
+    .unwrap();
+    assert!(spec::build(empty_name).is_err());
+}
+
+// --- create_test_report (composite orchestration against the mock) ---
+
+#[tokio::test]
+async fn create_test_report_creates_tree_in_order() {
+    let mut mock = MockTestReportServiceImpl::new();
+
+    mock.expect_create_test_report().times(1).returning(|_| {
+        Ok(Response::new(CreateTestReportResponse {
+            test_report: Some(TestReport {
+                test_report_id: "r1".into(),
+                ..Default::default()
+            }),
+        }))
+    });
+
+    // Echo back an id derived from step_path, and assert report id + parent linkage.
+    mock.expect_create_test_step().times(3).returning(|req| {
+        let step = req.into_inner().test_step.expect("step present");
+        assert_eq!(step.test_report_id, "r1");
+        if step.step_path == "2.1" {
+            assert_eq!(step.parent_step_id, "id-2", "child links to parent's real id");
+        } else {
+            assert_eq!(step.parent_step_id, "", "roots have no parent");
+        }
+        let test_step_id = format!("id-{}", step.step_path);
+        Ok(Response::new(CreateTestStepResponse {
+            test_step: Some(TestStep {
+                test_step_id,
+                ..step
+            }),
+        }))
+    });
+
+    mock.expect_create_test_measurements()
+        .times(1)
+        .returning(|req| {
+            let measurements = req.into_inner().test_measurements;
+            assert_eq!(measurements.len(), 1);
+            assert_eq!(measurements[0].test_step_id, "id-1");
+            assert_eq!(measurements[0].test_report_id, "r1");
+            Ok(Response::new(CreateTestMeasurementsResponse {
+                measurements_created_count: measurements.len() as i32,
+                measurement_ids: vec!["m1".into()],
+            }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let built = built_from_json(
+        r#"{
+            "name": "r", "test_system_name": "rig", "test_case": "tc",
+            "steps": [
+                { "name": "first", "measurements": [ { "name": "v", "numeric_value": 1.0 } ] },
+                { "name": "second", "steps": [ { "name": "child" } ] }
+            ]
+        }"#,
+    );
+
+    let created = service
+        .create_test_report(built)
+        .await
+        .expect("create_test_report failed");
+
+    assert_eq!(created.test_report_id, "r1");
+    assert_eq!(created.steps_created, 3);
+    assert_eq!(created.measurements_created, 1);
+}
+
+#[tokio::test]
+async fn create_test_report_surfaces_report_id_on_step_failure() {
+    let mut mock = MockTestReportServiceImpl::new();
+    mock.expect_create_test_report().returning(|_| {
+        Ok(Response::new(CreateTestReportResponse {
+            test_report: Some(TestReport {
+                test_report_id: "r1".into(),
+                ..Default::default()
+            }),
+        }))
+    });
+    mock.expect_create_test_step()
+        .returning(|_| Err(Status::internal("boom")));
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let built = built_from_json(
+        r#"{ "name": "r", "test_system_name": "rig", "test_case": "tc",
+             "steps": [ { "name": "s" } ] }"#,
+    );
+
+    let err = service
+        .create_test_report(built)
+        .await
+        .expect_err("expected step failure");
+
+    let msg = err.to_string();
+    assert!(msg.contains("r1"), "error should name the created report id: {msg}");
+}
+
+// --- append_test_measurements ---
+
+#[tokio::test]
+async fn append_test_measurements_sets_ids_and_batches() {
+    let mut mock = MockTestReportServiceImpl::new();
+    mock.expect_create_test_measurements()
+        .times(1)
+        .returning(|req| {
+            let measurements = req.into_inner().test_measurements;
+            assert_eq!(measurements.len(), 2);
+            for m in &measurements {
+                assert_eq!(m.test_report_id, "r9");
+                assert_eq!(m.test_step_id, "s9");
+            }
+            Ok(Response::new(CreateTestMeasurementsResponse {
+                measurements_created_count: measurements.len() as i32,
+                measurement_ids: vec!["m1".into(), "m2".into()],
+            }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let measurements = spec::build_measurements(
+        serde_json::from_str(
+            r#"[
+                { "name": "v", "numeric_value": 1.0 },
+                { "name": "ok", "boolean_value": true }
+            ]"#,
+        )
+        .unwrap(),
+    )
+    .expect("measurements should build");
+
+    let created = service
+        .append_test_measurements("r9".to_string(), "s9".to_string(), measurements)
+        .await
+        .expect("append_test_measurements failed");
+
+    assert_eq!(created, 2);
+}
+
+#[tokio::test]
+async fn append_test_measurements_propagates_grpc_error() {
+    let mut mock = MockTestReportServiceImpl::new();
+    mock.expect_create_test_measurements()
+        .returning(|_| Err(Status::not_found("no such step")));
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let measurements = spec::build_measurements(
+        serde_json::from_str(r#"[ { "name": "v", "numeric_value": 1.0 } ]"#).unwrap(),
+    )
+    .unwrap();
+
+    let err = service
+        .append_test_measurements("r9".to_string(), "missing".to_string(), measurements)
+        .await
+        .expect_err("expected error");
+
+    assert!(err.to_string().contains("failed to append test measurements"));
 }

--- a/rust/crates/sift_mcp/src/service/test_reports/test.rs
+++ b/rust/crates/sift_mcp/src/service/test_reports/test.rs
@@ -1,0 +1,279 @@
+use sift_rs::test_reports::v1::{
+    CountTestMeasurementsResponse, CountTestStepsResponse, ListTestMeasurementsResponse,
+    ListTestReportsResponse, ListTestStepsResponse, TestMeasurement, TestReport, TestStep,
+    test_report_service_server::TestReportServiceServer,
+};
+use sift_test_util::{grpc::memory_sift_channel, mock::test_reports::v1::MockTestReportServiceImpl};
+use tokio::task::JoinHandle;
+use tonic::{Response, Status, transport::Server};
+
+use super::TestReportService;
+use crate::policy::RetryPolicy;
+use crate::service::common::PAGE_SIZE;
+
+async fn service_with_mock(
+    mock: MockTestReportServiceImpl,
+) -> (TestReportService, JoinHandle<()>) {
+    let (client, server) = tokio::io::duplex(1024);
+    let channel = memory_sift_channel(client).await;
+
+    let handle = tokio::spawn(async move {
+        Server::builder()
+            .add_service(TestReportServiceServer::new(mock))
+            .serve_with_incoming(tokio_stream::once(Ok::<_, std::io::Error>(server)))
+            .await
+            .unwrap();
+    });
+
+    (TestReportService::new(channel, RetryPolicy::default()), handle)
+}
+
+#[tokio::test]
+async fn list_test_reports_returns_single_page() {
+    let mut mock = MockTestReportServiceImpl::new();
+    mock.expect_list_test_reports()
+        .withf(|req| req.get_ref().filter == "name == \"nightly\"")
+        .returning(|_| {
+            Ok(Response::new(ListTestReportsResponse {
+                test_reports: vec![
+                    TestReport {
+                        test_report_id: "r1".into(),
+                        name: "nightly".into(),
+                        ..Default::default()
+                    },
+                    TestReport {
+                        test_report_id: "r2".into(),
+                        name: "nightly".into(),
+                        ..Default::default()
+                    },
+                ],
+                next_page_token: String::new(),
+            }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let reports = service
+        .list_test_reports("name == \"nightly\"".to_string(), None, None)
+        .await
+        .expect("list_test_reports failed");
+
+    assert_eq!(reports.len(), 2);
+    assert_eq!(reports[0].test_report_id, "r1");
+    assert_eq!(reports[1].test_report_id, "r2");
+}
+
+#[tokio::test]
+async fn list_test_reports_paginates_until_token_empty() {
+    let mut mock = MockTestReportServiceImpl::new();
+    mock.expect_list_test_reports().returning(|req| {
+        let req = req.into_inner();
+        assert_eq!(req.page_size, PAGE_SIZE);
+        let (test_reports, next) = match req.page_token.as_str() {
+            "" => (
+                vec![TestReport {
+                    test_report_id: "r1".into(),
+                    ..Default::default()
+                }],
+                "page-2".to_string(),
+            ),
+            "page-2" => (
+                vec![TestReport {
+                    test_report_id: "r2".into(),
+                    ..Default::default()
+                }],
+                "page-3".to_string(),
+            ),
+            "page-3" => (
+                vec![TestReport {
+                    test_report_id: "r3".into(),
+                    ..Default::default()
+                }],
+                String::new(),
+            ),
+            other => return Err(Status::invalid_argument(format!("bad token: {other}"))),
+        };
+        Ok(Response::new(ListTestReportsResponse {
+            test_reports,
+            next_page_token: next,
+        }))
+    });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let reports = service
+        .list_test_reports(String::new(), None, None)
+        .await
+        .expect("list_test_reports failed");
+
+    let ids: Vec<&str> = reports.iter().map(|r| r.test_report_id.as_str()).collect();
+    assert_eq!(ids, vec!["r1", "r2", "r3"]);
+}
+
+#[tokio::test]
+async fn list_test_reports_respects_limit() {
+    let mut mock = MockTestReportServiceImpl::new();
+    mock.expect_list_test_reports().times(1).returning(|req| {
+        let req = req.into_inner();
+        assert_eq!(req.page_size, 2);
+        Ok(Response::new(ListTestReportsResponse {
+            test_reports: vec![
+                TestReport {
+                    test_report_id: "r1".into(),
+                    ..Default::default()
+                },
+                TestReport {
+                    test_report_id: "r2".into(),
+                    ..Default::default()
+                },
+            ],
+            next_page_token: "page-2".into(),
+        }))
+    });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let reports = service
+        .list_test_reports(String::new(), None, Some(2))
+        .await
+        .expect("list_test_reports failed");
+
+    assert_eq!(reports.len(), 2);
+}
+
+#[tokio::test]
+async fn list_test_reports_propagates_grpc_error() {
+    let mut mock = MockTestReportServiceImpl::new();
+    mock.expect_list_test_reports()
+        .returning(|_| Err(Status::invalid_argument("bad filter")));
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let err = service
+        .list_test_reports("nope".to_string(), None, None)
+        .await
+        .expect_err("expected error");
+
+    assert!(err.to_string().contains("failed to query test reports"));
+}
+
+#[tokio::test]
+async fn list_test_steps_returns_single_page() {
+    let mut mock = MockTestReportServiceImpl::new();
+    mock.expect_list_test_steps()
+        .withf(|req| req.get_ref().filter == "test_report_id == \"r1\"")
+        .returning(|_| {
+            Ok(Response::new(ListTestStepsResponse {
+                test_steps: vec![
+                    TestStep {
+                        test_step_id: "s1".into(),
+                        test_report_id: "r1".into(),
+                        step_path: "1".into(),
+                        ..Default::default()
+                    },
+                    TestStep {
+                        test_step_id: "s2".into(),
+                        test_report_id: "r1".into(),
+                        step_path: "1.1".into(),
+                        ..Default::default()
+                    },
+                ],
+                next_page_token: String::new(),
+            }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let steps = service
+        .list_test_steps("test_report_id == \"r1\"".to_string(), None, None)
+        .await
+        .expect("list_test_steps failed");
+
+    assert_eq!(steps.len(), 2);
+    assert_eq!(steps[0].step_path, "1");
+    assert_eq!(steps[1].step_path, "1.1");
+}
+
+#[tokio::test]
+async fn list_test_measurements_returns_single_page() {
+    let mut mock = MockTestReportServiceImpl::new();
+    mock.expect_list_test_measurements()
+        .withf(|req| req.get_ref().filter == "test_step_id == \"s1\"")
+        .returning(|_| {
+            Ok(Response::new(ListTestMeasurementsResponse {
+                test_measurements: vec![TestMeasurement {
+                    measurement_id: "m1".into(),
+                    test_step_id: "s1".into(),
+                    test_report_id: "r1".into(),
+                    passed: true,
+                    ..Default::default()
+                }],
+                next_page_token: String::new(),
+            }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let measurements = service
+        .list_test_measurements("test_step_id == \"s1\"".to_string(), None, None)
+        .await
+        .expect("list_test_measurements failed");
+
+    assert_eq!(measurements.len(), 1);
+    assert_eq!(measurements[0].measurement_id, "m1");
+    assert!(measurements[0].passed);
+}
+
+#[tokio::test]
+async fn count_test_steps_returns_count() {
+    let mut mock = MockTestReportServiceImpl::new();
+    mock.expect_count_test_steps()
+        .withf(|req| {
+            req.get_ref().filter == "test_report_id == \"r1\" && status == TEST_STATUS_FAILED"
+        })
+        .returning(|_| Ok(Response::new(CountTestStepsResponse { count: 7 })));
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let count = service
+        .count_test_steps(
+            "test_report_id == \"r1\" && status == TEST_STATUS_FAILED".to_string(),
+        )
+        .await
+        .expect("count_test_steps failed");
+
+    assert_eq!(count, 7);
+}
+
+#[tokio::test]
+async fn count_test_steps_propagates_grpc_error() {
+    let mut mock = MockTestReportServiceImpl::new();
+    mock.expect_count_test_steps()
+        .returning(|_| Err(Status::invalid_argument("bad filter")));
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let err = service
+        .count_test_steps("nope".to_string())
+        .await
+        .expect_err("expected error");
+
+    assert!(err.to_string().contains("failed to count test steps"));
+}
+
+#[tokio::test]
+async fn count_test_measurements_returns_count() {
+    let mut mock = MockTestReportServiceImpl::new();
+    mock.expect_count_test_measurements()
+        .withf(|req| req.get_ref().filter == "passed == false")
+        .returning(|_| Ok(Response::new(CountTestMeasurementsResponse { count: 3 })));
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let count = service
+        .count_test_measurements("passed == false".to_string())
+        .await
+        .expect("count_test_measurements failed");
+
+    assert_eq!(count, 3);
+}

--- a/rust/crates/sift_mcp/src/service/test_reports/test.rs
+++ b/rust/crates/sift_mcp/src/service/test_reports/test.rs
@@ -570,3 +570,79 @@ async fn append_test_measurements_propagates_grpc_error() {
 
     assert!(err.to_string().contains("failed to append test measurements"));
 }
+
+#[test]
+fn normalize_enum_filter_rewrites_canonical_names_to_short_form() {
+    use super::normalize_enum_filter;
+
+    assert_eq!(
+        normalize_enum_filter("status == \"TEST_STATUS_FAILED\""),
+        "status == \"failed\""
+    );
+    assert_eq!(
+        normalize_enum_filter("status == \"TEST_STATUS_IN_PROGRESS\""),
+        "status == \"in_progress\""
+    );
+    assert_eq!(
+        normalize_enum_filter("step_type == \"TEST_STEP_TYPE_ACTION\""),
+        "step_type == \"action\""
+    );
+    assert_eq!(
+        normalize_enum_filter("measurement_type == \"TEST_MEASUREMENT_TYPE_DOUBLE\""),
+        "measurement_type == \"double\""
+    );
+}
+
+#[test]
+fn normalize_enum_filter_handles_compound_and_already_short_filters() {
+    use super::normalize_enum_filter;
+
+    // Multiple enum values in one expression are each rewritten.
+    assert_eq!(
+        normalize_enum_filter(
+            "test_report_id == \"r1\" && status == \"TEST_STATUS_FAILED\" \
+             && step_type == \"TEST_STEP_TYPE_GROUP\""
+        ),
+        "test_report_id == \"r1\" && status == \"failed\" && step_type == \"group\""
+    );
+
+    // The short form the backend already accepts is left untouched.
+    assert_eq!(
+        normalize_enum_filter("status == \"failed\""),
+        "status == \"failed\""
+    );
+}
+
+#[test]
+fn normalize_enum_filter_leaves_unrelated_values_intact() {
+    use super::normalize_enum_filter;
+
+    // Identifiers, operators, and ordinary string values are not enum values and stay verbatim.
+    assert_eq!(
+        normalize_enum_filter("name == \"nightly\" && passed == false"),
+        "name == \"nightly\" && passed == false"
+    );
+
+    // A prefix with no suffix is not a valid enum value and is left alone.
+    assert_eq!(
+        normalize_enum_filter("name == \"TEST_STATUS_\""),
+        "name == \"TEST_STATUS_\""
+    );
+}
+
+#[tokio::test]
+async fn count_test_steps_forwards_short_enum_form() {
+    let mut mock = MockTestReportServiceImpl::new();
+    mock.expect_count_test_steps()
+        .withf(|req| req.get_ref().filter == "status == \"failed\"")
+        .returning(|_| Ok(Response::new(CountTestStepsResponse { count: 7 })));
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let count = service
+        .count_test_steps("status == \"TEST_STATUS_FAILED\"".to_string())
+        .await
+        .expect("count_test_steps failed");
+
+    assert_eq!(count, 7);
+}

--- a/rust/crates/sift_mcp/src/service/test_reports/test.rs
+++ b/rust/crates/sift_mcp/src/service/test_reports/test.rs
@@ -5,12 +5,14 @@ use sift_rs::test_reports::v1::{
     TestReport, TestStatus, TestStep, TestStepType, test_measurement,
     test_report_service_server::TestReportServiceServer,
 };
-use sift_test_util::{grpc::memory_sift_channel, mock::test_reports::v1::MockTestReportServiceImpl};
+use sift_test_util::{
+    grpc::memory_sift_channel, mock::test_reports::v1::MockTestReportServiceImpl,
+};
 use tokio::task::JoinHandle;
 use tonic::{Response, Status, transport::Server};
 
-use super::spec;
 use super::TestReportService;
+use super::spec;
 use crate::policy::RetryPolicy;
 use crate::service::common::PAGE_SIZE;
 
@@ -19,9 +21,7 @@ fn built_from_json(json: &str) -> spec::BuiltReport {
     spec::build(parsed).expect("spec should build")
 }
 
-async fn service_with_mock(
-    mock: MockTestReportServiceImpl,
-) -> (TestReportService, JoinHandle<()>) {
+async fn service_with_mock(mock: MockTestReportServiceImpl) -> (TestReportService, JoinHandle<()>) {
     let (client, server) = tokio::io::duplex(1024);
     let channel = memory_sift_channel(client).await;
 
@@ -33,7 +33,10 @@ async fn service_with_mock(
             .unwrap();
     });
 
-    (TestReportService::new(channel, RetryPolicy::default()), handle)
+    (
+        TestReportService::new(channel, RetryPolicy::default()),
+        handle,
+    )
 }
 
 #[tokio::test]
@@ -244,9 +247,7 @@ async fn count_test_steps_returns_count() {
     let (service, _h) = service_with_mock(mock).await;
 
     let count = service
-        .count_test_steps(
-            "test_report_id == \"r1\" && status == TEST_STATUS_FAILED".to_string(),
-        )
+        .count_test_steps("test_report_id == \"r1\" && status == TEST_STATUS_FAILED".to_string())
         .await
         .expect("count_test_steps failed");
 
@@ -306,10 +307,7 @@ fn build_computes_step_paths_and_parent_links() {
         .map(|s| (s.step_path.as_str(), s.parent_path.as_deref()))
         .collect();
     // Pre-order, with computed paths and parent links.
-    assert_eq!(
-        paths,
-        vec![("1", None), ("2", None), ("2.1", Some("2"))]
-    );
+    assert_eq!(paths, vec![("1", None), ("2", None), ("2.1", Some("2"))]);
     assert_eq!(built.steps[2].step.step_path, "2.1");
 }
 
@@ -404,10 +402,9 @@ fn build_rejects_unknown_enum_and_bad_timestamp() {
 
 #[test]
 fn build_rejects_empty_required_field() {
-    let empty_name = serde_json::from_str(
-        r#"{ "name": "", "test_system_name": "rig", "test_case": "tc" }"#,
-    )
-    .unwrap();
+    let empty_name =
+        serde_json::from_str(r#"{ "name": "", "test_system_name": "rig", "test_case": "tc" }"#)
+            .unwrap();
     assert!(spec::build(empty_name).is_err());
 }
 
@@ -431,7 +428,10 @@ async fn create_test_report_creates_tree_in_order() {
         let step = req.into_inner().test_step.expect("step present");
         assert_eq!(step.test_report_id, "r1");
         if step.step_path == "2.1" {
-            assert_eq!(step.parent_step_id, "id-2", "child links to parent's real id");
+            assert_eq!(
+                step.parent_step_id, "id-2",
+                "child links to parent's real id"
+            );
         } else {
             assert_eq!(step.parent_step_id, "", "roots have no parent");
         }
@@ -506,7 +506,10 @@ async fn create_test_report_surfaces_report_id_on_step_failure() {
         .expect_err("expected step failure");
 
     let msg = err.to_string();
-    assert!(msg.contains("r1"), "error should name the created report id: {msg}");
+    assert!(
+        msg.contains("r1"),
+        "error should name the created report id: {msg}"
+    );
 }
 
 // --- append_test_measurements ---
@@ -568,7 +571,10 @@ async fn append_test_measurements_propagates_grpc_error() {
         .await
         .expect_err("expected error");
 
-    assert!(err.to_string().contains("failed to append test measurements"));
+    assert!(
+        err.to_string()
+            .contains("failed to append test measurements")
+    );
 }
 
 #[test]

--- a/rust/crates/sift_mcp/src/service/url/mod.rs
+++ b/rust/crates/sift_mcp/src/service/url/mod.rs
@@ -142,7 +142,10 @@ impl UrlService {
     /// self-hosted `rest_uri` without an `api.` subdomain).
     pub fn build_test_report_url(&self, test_report_id: &str) -> Result<String, ErrorData> {
         let host = derive_web_host(&self.rest_uri)?;
-        Ok(format!("{host}/test-results/{}", encode_value(test_report_id)))
+        Ok(format!(
+            "{host}/test-results/{}",
+            encode_value(test_report_id)
+        ))
     }
 
     /// Build the Sift web URL for a single rule: `<host>/rules/<rule_id>`. The

--- a/rust/crates/sift_mcp/src/service/url/mod.rs
+++ b/rust/crates/sift_mcp/src/service/url/mod.rs
@@ -136,6 +136,15 @@ impl UrlService {
         Ok(format!("{host}/reports/{}", encode_value(report_id)))
     }
 
+    /// Build the Sift web URL for a single test report:
+    /// `<host>/test-results/<test_report_id>`. The host is derived from
+    /// `rest_uri`. Returns `INVALID_PARAMS` if the host cannot be derived (e.g. a
+    /// self-hosted `rest_uri` without an `api.` subdomain).
+    pub fn build_test_report_url(&self, test_report_id: &str) -> Result<String, ErrorData> {
+        let host = derive_web_host(&self.rest_uri)?;
+        Ok(format!("{host}/test-results/{}", encode_value(test_report_id)))
+    }
+
     /// Build the Sift web URL for a single rule: `<host>/rules/<rule_id>`. The
     /// host is derived from `rest_uri`. Returns `INVALID_PARAMS` if the host
     /// cannot be derived (e.g. a self-hosted `rest_uri` without an `api.`

--- a/rust/crates/sift_mcp/src/tool/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/mod.rs
@@ -8,3 +8,4 @@ pub mod ping;
 pub mod reports;
 pub mod rules;
 pub mod runs;
+pub mod test_reports;

--- a/rust/crates/sift_mcp/src/tool/test_reports/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/test_reports/mod.rs
@@ -1,0 +1,264 @@
+use rmcp::{
+    handler::server::wrapper::Parameters,
+    model::CallToolResult,
+    schemars::{self, JsonSchema},
+    tool, tool_router,
+};
+use serde::Deserialize;
+
+use crate::{
+    error::{self, from_anyhow},
+    server::SiftMcpServer,
+    tool::common::ListParams,
+};
+
+/// Filter-only parameters for the `count_*` test-results tools. Counting takes no
+/// ordering or page size, so it does not reuse `ListParams`.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CountParams {
+    pub(crate) filter: String,
+}
+
+#[tool_router(router = test_reports_router, vis = "pub(crate)")]
+impl SiftMcpServer {
+    #[tool(
+        name = "list_test_reports",
+        description = "
+            List test reports (test-results runs) in Sift, optionally filtered by a CEL expression and ordered
+            by one or more fields. A test report is the top of the results tree: it owns test steps, which own
+            test measurements. Start an audit here, then drill into `list_test_steps` and `list_test_measurements`.
+
+            Output:
+              - `{ \"test_reports\": [TestReport, ...] }`. Each item includes `test_report_id`, `status`, `name`,
+                `test_system_name`, `test_case`, `start_time`, `end_time`, `serial_number`, `part_number`,
+                `system_operator`, `run_id`, `metadata`, `is_archived`, and `archived_date`. `run_id` links the
+                report to the Sift run that holds the ingested channel data; empty when none is associated.
+
+            Parameters:
+              - `filter`: CEL expression. Pass an empty string to list everything. Filterable fields:
+                `test_report_id`, `status`, `name`, `test_system_name`, `test_case`, `start_time`, `end_time`,
+                `serial_number`, `part_number`, `system_operator`, `run_id`, `archived_date`,
+                `created_by_user_id`, `modified_by_user_id`, `metadata`. Reference metadata entries as
+                `metadata.{key}`. `status` matches the `TestStatus` enum: `TEST_STATUS_DRAFT`,
+                `TEST_STATUS_PASSED`, `TEST_STATUS_FAILED`, `TEST_STATUS_ABORTED`, `TEST_STATUS_ERROR`,
+                `TEST_STATUS_IN_PROGRESS`, `TEST_STATUS_SKIPPED`. Filtering `test_report_id == \"...\"` fetches one
+                report (there is no separate get tool).
+              - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `test_report_id`,
+                `name`, `test_system_name`, `test_case`, `start_time`, `end_time`, `created_date`, `modified_date`.
+                Default sort is `start_time desc` (newest first). Example: `\"start_time desc,name\"`.
+              - `limit`: optional cap on returned items. Values in `1..=1000` cap the result set. Omitting it OR
+                passing a value above 1000 returns ALL matching reports (paginated server-side).
+
+            Errors:
+              - `INVALID_PARAMS` if `filter` is not a valid CEL expression or `order_by` references an unknown field.
+              - `INTERNAL_ERROR` for upstream gRPC failures.
+
+            Guidance:
+              - To audit a single run, resolve the report first (by `name`, `run_id`, or `test_case`), then pass
+                its `test_report_id` to the step and measurement tools.
+        ",
+        annotations(title = "test_reports_router/list_test_reports", read_only_hint = true)
+    )]
+    pub async fn list_test_reports(&self, params: Parameters<ListParams>) -> error::McpResult {
+        let Parameters(ListParams {
+            filter,
+            order_by,
+            limit,
+        }) = params;
+
+        let out = self
+            .test_report_service
+            .list_test_reports(filter, order_by, limit)
+            .await
+            .map(|test_reports| serde_json::json!({ "test_reports": test_reports }))
+            .map_err(from_anyhow)?;
+
+        Ok(CallToolResult::structured(out))
+    }
+
+    #[tool(
+        name = "list_test_steps",
+        description = "
+            List test steps, optionally filtered by a CEL expression and ordered by one or more fields. Steps form
+            a tree within a report via `parent_step_id` and the hierarchical `step_path` (e.g. \"1\", \"1.1\",
+            \"1.2.3\"). Scope to one report with `test_report_id == \"...\"`.
+
+            Output:
+              - `{ \"test_steps\": [TestStep, ...] }`. Each item includes `test_step_id`, `test_report_id`,
+                `parent_step_id`, `name`, `description`, `step_type`, `step_path`, `status`, `start_time`,
+                `end_time`, `error_info` (`{ error_code, error_message }`), and `metadata`. `error_info` is
+                diagnostic only: a populated `error_info` does not by itself mean the step failed — derive
+                pass/fail from `status`.
+
+            Parameters:
+              - `filter`: CEL expression. Pass an empty string to list everything (rarely useful; almost always
+                scope by `test_report_id`). Filterable fields: `test_step_id`, `test_report_id`, `parent_step_id`,
+                `name`, `description`, `step_type`, `step_path`, `status`, `start_time`, `end_time`, `error_code`,
+                `error_message`, `created_date`, `modified_date`, `metadata`. `step_type` matches the
+                `TestStepType` enum: `TEST_STEP_TYPE_SEQUENCE`, `TEST_STEP_TYPE_GROUP`, `TEST_STEP_TYPE_ACTION`,
+                `TEST_STEP_TYPE_FLOW_CONTROL`. `status` matches `TestStatus` (see `list_test_reports`).
+              - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `test_step_id`,
+                `name`, `step_type`, `step_path`, `status`, `start_time`, `end_time`, `created_date`,
+                `modified_date`. Default sort is `step_path` ascending (tree order). Example:
+                `\"step_path asc,start_time desc\"`.
+              - `limit`: optional cap on returned items. Values in `1..=1000` cap the result set. Omitting it OR
+                passing a value above 1000 returns ALL matching steps (paginated server-side). Use
+                `count_test_steps` to learn the true total before relying on a capped page.
+
+            Errors:
+              - `INVALID_PARAMS` if `filter` is not a valid CEL expression or `order_by` references an unknown field.
+              - `INTERNAL_ERROR` for upstream gRPC failures.
+
+            Guidance:
+              - To find failures, filter `test_report_id == \"...\" && status == TEST_STATUS_FAILED`.
+              - Order by `step_path` to reconstruct the execution tree; use `parent_step_id` to attach children.
+        ",
+        annotations(title = "test_reports_router/list_test_steps", read_only_hint = true)
+    )]
+    pub async fn list_test_steps(&self, params: Parameters<ListParams>) -> error::McpResult {
+        let Parameters(ListParams {
+            filter,
+            order_by,
+            limit,
+        }) = params;
+
+        let out = self
+            .test_report_service
+            .list_test_steps(filter, order_by, limit)
+            .await
+            .map(|test_steps| serde_json::json!({ "test_steps": test_steps }))
+            .map_err(from_anyhow)?;
+
+        Ok(CallToolResult::structured(out))
+    }
+
+    #[tool(
+        name = "list_test_measurements",
+        description = "
+            List test measurements, optionally filtered by a CEL expression and ordered by one or more fields. A
+            measurement is a single recorded value on a step, with optional bounds and a pass/fail verdict. Scope
+            to a report with `test_report_id == \"...\"` or to one step with `test_step_id == \"...\"`.
+
+            Output:
+              - `{ \"test_measurements\": [TestMeasurement, ...] }`. Each item includes `measurement_id`,
+                `measurement_type`, `name`, `test_step_id`, `test_report_id`, the value (`numeric_value`,
+                `string_value`, or `boolean_value`), `unit`, bounds (`numeric_bounds` `{ min, max }` or
+                `string_bounds` `{ expected_value }`), `passed`, `timestamp`, `description`, `channel_names`, and
+                `metadata`. `channel_names` ties the measurement to Sift channels on the report's run for
+                cross-plotting in Explore.
+
+            Parameters:
+              - `filter`: CEL expression. Pass an empty string to list everything (almost always scope by
+                `test_report_id` or `test_step_id`). Filterable fields: `measurement_id`, `measurement_type`,
+                `name`, `test_step_id`, `test_report_id`, `numeric_value`, `string_value`, `boolean_value`,
+                `passed`, `timestamp`, `created_date`, `modified_date`, `metadata`. `measurement_type` matches the
+                `TestMeasurementType` enum: `TEST_MEASUREMENT_TYPE_DOUBLE`, `TEST_MEASUREMENT_TYPE_STRING`,
+                `TEST_MEASUREMENT_TYPE_BOOLEAN`, `TEST_MEASUREMENT_TYPE_LIMIT`.
+              - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `measurement_id`,
+                `name`, `measurement_type`, `test_step_id`, `test_report_id`, `passed`, `timestamp`,
+                `created_date`, `modified_date`. Default sort is `timestamp` ascending. Example:
+                `\"timestamp asc,name\"`.
+              - `limit`: optional cap on returned items. Values in `1..=1000` cap the result set. Omitting it OR
+                passing a value above 1000 returns ALL matching measurements (paginated server-side). Use
+                `count_test_measurements` to learn the true total before relying on a capped page.
+
+            Errors:
+              - `INVALID_PARAMS` if `filter` is not a valid CEL expression or `order_by` references an unknown field.
+              - `INTERNAL_ERROR` for upstream gRPC failures.
+
+            Guidance:
+              - To audit limit checks, filter `passed == false` within a report and compare each value against its
+                `numeric_bounds`/`string_bounds`.
+        ",
+        annotations(title = "test_reports_router/list_test_measurements", read_only_hint = true)
+    )]
+    pub async fn list_test_measurements(&self, params: Parameters<ListParams>) -> error::McpResult {
+        let Parameters(ListParams {
+            filter,
+            order_by,
+            limit,
+        }) = params;
+
+        let out = self
+            .test_report_service
+            .list_test_measurements(filter, order_by, limit)
+            .await
+            .map(|test_measurements| serde_json::json!({ "test_measurements": test_measurements }))
+            .map_err(from_anyhow)?;
+
+        Ok(CallToolResult::structured(out))
+    }
+
+    #[tool(
+        name = "count_test_steps",
+        description = "
+            Count test steps matching a CEL filter, without fetching them. Use this to learn the true total when a
+            report may hold more steps than the 1000-item list cap, or to reconcile expected vs actual counts in an
+            audit (e.g. \"how many steps failed in this report\").
+
+            Output:
+              - `{ \"count\": <int64> }`. The total number of steps matching the filter.
+
+            Parameters:
+              - `filter`: CEL expression. Pass an empty string to count all steps. Filterable fields are identical
+                to `list_test_steps`: `test_step_id`, `test_report_id`, `parent_step_id`, `name`, `description`,
+                `step_type`, `step_path`, `status`, `start_time`, `end_time`, `error_code`, `error_message`,
+                `created_date`, `modified_date`, `metadata`.
+
+            Errors:
+              - `INVALID_PARAMS` if `filter` is not a valid CEL expression.
+              - `INTERNAL_ERROR` for upstream gRPC failures.
+        ",
+        annotations(title = "test_reports_router/count_test_steps", read_only_hint = true)
+    )]
+    pub async fn count_test_steps(&self, params: Parameters<CountParams>) -> error::McpResult {
+        let Parameters(CountParams { filter }) = params;
+
+        let out = self
+            .test_report_service
+            .count_test_steps(filter)
+            .await
+            .map(|count| serde_json::json!({ "count": count }))
+            .map_err(from_anyhow)?;
+
+        Ok(CallToolResult::structured(out))
+    }
+
+    #[tool(
+        name = "count_test_measurements",
+        description = "
+            Count test measurements matching a CEL filter, without fetching them. Use this to learn the true total
+            when a report may hold more measurements than the 1000-item list cap, or to reconcile expected vs actual
+            counts in an audit (e.g. \"how many measurements failed their limits\").
+
+            Output:
+              - `{ \"count\": <int64> }`. The total number of measurements matching the filter.
+
+            Parameters:
+              - `filter`: CEL expression. Pass an empty string to count all measurements. Filterable fields are
+                identical to `list_test_measurements`: `measurement_id`, `measurement_type`, `name`,
+                `test_step_id`, `test_report_id`, `numeric_value`, `string_value`, `boolean_value`, `passed`,
+                `timestamp`, `created_date`, `modified_date`, `metadata`.
+
+            Errors:
+              - `INVALID_PARAMS` if `filter` is not a valid CEL expression.
+              - `INTERNAL_ERROR` for upstream gRPC failures.
+        ",
+        annotations(title = "test_reports_router/count_test_measurements", read_only_hint = true)
+    )]
+    pub async fn count_test_measurements(
+        &self,
+        params: Parameters<CountParams>,
+    ) -> error::McpResult {
+        let Parameters(CountParams { filter }) = params;
+
+        let out = self
+            .test_report_service
+            .count_test_measurements(filter)
+            .await
+            .map(|count| serde_json::json!({ "count": count }))
+            .map_err(from_anyhow)?;
+
+        Ok(CallToolResult::structured(out))
+    }
+}

--- a/rust/crates/sift_mcp/src/tool/test_reports/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/test_reports/mod.rs
@@ -11,8 +11,11 @@ use crate::{
     error::{self, from_anyhow},
     server::SiftMcpServer,
     service::test_reports::spec::{self, ReportSpec},
-    tool::common::ListParams,
+    tool::common::{ListParams, url_clause},
 };
+
+#[cfg(test)]
+mod test;
 
 /// Parse the `report_json` author spec, mapping any deserialization error to `INVALID_PARAMS`.
 fn parse_report_spec(report_json: &str) -> Result<ReportSpec, ErrorData> {
@@ -313,7 +316,10 @@ impl SiftMcpServer {
                   `channel_names` (array), and `metadata`.
 
             Output:
-              - `{ \"test_report_id\": \"...\", \"steps_created\": N, \"measurements_created\": M, \"next_step\": \"...\" }`.
+              - `{ \"test_report_id\": \"...\", \"steps_created\": N, \"measurements_created\": M, \"report_url\": string|null, \"next_step\": \"...\" }`.
+                `report_url` is the report's Sift web link (`<host>/test-results/<id>`), or null when
+                the host cannot be derived (self-hosted deployments). Surface it to the user as a
+                clickable link.
 
             Errors:
               - `INVALID_PARAMS` if `report_json` is not valid JSON, omits a required field, names an
@@ -344,13 +350,19 @@ impl SiftMcpServer {
             .await
             .map_err(from_anyhow)?;
 
+        let report_url = self
+            .url_service
+            .build_test_report_url(&created.test_report_id)
+            .ok();
+
         let next_step = format!(
-            "Created test report `{}` with {} step(s) and {} measurement(s) in Sift. Tell the user \
-             the new `test_report_id`. If they haven't indicated a next step, offer to verify with \
-             `list_test_steps` (filter `test_report_id == \"{}\"`).",
+            "Created test report `{}` with {} step(s) and {} measurement(s) in Sift.{} Tell the \
+             user the new `test_report_id` and surface the link. If they haven't indicated a next \
+             step, offer to verify with `list_test_steps` (filter `test_report_id == \"{}\"`).",
             created.test_report_id,
             created.steps_created,
             created.measurements_created,
+            url_clause(report_url.as_deref()),
             created.test_report_id,
         );
 
@@ -358,6 +370,7 @@ impl SiftMcpServer {
             "test_report_id": created.test_report_id,
             "steps_created": created.steps_created,
             "measurements_created": created.measurements_created,
+            "report_url": report_url,
             "next_step": next_step,
         }));
         result.content = vec![Content::text(next_step)];
@@ -381,7 +394,8 @@ impl SiftMcpServer {
                 default now), `description`, `channel_names`, and `metadata`. Must be non-empty.
 
             Output:
-              - `{ \"test_report_id\": \"...\", \"test_step_id\": \"...\", \"measurements_created\": N, \"next_step\": \"...\" }`.
+              - `{ \"test_report_id\": \"...\", \"test_step_id\": \"...\", \"measurements_created\": N, \"report_url\": string|null, \"next_step\": \"...\" }`.
+                `report_url` is the report's Sift web link, or null when the host cannot be derived.
 
             Errors:
               - `INVALID_PARAMS` if `measurements_json` is not a valid array, is empty, or a
@@ -425,16 +439,20 @@ impl SiftMcpServer {
             .await
             .map_err(from_anyhow)?;
 
+        let report_url = self.url_service.build_test_report_url(&test_report_id).ok();
+
         let next_step = format!(
             "Appended {created} measurement(s) to step `{test_step_id}` in report \
-             `{test_report_id}`. Tell the user. If they haven't indicated a next step, offer to \
+             `{test_report_id}`.{} Tell the user. If they haven't indicated a next step, offer to \
              verify with `list_test_measurements` (filter `test_step_id == \"{test_step_id}\"`).",
+            url_clause(report_url.as_deref()),
         );
 
         let mut result = CallToolResult::structured(serde_json::json!({
             "test_report_id": test_report_id,
             "test_step_id": test_step_id,
             "measurements_created": created,
+            "report_url": report_url,
             "next_step": next_step,
         }));
         result.content = vec![Content::text(next_step)];

--- a/rust/crates/sift_mcp/src/tool/test_reports/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/test_reports/mod.rs
@@ -1,6 +1,7 @@
 use rmcp::{
+    ErrorData,
     handler::server::wrapper::Parameters,
-    model::CallToolResult,
+    model::{CallToolResult, Content},
     schemars::{self, JsonSchema},
     tool, tool_router,
 };
@@ -9,14 +10,33 @@ use serde::Deserialize;
 use crate::{
     error::{self, from_anyhow},
     server::SiftMcpServer,
+    service::test_reports::spec::{self, ReportSpec},
     tool::common::ListParams,
 };
+
+/// Parse the `report_json` author spec, mapping any deserialization error to `INVALID_PARAMS`.
+fn parse_report_spec(report_json: &str) -> Result<ReportSpec, ErrorData> {
+    serde_json::from_str::<ReportSpec>(report_json)
+        .map_err(|e| ErrorData::invalid_params(format!("`report_json` is not valid: {e}"), None))
+}
 
 /// Filter-only parameters for the `count_*` test-results tools. Counting takes no
 /// ordering or page size, so it does not reuse `ListParams`.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct CountParams {
     pub(crate) filter: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateTestReportParams {
+    pub(crate) report_json: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AppendMeasurementsParams {
+    pub(crate) test_report_id: String,
+    pub(crate) test_step_id: String,
+    pub(crate) measurements_json: String,
 }
 
 #[tool_router(router = test_reports_router, vis = "pub(crate)")]
@@ -260,5 +280,164 @@ impl SiftMcpServer {
             .map_err(from_anyhow)?;
 
         Ok(CallToolResult::structured(out))
+    }
+
+    #[tool(
+        name = "create_test_report",
+        description = "
+            Create a test report together with its tree of steps and measurements in one call,
+            from a single JSON document. WRITE: this creates data in Sift. Confirm the destination
+            with the user before calling, and report back what was created.
+
+            Parameters:
+              - `report_json`: a JSON object describing the report. Shape:
+                - Report fields: `name` (required), `test_system_name` (required), `test_case`
+                  (required), `status` (optional, default `PASSED`; accepts `PASSED` or
+                  `TEST_STATUS_PASSED`), `start_time`/`end_time` (optional RFC3339, e.g.
+                  \"2026-06-24T10:00:00Z\"; default now), `serial_number`, `part_number`,
+                  `system_operator`, `run_id` (optional; links the report to an existing Sift run),
+                  `metadata` (optional flat object of string/number/bool values).
+                - `steps`: optional array. Each step has `name` (required), `status` (optional,
+                  default `PASSED`), `step_type` (optional, default `ACTION`; one of `SEQUENCE`,
+                  `GROUP`, `ACTION`, `FLOW_CONTROL`), `description`, `start_time`/`end_time`
+                  (optional, default the report window), `error_info` (`{ error_code, error_message }`),
+                  `metadata`, `measurements`, and a nested `steps` array for children. `step_path`
+                  and `parent_step_id` are computed from nesting (roots `1`, `2`; child of `1` is
+                  `1.1`) — do not supply them.
+                - Each measurement has `name` (required), EXACTLY ONE of `numeric_value`,
+                  `string_value`, or `boolean_value`, optional `numeric_bounds` (`{ min, max }`, with
+                  `numeric_value`) or `string_expected` (with `string_value`), `unit`, `passed`
+                  (optional; computed from bounds when omitted — numeric bounds inclusive, string
+                  equals `string_expected`, else true), `measurement_type` (optional; derived from
+                  the value kind), `timestamp` (optional RFC3339, default the step start), `description`,
+                  `channel_names` (array), and `metadata`.
+
+            Output:
+              - `{ \"test_report_id\": \"...\", \"steps_created\": N, \"measurements_created\": M, \"next_step\": \"...\" }`.
+
+            Errors:
+              - `INVALID_PARAMS` if `report_json` is not valid JSON, omits a required field, names an
+                unknown enum value, has a non-RFC3339 timestamp, or a measurement does not set exactly
+                one value (or pairs bounds with the wrong value kind).
+              - `INTERNAL_ERROR` for upstream gRPC failures.
+
+            Guidance:
+              - The create calls are not transactional. If a step or measurement fails after the report
+                is created, the report and earlier steps remain; the error names the created
+                `test_report_id`. Verify with `list_test_steps` (filter `test_report_id == \"...\"`).
+        ",
+        annotations(title = "test_reports_router/create_test_report", read_only_hint = false)
+    )]
+    pub async fn create_test_report(
+        &self,
+        params: Parameters<CreateTestReportParams>,
+    ) -> error::McpResult {
+        let Parameters(CreateTestReportParams { report_json }) = params;
+
+        let report_spec = parse_report_spec(&report_json)?;
+        let built = spec::build(report_spec)
+            .map_err(|e| ErrorData::invalid_params(format!("{e}"), None))?;
+
+        let created = self
+            .test_report_service
+            .create_test_report(built)
+            .await
+            .map_err(from_anyhow)?;
+
+        let next_step = format!(
+            "Created test report `{}` with {} step(s) and {} measurement(s) in Sift. Tell the user \
+             the new `test_report_id`. If they haven't indicated a next step, offer to verify with \
+             `list_test_steps` (filter `test_report_id == \"{}\"`).",
+            created.test_report_id,
+            created.steps_created,
+            created.measurements_created,
+            created.test_report_id,
+        );
+
+        let mut result = CallToolResult::structured(serde_json::json!({
+            "test_report_id": created.test_report_id,
+            "steps_created": created.steps_created,
+            "measurements_created": created.measurements_created,
+            "next_step": next_step,
+        }));
+        result.content = vec![Content::text(next_step)];
+        Ok(result)
+    }
+
+    #[tool(
+        name = "append_test_measurements",
+        description = "
+            Append measurements to an existing test step. WRITE: this creates data in Sift.
+            Confirm the destination with the user before calling.
+
+            Parameters:
+              - `test_report_id`: the report the step belongs to (required).
+              - `test_step_id`: the step to attach the measurements to (required).
+              - `measurements_json`: a JSON array of measurement objects, each with the same shape
+                as a measurement in `create_test_report`: `name` (required), EXACTLY ONE of
+                `numeric_value`/`string_value`/`boolean_value`, optional `numeric_bounds`
+                (`{ min, max }`) or `string_expected`, `unit`, `passed` (computed from bounds when
+                omitted), `measurement_type` (derived from the value kind), `timestamp` (RFC3339,
+                default now), `description`, `channel_names`, and `metadata`. Must be non-empty.
+
+            Output:
+              - `{ \"test_report_id\": \"...\", \"test_step_id\": \"...\", \"measurements_created\": N, \"next_step\": \"...\" }`.
+
+            Errors:
+              - `INVALID_PARAMS` if `measurements_json` is not a valid array, is empty, or a
+                measurement does not set exactly one value (or pairs bounds with the wrong value kind).
+              - `RESOURCE_NOT_FOUND` / `INVALID_PARAMS` if `test_report_id` or `test_step_id` does not
+                exist (the server rejects unknown ids).
+              - `INTERNAL_ERROR` for upstream gRPC failures.
+        ",
+        annotations(
+            title = "test_reports_router/append_test_measurements",
+            read_only_hint = false
+        )
+    )]
+    pub async fn append_test_measurements(
+        &self,
+        params: Parameters<AppendMeasurementsParams>,
+    ) -> error::McpResult {
+        let Parameters(AppendMeasurementsParams {
+            test_report_id,
+            test_step_id,
+            measurements_json,
+        }) = params;
+
+        let specs: Vec<spec::MeasurementSpec> =
+            serde_json::from_str(&measurements_json).map_err(|e| {
+                ErrorData::invalid_params(format!("`measurements_json` is not valid: {e}"), None)
+            })?;
+        if specs.is_empty() {
+            return Err(ErrorData::invalid_params(
+                "`measurements_json` must contain at least one measurement",
+                None,
+            ));
+        }
+
+        let measurements =
+            spec::build_measurements(specs).map_err(|e| ErrorData::invalid_params(format!("{e}"), None))?;
+
+        let created = self
+            .test_report_service
+            .append_test_measurements(test_report_id.clone(), test_step_id.clone(), measurements)
+            .await
+            .map_err(from_anyhow)?;
+
+        let next_step = format!(
+            "Appended {created} measurement(s) to step `{test_step_id}` in report \
+             `{test_report_id}`. Tell the user. If they haven't indicated a next step, offer to \
+             verify with `list_test_measurements` (filter `test_step_id == \"{test_step_id}\"`).",
+        );
+
+        let mut result = CallToolResult::structured(serde_json::json!({
+            "test_report_id": test_report_id,
+            "test_step_id": test_step_id,
+            "measurements_created": created,
+            "next_step": next_step,
+        }));
+        result.content = vec![Content::text(next_step)];
+        Ok(result)
     }
 }

--- a/rust/crates/sift_mcp/src/tool/test_reports/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/test_reports/mod.rs
@@ -193,7 +193,10 @@ impl SiftMcpServer {
               - To audit limit checks, filter `passed == false` within a report and compare each value against its
                 `numeric_bounds`/`string_bounds`.
         ",
-        annotations(title = "test_reports_router/list_test_measurements", read_only_hint = true)
+        annotations(
+            title = "test_reports_router/list_test_measurements",
+            read_only_hint = true
+        )
     )]
     pub async fn list_test_measurements(&self, params: Parameters<ListParams>) -> error::McpResult {
         let Parameters(ListParams {
@@ -267,7 +270,10 @@ impl SiftMcpServer {
               - `INVALID_PARAMS` if `filter` is not a valid CEL expression.
               - `INTERNAL_ERROR` for upstream gRPC failures.
         ",
-        annotations(title = "test_reports_router/count_test_measurements", read_only_hint = true)
+        annotations(
+            title = "test_reports_router/count_test_measurements",
+            read_only_hint = true
+        )
     )]
     pub async fn count_test_measurements(
         &self,
@@ -332,7 +338,10 @@ impl SiftMcpServer {
                 is created, the report and earlier steps remain; the error names the created
                 `test_report_id`. Verify with `list_test_steps` (filter `test_report_id == \"...\"`).
         ",
-        annotations(title = "test_reports_router/create_test_report", read_only_hint = false)
+        annotations(
+            title = "test_reports_router/create_test_report",
+            read_only_hint = false
+        )
     )]
     pub async fn create_test_report(
         &self,
@@ -430,8 +439,8 @@ impl SiftMcpServer {
             ));
         }
 
-        let measurements =
-            spec::build_measurements(specs).map_err(|e| ErrorData::invalid_params(format!("{e}"), None))?;
+        let measurements = spec::build_measurements(specs)
+            .map_err(|e| ErrorData::invalid_params(format!("{e}"), None))?;
 
         let created = self
             .test_report_service

--- a/rust/crates/sift_mcp/src/tool/test_reports/test.rs
+++ b/rust/crates/sift_mcp/src/tool/test_reports/test.rs
@@ -1,0 +1,83 @@
+use rmcp::handler::server::wrapper::Parameters;
+use sift_rs::test_reports::v1::{
+    CreateTestMeasurementsResponse, CreateTestReportResponse, TestReport,
+    test_report_service_server::TestReportServiceServer,
+};
+use sift_test_util::{
+    grpc::memory_sift_channel, mock::test_reports::v1::MockTestReportServiceImpl,
+};
+use tokio::task::JoinHandle;
+use tonic::{Response, transport::Server};
+
+use super::{AppendMeasurementsParams, CreateTestReportParams};
+use crate::{server::SiftMcpServer, tool::common::test_support::structured_field};
+
+async fn server_with_mock(mock: MockTestReportServiceImpl) -> (SiftMcpServer, JoinHandle<()>) {
+    let (client, server) = tokio::io::duplex(1024);
+    let channel = memory_sift_channel(client).await;
+
+    let handle = tokio::spawn(async move {
+        Server::builder()
+            .add_service(TestReportServiceServer::new(mock))
+            .serve_with_incoming(tokio_stream::once(Ok::<_, std::io::Error>(server)))
+            .await
+            .unwrap();
+    });
+
+    (
+        SiftMcpServer::new(channel, String::from("https://api.test.local")),
+        handle,
+    )
+}
+
+#[tokio::test]
+async fn create_test_report_surfaces_url() {
+    let mut mock = MockTestReportServiceImpl::new();
+    mock.expect_create_test_report().returning(|_| {
+        Ok(Response::new(CreateTestReportResponse {
+            test_report: Some(TestReport {
+                test_report_id: "tr1".into(),
+                ..Default::default()
+            }),
+        }))
+    });
+
+    let (server, _h) = server_with_mock(mock).await;
+
+    let params = CreateTestReportParams {
+        report_json: r#"{"name":"n","test_system_name":"s","test_case":"c"}"#.into(),
+    };
+    let resp = server
+        .create_test_report(Parameters(params))
+        .await
+        .expect("create_test_report failed");
+
+    let report_url = structured_field(resp, "report_url");
+    assert_eq!(report_url, "https://app.test.local/test-results/tr1");
+}
+
+#[tokio::test]
+async fn append_test_measurements_surfaces_url() {
+    let mut mock = MockTestReportServiceImpl::new();
+    mock.expect_create_test_measurements().returning(|_| {
+        Ok(Response::new(CreateTestMeasurementsResponse {
+            measurements_created_count: 1,
+            measurement_ids: vec!["m1".into()],
+        }))
+    });
+
+    let (server, _h) = server_with_mock(mock).await;
+
+    let params = AppendMeasurementsParams {
+        test_report_id: "tr1".into(),
+        test_step_id: "ts1".into(),
+        measurements_json: r#"[{"name":"v","numeric_value":1.0}]"#.into(),
+    };
+    let resp = server
+        .append_test_measurements(Parameters(params))
+        .await
+        .expect("append_test_measurements failed");
+
+    let report_url = structured_field(resp, "report_url");
+    assert_eq!(report_url, "https://app.test.local/test-results/tr1");
+}

--- a/rust/crates/sift_test_util/src/mock/mod.rs
+++ b/rust/crates/sift_test_util/src/mock/mod.rs
@@ -5,6 +5,7 @@ pub mod data;
 pub mod reports;
 pub mod rules;
 pub mod runs;
+pub mod test_reports;
 
 /// A test demonstrating a little bit of everything of how to leverage the mock API.
 #[cfg(test)]

--- a/rust/crates/sift_test_util/src/mock/test_reports.rs
+++ b/rust/crates/sift_test_util/src/mock/test_reports.rs
@@ -1,0 +1,1 @@
+pub mod v1;

--- a/rust/crates/sift_test_util/src/mock/test_reports/v1.rs
+++ b/rust/crates/sift_test_util/src/mock/test_reports/v1.rs
@@ -1,0 +1,93 @@
+use async_trait::async_trait;
+use mockall::mock;
+use sift_rs::test_reports::v1::{
+    CountTestMeasurementsRequest, CountTestMeasurementsResponse, CountTestStepsRequest,
+    CountTestStepsResponse, CreateTestMeasurementRequest, CreateTestMeasurementResponse,
+    CreateTestMeasurementsRequest, CreateTestMeasurementsResponse, CreateTestReportRequest,
+    CreateTestReportResponse, CreateTestStepRequest, CreateTestStepResponse,
+    DeleteTestMeasurementRequest, DeleteTestMeasurementResponse, DeleteTestReportRequest,
+    DeleteTestReportResponse, DeleteTestStepRequest, DeleteTestStepResponse, GetTestReportRequest,
+    GetTestReportResponse, ImportTestReportRequest, ImportTestReportResponse,
+    ListTestMeasurementsRequest, ListTestMeasurementsResponse, ListTestReportsRequest,
+    ListTestReportsResponse, ListTestStepsRequest, ListTestStepsResponse,
+    UpdateTestMeasurementRequest, UpdateTestMeasurementResponse, UpdateTestReportRequest,
+    UpdateTestReportResponse, UpdateTestStepRequest, UpdateTestStepResponse,
+    test_report_service_server::TestReportService,
+};
+use tonic::{Request, Response, Status};
+
+mock! {
+    pub TestReportServiceImpl {}
+
+    #[async_trait]
+    impl TestReportService for TestReportServiceImpl {
+        async fn import_test_report(
+            &self,
+            request: Request<ImportTestReportRequest>,
+        ) -> std::result::Result<Response<ImportTestReportResponse>, Status>;
+        async fn create_test_report(
+            &self,
+            request: Request<CreateTestReportRequest>,
+        ) -> std::result::Result<Response<CreateTestReportResponse>, Status>;
+        async fn get_test_report(
+            &self,
+            request: Request<GetTestReportRequest>,
+        ) -> std::result::Result<Response<GetTestReportResponse>, Status>;
+        async fn list_test_reports(
+            &self,
+            request: Request<ListTestReportsRequest>,
+        ) -> std::result::Result<Response<ListTestReportsResponse>, Status>;
+        async fn update_test_report(
+            &self,
+            request: Request<UpdateTestReportRequest>,
+        ) -> std::result::Result<Response<UpdateTestReportResponse>, Status>;
+        async fn delete_test_report(
+            &self,
+            request: Request<DeleteTestReportRequest>,
+        ) -> std::result::Result<Response<DeleteTestReportResponse>, Status>;
+        async fn create_test_step(
+            &self,
+            request: Request<CreateTestStepRequest>,
+        ) -> std::result::Result<Response<CreateTestStepResponse>, Status>;
+        async fn list_test_steps(
+            &self,
+            request: Request<ListTestStepsRequest>,
+        ) -> std::result::Result<Response<ListTestStepsResponse>, Status>;
+        async fn update_test_step(
+            &self,
+            request: Request<UpdateTestStepRequest>,
+        ) -> std::result::Result<Response<UpdateTestStepResponse>, Status>;
+        async fn delete_test_step(
+            &self,
+            request: Request<DeleteTestStepRequest>,
+        ) -> std::result::Result<Response<DeleteTestStepResponse>, Status>;
+        async fn create_test_measurement(
+            &self,
+            request: Request<CreateTestMeasurementRequest>,
+        ) -> std::result::Result<Response<CreateTestMeasurementResponse>, Status>;
+        async fn create_test_measurements(
+            &self,
+            request: Request<CreateTestMeasurementsRequest>,
+        ) -> std::result::Result<Response<CreateTestMeasurementsResponse>, Status>;
+        async fn list_test_measurements(
+            &self,
+            request: Request<ListTestMeasurementsRequest>,
+        ) -> std::result::Result<Response<ListTestMeasurementsResponse>, Status>;
+        async fn count_test_steps(
+            &self,
+            request: Request<CountTestStepsRequest>,
+        ) -> std::result::Result<Response<CountTestStepsResponse>, Status>;
+        async fn count_test_measurements(
+            &self,
+            request: Request<CountTestMeasurementsRequest>,
+        ) -> std::result::Result<Response<CountTestMeasurementsResponse>, Status>;
+        async fn update_test_measurement(
+            &self,
+            request: Request<UpdateTestMeasurementRequest>,
+        ) -> std::result::Result<Response<UpdateTestMeasurementResponse>, Status>;
+        async fn delete_test_measurement(
+            &self,
+            request: Request<DeleteTestMeasurementRequest>,
+        ) -> std::result::Result<Response<DeleteTestMeasurementResponse>, Status>;
+    }
+}


### PR DESCRIPTION
Adds MCP support for test results: reports, steps, and measurements.