### PR TITLE
rust(feature): data review tools in mcp

### DIFF
--- a/rust/crates/sift_cli/assets/docs/src/agents/mcp.md
+++ b/rust/crates/sift_cli/assets/docs/src/agents/mcp.md
@@ -36,12 +36,19 @@ not run interactively.
 | `list_runs`      | List runs, with filtering and ordering.                                       |
 | `list_channels`  | List channels for an asset.                                                   |
 | `list_reports`   | List reports, with filtering and ordering.                                    |
+| `list_report_rule_summaries` | List the per-rule pass/fail/open summaries for a single report.   |
+| `create_report`  | Create a report over a run, from a template or a set of rules.                |
+| `update_report`  | Update a report's metadata (replace semantics).                               |
+| `list_annotations` | List annotations, with filtering and ordering.                              |
+| `create_annotation` | Create a data-review or phase annotation over a time range.                |
+| `update_annotation` | Update an annotation's fields (replace semantics for collections).         |
 | `list_rules`     | List rules, with filtering and ordering.                                      |
 | `list_rule_versions` | List the version history of a single rule.                                |
 | `get_data`       | Download channel data for an asset/run to a Parquet file, with optional decimation. |
 | `sql`            | Run SQL over one or more Parquet files; chain after `get_data` for analysis.  |
 | `upload_dataset` | Stream a Parquet dataset into Sift.                                           |
 | `update_asset`   | Update an asset's tags and/or metadata (replace semantics).                   |
+| `update_run`     | Update a run's fields (name, time bounds, pin, tags, metadata).               |
 | `create_rule`    | Create a rule from a JSON definition.                                         |
 | `update_rule`    | Update specific fields of a rule; unspecified fields are preserved.          |
 | `archive_rule`   | Archive a rule so it stops evaluating.                                        |

--- a/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
+++ b/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
@@ -17,14 +17,20 @@ to combine them when working with Sift.
 1. **Sift MCP server** — started by `sift-cli mcp`. The preferred surface for
    agents. Exposes structured, authenticated tools:
    - `list_assets`, `list_runs`, `list_channels`, `list_reports`, `list_rules`,
-     `list_rule_versions`: discover what exists.
+     `list_rule_versions`, `list_annotations`: discover what exists.
+   - `list_report_rule_summaries`: per-rule pass/fail/open breakdown for a report.
    - `get_data`: download channel data for an asset/run to a Parquet file.
    - `sql`: run SQL over one or more Parquet files (chain after `get_data`).
    - `upload_dataset`: stream a Parquet dataset into Sift.
    - `update_asset`: replace an existing asset's tags and/or metadata (write —
      replace semantics, so read-modify-write when appending).
+   - `update_run`: update a run's name, time bounds, pin state, tags, or metadata
+     (write — tags/metadata use replace semantics).
    - `create_rule`, `update_rule`, `archive_rule`, `unarchive_rule`: manage rules
      (writes — confirm the change with the user first).
+   - `create_annotation`, `update_annotation`: manage annotations (writes —
+     collections use replace semantics, so confirm the change first).
+   - `create_report`, `update_report`: manage reports (writes — confirm first).
    - `explore_url`: build a Sift Explore deep-link for an asset/run/channel
      selection, with an optional panel/chart pre-defined. Surface the URL
      inline as a clickable link so the user can open the view.

--- a/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
@@ -31,14 +31,20 @@ to combine them when working with Sift.
 1. **Sift MCP server** — started by `sift-cli mcp`. The preferred surface for
    agents. Exposes structured, authenticated tools:
    - `list_assets`, `list_runs`, `list_channels`, `list_reports`, `list_rules`,
-     `list_rule_versions`: discover what exists.
+     `list_rule_versions`, `list_annotations`: discover what exists.
+   - `list_report_rule_summaries`: per-rule pass/fail/open breakdown for a report.
    - `get_data`: download channel data for an asset/run to a Parquet file.
    - `sql`: run SQL over one or more Parquet files (chain after `get_data`).
    - `upload_dataset`: stream a Parquet dataset into Sift.
    - `update_asset`: replace an existing asset's tags and/or metadata (write —
      replace semantics, so read-modify-write when appending).
+   - `update_run`: update a run's name, time bounds, pin state, tags, or metadata
+     (write — tags/metadata use replace semantics).
    - `create_rule`, `update_rule`, `archive_rule`, `unarchive_rule`: manage rules
      (writes — confirm the change with the user first).
+   - `create_annotation`, `update_annotation`: manage annotations (writes —
+     collections use replace semantics, so confirm the change first).
+   - `create_report`, `update_report`: manage reports (writes — confirm first).
    - `explore_url`: build a Sift Explore deep-link for an asset/run/channel
      selection, with an optional panel/chart pre-defined. Surface the URL
      inline as a clickable link so the user can open the view.

--- a/rust/crates/sift_mcp/src/server/mod.rs
+++ b/rust/crates/sift_mcp/src/server/mod.rs
@@ -11,9 +11,9 @@ use sift_rs::SiftChannel;
 
 use crate::policy::RetryPolicy;
 use crate::service::{
-    assets::AssetService, channels::ChannelService, data::DataService, explore::ExploreService,
-    ingest::IngestService, ping::PingService, reports::ReportService, rules::RuleService,
-    runs::RunService,
+    annotations::AnnotationService, assets::AssetService, channels::ChannelService,
+    data::DataService, ingest::IngestService, ping::PingService, reports::ReportService,
+    rules::RuleService, runs::RunService, url::UrlService,
 };
 
 #[derive(Clone)]
@@ -21,10 +21,11 @@ pub struct SiftMcpServer {
     pub tool_router: ToolRouter<Self>,
     pub prompt_router: PromptRouter<Self>,
 
+    pub annotation_service: AnnotationService,
     pub asset_service: AssetService,
     pub channel_service: ChannelService,
     pub data_service: DataService,
-    pub explore_service: ExploreService,
+    pub url_service: UrlService,
     pub ingest_service: IngestService,
     pub ping_service: PingService,
     pub run_service: RunService,
@@ -53,15 +54,17 @@ impl SiftMcpServer {
         tool_router.merge(Self::explore_router());
         tool_router.merge(Self::ping_router());
         tool_router.merge(Self::rules_router());
+        tool_router.merge(Self::annotations_router());
 
         let prompt_router = Self::prompt_router();
 
         let retry_policy = RetryPolicy::default();
 
+        let annotation_service = AnnotationService::new(channel.clone(), retry_policy.clone());
         let asset_service = AssetService::new(channel.clone(), retry_policy.clone());
         let data_service = DataService::new(channel.clone(), retry_policy.clone());
         let channel_service = ChannelService::new(channel.clone(), retry_policy.clone());
-        let explore_service = ExploreService::new(rest_uri);
+        let url_service = UrlService::new(rest_uri);
         let ingest_service = IngestService::new(channel.clone());
         let ping_service = PingService::new(channel.clone(), retry_policy.clone());
         let run_service = RunService::new(channel.clone(), retry_policy.clone());
@@ -69,10 +72,11 @@ impl SiftMcpServer {
         let rule_service = RuleService::new(channel.clone(), retry_policy);
 
         Self {
+            annotation_service,
             asset_service,
             channel_service,
             data_service,
-            explore_service,
+            url_service,
             ingest_service,
             ping_service,
             run_service,

--- a/rust/crates/sift_mcp/src/service/annotations/mod.rs
+++ b/rust/crates/sift_mcp/src/service/annotations/mod.rs
@@ -1,0 +1,256 @@
+use crate::policy::{RetryPolicy, with_retry};
+use crate::service::common;
+use anyhow::{Context, Result, anyhow};
+use pbjson_types::{FieldMask, Timestamp};
+use sift_rs::{
+    SiftChannel,
+    annotations::v1::{
+        Annotation, AnnotationLinkedChannel, AnnotationState, AnnotationType,
+        CreateAnnotationRequest, ListAnnotationsRequest, ListAnnotationsResponse,
+        UpdateAnnotationRequest, annotation_linked_channel,
+        annotation_service_client::AnnotationServiceClient,
+    },
+    metadata::v1::MetadataValue,
+};
+
+#[cfg(test)]
+mod test;
+
+/// Build a protobuf `Timestamp` from Unix nanoseconds via the shared helper.
+fn timestamp_from_unix_nanos(nanos: i64) -> Timestamp {
+    let (seconds, nanos) = common::unix_nanos_to_secs_and_subsec_nanos(nanos);
+    Timestamp { seconds, nanos }
+}
+
+/// Map a list of channel ids to plain `AnnotationLinkedChannel` entries. Only the
+/// raw-channel variant is supported here; bit-field and calculated-channel links
+/// are out of scope for the MCP surface.
+fn linked_channels(ids: Vec<String>) -> Vec<AnnotationLinkedChannel> {
+    ids.into_iter()
+        .map(|channel_id| AnnotationLinkedChannel {
+            r#type: Some(annotation_linked_channel::Type::Channel(
+                sift_rs::annotations::v1::AnnotationLinkedChannelsChannel { channel_id },
+            )),
+        })
+        .collect()
+}
+
+#[derive(Clone)]
+pub struct AnnotationService {
+    channel: SiftChannel,
+    policy: RetryPolicy,
+}
+
+impl AnnotationService {
+    pub fn new(channel: SiftChannel, policy: RetryPolicy) -> Self {
+        Self { channel, policy }
+    }
+
+    pub async fn list_annotations(
+        &self,
+        filter: String,
+        order_by: Option<String>,
+        limit: Option<u32>,
+        organization_id: Option<String>,
+    ) -> Result<Vec<Annotation>> {
+        let (page_size, record_limit) = common::paging(limit);
+
+        let mut page_token = String::new();
+        let mut results = Vec::new();
+
+        let order_by = order_by.unwrap_or_default();
+        let organization_id = organization_id.unwrap_or_default();
+
+        loop {
+            let channel = self.channel.clone();
+            let filter = filter.clone();
+            let order_by = order_by.clone();
+            let organization_id = organization_id.clone();
+            let token = page_token.clone();
+
+            let resp = with_retry(&self.policy, move || {
+                let channel = channel.clone();
+                let filter = filter.clone();
+                let order_by = order_by.clone();
+                let organization_id = organization_id.clone();
+                let token = token.clone();
+                async move {
+                    let mut client = AnnotationServiceClient::new(channel);
+                    client
+                        .list_annotations(ListAnnotationsRequest {
+                            page_size,
+                            page_token: token,
+                            filter,
+                            organization_id,
+                            order_by,
+                        })
+                        .await
+                        .map(|resp| resp.into_inner())
+                }
+            })
+            .await
+            .context("failed to query annotations")?;
+
+            let ListAnnotationsResponse {
+                annotations,
+                next_page_token,
+            } = resp;
+            if annotations.is_empty() {
+                break;
+            }
+            results.extend(annotations);
+
+            if results.len() >= record_limit || next_page_token.is_empty() {
+                break;
+            }
+            page_token = next_page_token;
+        }
+
+        results.truncate(record_limit);
+
+        Ok(results)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create_annotation(
+        &self,
+        name: String,
+        description: Option<String>,
+        start_time_unix_nanos: i64,
+        end_time_unix_nanos: i64,
+        annotation_type: AnnotationType,
+        state: Option<AnnotationState>,
+        assets: Option<Vec<String>>,
+        tags: Option<Vec<String>>,
+        linked_channel_ids: Option<Vec<String>>,
+        run_id: Option<String>,
+        assign_to_user_id: Option<String>,
+        metadata: Option<Vec<MetadataValue>>,
+        organization_id: Option<String>,
+    ) -> Result<Annotation> {
+        let request = CreateAnnotationRequest {
+            name,
+            description: description.unwrap_or_default(),
+            start_time: Some(timestamp_from_unix_nanos(start_time_unix_nanos)),
+            end_time: Some(timestamp_from_unix_nanos(end_time_unix_nanos)),
+            assets: assets.unwrap_or_default(),
+            linked_channels: linked_channels(linked_channel_ids.unwrap_or_default()),
+            tags: tags.unwrap_or_default(),
+            run_id,
+            assign_to_user_id,
+            organization_id: organization_id.unwrap_or_default(),
+            state: state.map(|s| s as i32),
+            annotation_type: annotation_type as i32,
+            created_by_condition_id: None,
+            legend_config: None,
+            created_by_rule_condition_version_id: None,
+            metadata: metadata.unwrap_or_default(),
+        };
+
+        let channel = self.channel.clone();
+        let resp = with_retry(&self.policy, move || {
+            let channel = channel.clone();
+            let request = request.clone();
+            async move {
+                let mut client = AnnotationServiceClient::new(channel);
+                client
+                    .create_annotation(request)
+                    .await
+                    .map(|resp| resp.into_inner())
+            }
+        })
+        .await
+        .context("failed to create annotation")?;
+
+        resp.annotation
+            .ok_or_else(|| anyhow!("create_annotation response missing annotation"))
+    }
+
+    /// Update a subset of an existing annotation's fields. Per
+    /// `protos/sift/annotations/v1/annotations.proto::UpdateAnnotationRequest` the
+    /// updatable fields are `name`, `description`, `start_time`, `end_time`,
+    /// `assigned_to_user_id`, `state`, `tags`, `legend_config`, `linked_channels`,
+    /// and `metadata`. This service exposes all but `legend_config`.
+    ///
+    /// `tags`, `linked_channels`, and `metadata` use REPLACE semantics — passing
+    /// `Some(vec![])` clears the field.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn update_annotation(
+        &self,
+        annotation_id: String,
+        name: Option<String>,
+        description: Option<String>,
+        start_time_unix_nanos: Option<i64>,
+        end_time_unix_nanos: Option<i64>,
+        assigned_to_user_id: Option<String>,
+        state: Option<AnnotationState>,
+        tags: Option<Vec<String>>,
+        linked_channel_ids: Option<Vec<String>>,
+        metadata: Option<Vec<MetadataValue>>,
+    ) -> Result<Annotation> {
+        let mut annotation = Annotation {
+            annotation_id,
+            ..Default::default()
+        };
+        let mut paths = Vec::new();
+
+        if let Some(v) = name {
+            annotation.name = v;
+            paths.push("name".to_string());
+        }
+        if let Some(v) = description {
+            annotation.description = v;
+            paths.push("description".to_string());
+        }
+        if let Some(v) = start_time_unix_nanos {
+            annotation.start_time = Some(timestamp_from_unix_nanos(v));
+            paths.push("start_time".to_string());
+        }
+        if let Some(v) = end_time_unix_nanos {
+            annotation.end_time = Some(timestamp_from_unix_nanos(v));
+            paths.push("end_time".to_string());
+        }
+        if let Some(v) = assigned_to_user_id {
+            annotation.assigned_to_user_id = v;
+            paths.push("assigned_to_user_id".to_string());
+        }
+        if let Some(v) = state {
+            annotation.state = Some(v as i32);
+            paths.push("state".to_string());
+        }
+        if let Some(v) = tags {
+            annotation.tags = v;
+            paths.push("tags".to_string());
+        }
+        if let Some(v) = linked_channel_ids {
+            annotation.linked_channels = linked_channels(v);
+            paths.push("linked_channels".to_string());
+        }
+        if let Some(v) = metadata {
+            annotation.metadata = v;
+            paths.push("metadata".to_string());
+        }
+
+        let channel = self.channel.clone();
+        let resp = with_retry(&self.policy, move || {
+            let channel = channel.clone();
+            let annotation = annotation.clone();
+            let paths = paths.clone();
+            async move {
+                let mut client = AnnotationServiceClient::new(channel);
+                client
+                    .update_annotation(UpdateAnnotationRequest {
+                        annotation: Some(annotation),
+                        update_mask: Some(FieldMask { paths }),
+                    })
+                    .await
+                    .map(|resp| resp.into_inner())
+            }
+        })
+        .await
+        .context("failed to update annotation")?;
+
+        resp.annotation
+            .ok_or_else(|| anyhow!("update_annotation response missing annotation"))
+    }
+}

--- a/rust/crates/sift_mcp/src/service/annotations/test.rs
+++ b/rust/crates/sift_mcp/src/service/annotations/test.rs
@@ -1,0 +1,342 @@
+use sift_rs::annotations::v1::{
+    Annotation, AnnotationState, AnnotationType, CreateAnnotationResponse, ListAnnotationsResponse,
+    UpdateAnnotationResponse, annotation_service_server::AnnotationServiceServer,
+};
+use sift_test_util::{grpc::memory_sift_channel, mock::annotations::v1::MockAnnotationServiceImpl};
+use tokio::task::JoinHandle;
+use tonic::{Response, Status, transport::Server};
+
+use super::AnnotationService;
+use crate::service::common::PAGE_SIZE;
+
+async fn service_with_mock(mock: MockAnnotationServiceImpl) -> (AnnotationService, JoinHandle<()>) {
+    let (client, server) = tokio::io::duplex(1024);
+    let channel = memory_sift_channel(client).await;
+
+    let handle = tokio::spawn(async move {
+        Server::builder()
+            .add_service(AnnotationServiceServer::new(mock))
+            .serve_with_incoming(tokio_stream::once(Ok::<_, std::io::Error>(server)))
+            .await
+            .unwrap();
+    });
+
+    (
+        AnnotationService::new(channel, crate::policy::RetryPolicy::default()),
+        handle,
+    )
+}
+
+#[tokio::test]
+async fn list_annotations_returns_single_page() {
+    let mut mock = MockAnnotationServiceImpl::new();
+    mock.expect_list_annotations()
+        .withf(|req| req.get_ref().filter == "name == \"liftoff\"")
+        .returning(|_| {
+            Ok(Response::new(ListAnnotationsResponse {
+                annotations: vec![Annotation {
+                    annotation_id: "ann1".into(),
+                    name: "liftoff".into(),
+                    ..Default::default()
+                }],
+                next_page_token: String::new(),
+            }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let annotations = service
+        .list_annotations("name == \"liftoff\"".to_string(), None, None, None)
+        .await
+        .expect("list_annotations failed");
+
+    assert_eq!(annotations.len(), 1);
+    assert_eq!(annotations[0].annotation_id, "ann1");
+}
+
+#[tokio::test]
+async fn list_annotations_forwards_organization_id() {
+    let mut mock = MockAnnotationServiceImpl::new();
+    mock.expect_list_annotations()
+        .withf(|req| req.get_ref().organization_id == "org-123")
+        .returning(|_| {
+            Ok(Response::new(ListAnnotationsResponse {
+                annotations: vec![Annotation {
+                    annotation_id: "ann1".into(),
+                    ..Default::default()
+                }],
+                next_page_token: String::new(),
+            }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let annotations = service
+        .list_annotations(String::new(), None, None, Some("org-123".to_string()))
+        .await
+        .expect("list_annotations failed");
+
+    assert_eq!(annotations.len(), 1);
+}
+
+#[tokio::test]
+async fn list_annotations_paginates_until_token_empty() {
+    let mut mock = MockAnnotationServiceImpl::new();
+    mock.expect_list_annotations().returning(|req| {
+        let req = req.into_inner();
+        assert_eq!(req.page_size, PAGE_SIZE);
+        let (annotations, next) = match req.page_token.as_str() {
+            "" => (
+                vec![Annotation {
+                    annotation_id: "ann1".into(),
+                    ..Default::default()
+                }],
+                "page-2".to_string(),
+            ),
+            "page-2" => (
+                vec![Annotation {
+                    annotation_id: "ann2".into(),
+                    ..Default::default()
+                }],
+                String::new(),
+            ),
+            other => return Err(Status::invalid_argument(format!("bad token: {other}"))),
+        };
+        Ok(Response::new(ListAnnotationsResponse {
+            annotations,
+            next_page_token: next,
+        }))
+    });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let annotations = service
+        .list_annotations(String::new(), None, None, None)
+        .await
+        .expect("list_annotations failed");
+
+    let ids: Vec<&str> = annotations
+        .iter()
+        .map(|a| a.annotation_id.as_str())
+        .collect();
+    assert_eq!(ids, vec!["ann1", "ann2"]);
+}
+
+#[tokio::test]
+async fn list_annotations_truncates_to_limit_across_pages() {
+    let mut mock = MockAnnotationServiceImpl::new();
+    mock.expect_list_annotations().returning(|req| {
+        let req = req.into_inner();
+        assert_eq!(req.page_size, 3);
+        let (annotations, next) = match req.page_token.as_str() {
+            "" => (
+                vec![
+                    Annotation {
+                        annotation_id: "ann1".into(),
+                        ..Default::default()
+                    },
+                    Annotation {
+                        annotation_id: "ann2".into(),
+                        ..Default::default()
+                    },
+                ],
+                "page-2".to_string(),
+            ),
+            "page-2" => (
+                vec![
+                    Annotation {
+                        annotation_id: "ann3".into(),
+                        ..Default::default()
+                    },
+                    Annotation {
+                        annotation_id: "ann4".into(),
+                        ..Default::default()
+                    },
+                ],
+                String::new(),
+            ),
+            other => return Err(Status::invalid_argument(format!("bad token: {other}"))),
+        };
+        Ok(Response::new(ListAnnotationsResponse {
+            annotations,
+            next_page_token: next,
+        }))
+    });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let annotations = service
+        .list_annotations(String::new(), None, Some(3), None)
+        .await
+        .expect("list_annotations failed");
+
+    let ids: Vec<&str> = annotations
+        .iter()
+        .map(|a| a.annotation_id.as_str())
+        .collect();
+    assert_eq!(ids, vec!["ann1", "ann2", "ann3"]);
+}
+
+#[tokio::test]
+async fn list_annotations_propagates_grpc_error() {
+    let mut mock = MockAnnotationServiceImpl::new();
+    mock.expect_list_annotations()
+        .returning(|_| Err(Status::not_found("no such annotation")));
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let err = service
+        .list_annotations(String::new(), None, None, None)
+        .await
+        .expect_err("expected error");
+
+    assert!(err.to_string().contains("failed to query annotations"));
+}
+
+#[tokio::test]
+async fn create_annotation_maps_fields() {
+    let mut mock = MockAnnotationServiceImpl::new();
+    mock.expect_create_annotation()
+        .withf(|req| {
+            let req = req.get_ref();
+            req.name == "review window"
+                && req.annotation_type == AnnotationType::DataReview as i32
+                && req.state == Some(AnnotationState::Open as i32)
+                && req.start_time.as_ref().map(|t| t.seconds) == Some(1)
+                && req.end_time.as_ref().map(|t| t.seconds) == Some(2)
+                && req.linked_channels.len() == 1
+                && req.assets == vec!["rover".to_string()]
+        })
+        .returning(|_| {
+            Ok(Response::new(CreateAnnotationResponse {
+                annotation: Some(Annotation {
+                    annotation_id: "ann-new".into(),
+                    name: "review window".into(),
+                    ..Default::default()
+                }),
+            }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let annotation = service
+        .create_annotation(
+            "review window".to_string(),
+            None,
+            1_000_000_000,
+            2_000_000_000,
+            AnnotationType::DataReview,
+            Some(AnnotationState::Open),
+            Some(vec!["rover".to_string()]),
+            None,
+            Some(vec!["chan-1".to_string()]),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create_annotation failed");
+
+    assert_eq!(annotation.annotation_id, "ann-new");
+}
+
+#[tokio::test]
+async fn create_annotation_propagates_grpc_error() {
+    let mut mock = MockAnnotationServiceImpl::new();
+    mock.expect_create_annotation()
+        .returning(|_| Err(Status::invalid_argument("bad input")));
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let err = service
+        .create_annotation(
+            "x".to_string(),
+            None,
+            1,
+            2,
+            AnnotationType::Phase,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect_err("expected error");
+
+    assert!(err.to_string().contains("failed to create annotation"));
+}
+
+#[tokio::test]
+async fn update_annotation_builds_mask_from_provided_fields() {
+    let mut mock = MockAnnotationServiceImpl::new();
+    mock.expect_update_annotation()
+        .withf(|req| {
+            let req = req.get_ref();
+            let paths = &req.update_mask.as_ref().unwrap().paths;
+            let ann = req.annotation.as_ref().unwrap();
+            ann.annotation_id == "ann1"
+                && ann.name == "renamed"
+                && paths == &vec!["name".to_string(), "tags".to_string()]
+        })
+        .returning(|_| {
+            Ok(Response::new(UpdateAnnotationResponse {
+                annotation: Some(Annotation {
+                    annotation_id: "ann1".into(),
+                    name: "renamed".into(),
+                    ..Default::default()
+                }),
+            }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let annotation = service
+        .update_annotation(
+            "ann1".to_string(),
+            Some("renamed".to_string()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(vec!["important".to_string()]),
+            None,
+            None,
+        )
+        .await
+        .expect("update_annotation failed");
+
+    assert_eq!(annotation.name, "renamed");
+}
+
+#[tokio::test]
+async fn update_annotation_propagates_grpc_error() {
+    let mut mock = MockAnnotationServiceImpl::new();
+    mock.expect_update_annotation()
+        .returning(|_| Err(Status::not_found("no such annotation")));
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let err = service
+        .update_annotation(
+            "ann1".to_string(),
+            Some("x".to_string()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect_err("expected error");
+
+    assert!(err.to_string().contains("failed to update annotation"));
+}

--- a/rust/crates/sift_mcp/src/service/mod.rs
+++ b/rust/crates/sift_mcp/src/service/mod.rs
@@ -1,11 +1,12 @@
+pub mod annotations;
 pub mod assets;
 pub mod channels;
 pub mod data;
-pub mod explore;
 pub mod ingest;
 pub mod ping;
 pub mod reports;
 pub mod rules;
 pub mod runs;
+pub mod url;
 
 pub(crate) mod common;

--- a/rust/crates/sift_mcp/src/service/reports/mod.rs
+++ b/rust/crates/sift_mcp/src/service/reports/mod.rs
@@ -1,15 +1,45 @@
 use crate::policy::{RetryPolicy, with_retry};
 use crate::service::common;
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
+use pbjson_types::FieldMask;
 use sift_rs::{
     SiftChannel,
+    metadata::v1::MetadataValue,
     reports::v1::{
-        ListReportsRequest, ListReportsResponse, Report, report_service_client::ReportServiceClient,
+        CreateReportFromReportTemplateRequest, CreateReportFromRulesRequest, CreateReportRequest,
+        CreateReportRequestClientKeys, CreateReportRequestRuleIds,
+        CreateReportRequestRuleVersionIds, GetReportRequest, ListReportRuleSummariesRequest,
+        ListReportRuleSummariesResponse, ListReportsRequest, ListReportsResponse, Report,
+        ReportRuleSummary, UpdateReportRequest, create_report_from_rules_request,
+        create_report_request, report_service_client::ReportServiceClient,
     },
 };
 
 #[cfg(test)]
 mod test;
+
+/// How the set of rules a report is built from is identified. Exactly one variant
+/// is constructed from the flat tool params. Variant names mirror the proto
+/// `rule_identifiers` oneof fields.
+#[allow(clippy::enum_variant_names)]
+pub enum RuleIdentifier {
+    RuleIds(Vec<String>),
+    RuleClientKeys(Vec<String>),
+    RuleVersionIds(Vec<String>),
+}
+
+/// The source a report is created from. Flattens the `CreateReportRequest`
+/// oneof into a typed choice built in the tool handler.
+pub enum ReportSource {
+    Template {
+        report_template_id: String,
+    },
+    Rules {
+        description: Option<String>,
+        tag_names: Vec<String>,
+        rules: RuleIdentifier,
+    },
+}
 
 #[derive(Clone)]
 pub struct ReportService {
@@ -85,5 +115,201 @@ impl ReportService {
         results.truncate(record_limit);
 
         Ok(results)
+    }
+
+    pub async fn list_report_rule_summaries(
+        &self,
+        report_id: String,
+        filter: String,
+        order_by: Option<String>,
+        limit: Option<u32>,
+    ) -> Result<Vec<ReportRuleSummary>> {
+        let (page_size, record_limit) = common::paging(limit);
+
+        let mut page_token = String::new();
+        let mut results = Vec::new();
+
+        let order_by = order_by.unwrap_or_default();
+
+        loop {
+            let channel = self.channel.clone();
+            let report_id = report_id.clone();
+            let filter = filter.clone();
+            let order_by = order_by.clone();
+            let token = page_token.clone();
+
+            let resp = with_retry(&self.policy, move || {
+                let channel = channel.clone();
+                let report_id = report_id.clone();
+                let filter = filter.clone();
+                let order_by = order_by.clone();
+                let token = token.clone();
+                async move {
+                    let mut client = ReportServiceClient::new(channel);
+                    client
+                        .list_report_rule_summaries(ListReportRuleSummariesRequest {
+                            report_id,
+                            page_size,
+                            page_token: token,
+                            filter,
+                            order_by,
+                        })
+                        .await
+                        .map(|resp| resp.into_inner())
+                }
+            })
+            .await
+            .context("failed to query report rule summaries")?;
+
+            let ListReportRuleSummariesResponse {
+                report_rule_summaries,
+                next_page_token,
+            } = resp;
+            if report_rule_summaries.is_empty() {
+                break;
+            }
+            results.extend(report_rule_summaries);
+
+            if results.len() >= record_limit || next_page_token.is_empty() {
+                break;
+            }
+            page_token = next_page_token;
+        }
+
+        results.truncate(record_limit);
+
+        Ok(results)
+    }
+
+    pub async fn create_report(
+        &self,
+        organization_id: Option<String>,
+        run_id: String,
+        name: String,
+        metadata: Option<Vec<MetadataValue>>,
+        source: ReportSource,
+    ) -> Result<Report> {
+        let request = match source {
+            ReportSource::Template { report_template_id } => {
+                create_report_request::Request::ReportFromReportTemplateRequest(
+                    CreateReportFromReportTemplateRequest { report_template_id },
+                )
+            }
+            ReportSource::Rules {
+                description,
+                tag_names,
+                rules,
+            } => {
+                let rule_identifiers = match rules {
+                    RuleIdentifier::RuleIds(rule_ids) => {
+                        create_report_from_rules_request::RuleIdentifiers::RuleIds(
+                            CreateReportRequestRuleIds { rule_ids },
+                        )
+                    }
+                    RuleIdentifier::RuleClientKeys(rule_client_keys) => {
+                        create_report_from_rules_request::RuleIdentifiers::RuleClientKeys(
+                            CreateReportRequestClientKeys { rule_client_keys },
+                        )
+                    }
+                    RuleIdentifier::RuleVersionIds(rule_version_ids) => {
+                        create_report_from_rules_request::RuleIdentifiers::RuleVersionIds(
+                            CreateReportRequestRuleVersionIds { rule_version_ids },
+                        )
+                    }
+                };
+                create_report_request::Request::ReportFromRulesRequest(
+                    CreateReportFromRulesRequest {
+                        name: name.clone(),
+                        description,
+                        tag_names,
+                        rule_identifiers: Some(rule_identifiers),
+                    },
+                )
+            }
+        };
+
+        let create_request = CreateReportRequest {
+            organization_id: organization_id.unwrap_or_default(),
+            run_id,
+            name: Some(name),
+            metadata: metadata.unwrap_or_default(),
+            request: Some(request),
+        };
+
+        let channel = self.channel.clone();
+        let resp = with_retry(&self.policy, move || {
+            let channel = channel.clone();
+            let create_request = create_request.clone();
+            async move {
+                let mut client = ReportServiceClient::new(channel);
+                client
+                    .create_report(create_request)
+                    .await
+                    .map(|resp| resp.into_inner())
+            }
+        })
+        .await
+        .context("failed to create report")?;
+
+        resp.report
+            .ok_or_else(|| anyhow!("create_report response missing report"))
+    }
+
+    /// Update an existing report's metadata. Per
+    /// `protos/sift/reports/v1/reports.proto::UpdateReportRequest` the updatable
+    /// fields are `archived_date`, `is_archived`, and `metadata`; this service
+    /// exposes `metadata` only (archive flow is out of scope). `metadata` uses
+    /// REPLACE semantics.
+    ///
+    /// `UpdateReportResponse` is empty, so the updated `Report` is re-fetched via
+    /// `GetReport` and returned.
+    pub async fn update_report(
+        &self,
+        report_id: String,
+        metadata: Vec<MetadataValue>,
+    ) -> Result<Report> {
+        let report = Report {
+            report_id: report_id.clone(),
+            metadata,
+            ..Default::default()
+        };
+        let paths = vec!["metadata".to_string()];
+
+        let channel = self.channel.clone();
+        with_retry(&self.policy, move || {
+            let channel = channel.clone();
+            let report = report.clone();
+            let paths = paths.clone();
+            async move {
+                let mut client = ReportServiceClient::new(channel);
+                client
+                    .update_report(UpdateReportRequest {
+                        report: Some(report),
+                        update_mask: Some(FieldMask { paths }),
+                    })
+                    .await
+                    .map(|resp| resp.into_inner())
+            }
+        })
+        .await
+        .context("failed to update report")?;
+
+        let channel = self.channel.clone();
+        let resp = with_retry(&self.policy, move || {
+            let channel = channel.clone();
+            let report_id = report_id.clone();
+            async move {
+                let mut client = ReportServiceClient::new(channel);
+                client
+                    .get_report(GetReportRequest { report_id })
+                    .await
+                    .map(|resp| resp.into_inner())
+            }
+        })
+        .await
+        .context("failed to fetch report after update")?;
+
+        resp.report
+            .ok_or_else(|| anyhow!("get_report response missing report"))
     }
 }

--- a/rust/crates/sift_mcp/src/service/reports/test.rs
+++ b/rust/crates/sift_mcp/src/service/reports/test.rs
@@ -1,11 +1,13 @@
 use sift_rs::reports::v1::{
-    ListReportsResponse, Report, report_service_server::ReportServiceServer,
+    CreateReportResponse, GetReportResponse, ListReportRuleSummariesResponse, ListReportsResponse,
+    Report, ReportRuleSummary, UpdateReportResponse, create_report_request,
+    report_service_server::ReportServiceServer,
 };
 use sift_test_util::{grpc::memory_sift_channel, mock::reports::v1::MockReportServiceImpl};
 use tokio::task::JoinHandle;
 use tonic::{Response, Status, transport::Server};
 
-use super::ReportService;
+use super::{ReportService, ReportSource, RuleIdentifier};
 use crate::service::common::PAGE_SIZE;
 
 async fn service_with_mock(mock: MockReportServiceImpl) -> (ReportService, JoinHandle<()>) {
@@ -235,4 +237,272 @@ async fn list_reports_propagates_grpc_error() {
         .expect_err("expected error");
 
     assert!(err.to_string().contains("failed to query reports"));
+}
+
+#[tokio::test]
+async fn list_report_rule_summaries_returns_single_page() {
+    let mut mock = MockReportServiceImpl::new();
+    mock.expect_list_report_rule_summaries()
+        .withf(|req| req.get_ref().report_id == "rep1")
+        .returning(|_| {
+            Ok(Response::new(ListReportRuleSummariesResponse {
+                report_rule_summaries: vec![ReportRuleSummary {
+                    rule_id: "rule-1".into(),
+                    ..Default::default()
+                }],
+                next_page_token: String::new(),
+            }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let summaries = service
+        .list_report_rule_summaries("rep1".to_string(), String::new(), None, None)
+        .await
+        .expect("list_report_rule_summaries failed");
+
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].rule_id, "rule-1");
+}
+
+#[tokio::test]
+async fn list_report_rule_summaries_paginates_until_token_empty() {
+    let mut mock = MockReportServiceImpl::new();
+    mock.expect_list_report_rule_summaries().returning(|req| {
+        let req = req.into_inner();
+        assert_eq!(req.page_size, PAGE_SIZE);
+        let (summaries, next) = match req.page_token.as_str() {
+            "" => (
+                vec![ReportRuleSummary {
+                    rule_id: "rule-1".into(),
+                    ..Default::default()
+                }],
+                "page-2".to_string(),
+            ),
+            "page-2" => (
+                vec![ReportRuleSummary {
+                    rule_id: "rule-2".into(),
+                    ..Default::default()
+                }],
+                String::new(),
+            ),
+            other => return Err(Status::invalid_argument(format!("bad token: {other}"))),
+        };
+        Ok(Response::new(ListReportRuleSummariesResponse {
+            report_rule_summaries: summaries,
+            next_page_token: next,
+        }))
+    });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let summaries = service
+        .list_report_rule_summaries("rep1".to_string(), String::new(), None, None)
+        .await
+        .expect("list_report_rule_summaries failed");
+
+    let ids: Vec<&str> = summaries.iter().map(|s| s.rule_id.as_str()).collect();
+    assert_eq!(ids, vec!["rule-1", "rule-2"]);
+}
+
+#[tokio::test]
+async fn list_report_rule_summaries_respects_limit() {
+    let mut mock = MockReportServiceImpl::new();
+    mock.expect_list_report_rule_summaries()
+        .times(1)
+        .returning(|req| {
+            assert_eq!(req.get_ref().page_size, 1);
+            Ok(Response::new(ListReportRuleSummariesResponse {
+                report_rule_summaries: vec![
+                    ReportRuleSummary {
+                        rule_id: "rule-1".into(),
+                        ..Default::default()
+                    },
+                    ReportRuleSummary {
+                        rule_id: "rule-2".into(),
+                        ..Default::default()
+                    },
+                ],
+                next_page_token: "page-2".into(),
+            }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let summaries = service
+        .list_report_rule_summaries("rep1".to_string(), String::new(), None, Some(1))
+        .await
+        .expect("list_report_rule_summaries failed");
+
+    assert_eq!(summaries.len(), 1);
+}
+
+#[tokio::test]
+async fn list_report_rule_summaries_propagates_grpc_error() {
+    let mut mock = MockReportServiceImpl::new();
+    mock.expect_list_report_rule_summaries()
+        .returning(|_| Err(Status::not_found("no such report")));
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let err = service
+        .list_report_rule_summaries("rep1".to_string(), String::new(), None, None)
+        .await
+        .expect_err("expected error");
+
+    assert!(
+        err.to_string()
+            .contains("failed to query report rule summaries")
+    );
+}
+
+#[tokio::test]
+async fn create_report_from_rules_maps_oneof() {
+    let mut mock = MockReportServiceImpl::new();
+    mock.expect_create_report()
+        .withf(|req| {
+            let req = req.get_ref();
+            req.run_id == "run-1"
+                && req.name.as_deref() == Some("nightly report")
+                && matches!(
+                    req.request,
+                    Some(create_report_request::Request::ReportFromRulesRequest(_))
+                )
+        })
+        .returning(|_| {
+            Ok(Response::new(CreateReportResponse {
+                report: Some(Report {
+                    report_id: "rep-new".into(),
+                    ..Default::default()
+                }),
+            }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let report = service
+        .create_report(
+            None,
+            "run-1".to_string(),
+            "nightly report".to_string(),
+            None,
+            ReportSource::Rules {
+                description: None,
+                tag_names: vec![],
+                rules: RuleIdentifier::RuleIds(vec!["rule-1".to_string()]),
+            },
+        )
+        .await
+        .expect("create_report failed");
+
+    assert_eq!(report.report_id, "rep-new");
+}
+
+#[tokio::test]
+async fn create_report_from_template_maps_oneof() {
+    let mut mock = MockReportServiceImpl::new();
+    mock.expect_create_report()
+        .withf(|req| {
+            matches!(
+                req.get_ref().request,
+                Some(create_report_request::Request::ReportFromReportTemplateRequest(_))
+            )
+        })
+        .returning(|_| {
+            Ok(Response::new(CreateReportResponse {
+                report: Some(Report {
+                    report_id: "rep-tmpl".into(),
+                    ..Default::default()
+                }),
+            }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let report = service
+        .create_report(
+            None,
+            "run-1".to_string(),
+            "from template".to_string(),
+            None,
+            ReportSource::Template {
+                report_template_id: "tmpl-1".to_string(),
+            },
+        )
+        .await
+        .expect("create_report failed");
+
+    assert_eq!(report.report_id, "rep-tmpl");
+}
+
+#[tokio::test]
+async fn create_report_propagates_grpc_error() {
+    let mut mock = MockReportServiceImpl::new();
+    mock.expect_create_report()
+        .returning(|_| Err(Status::invalid_argument("bad input")));
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let err = service
+        .create_report(
+            None,
+            "run-1".to_string(),
+            "x".to_string(),
+            None,
+            ReportSource::Template {
+                report_template_id: "tmpl-1".to_string(),
+            },
+        )
+        .await
+        .expect_err("expected error");
+
+    assert!(err.to_string().contains("failed to create report"));
+}
+
+#[tokio::test]
+async fn update_report_sets_metadata_mask_and_refetches() {
+    let mut mock = MockReportServiceImpl::new();
+    mock.expect_update_report()
+        .withf(|req| {
+            let req = req.get_ref();
+            req.update_mask.as_ref().unwrap().paths == vec!["metadata".to_string()]
+                && req.report.as_ref().unwrap().report_id == "rep1"
+        })
+        .returning(|_| Ok(Response::new(UpdateReportResponse {})));
+    mock.expect_get_report()
+        .withf(|req| req.get_ref().report_id == "rep1")
+        .returning(|_| {
+            Ok(Response::new(GetReportResponse {
+                report: Some(Report {
+                    report_id: "rep1".into(),
+                    name: "after update".into(),
+                    ..Default::default()
+                }),
+            }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let report = service
+        .update_report("rep1".to_string(), vec![])
+        .await
+        .expect("update_report failed");
+
+    assert_eq!(report.name, "after update");
+}
+
+#[tokio::test]
+async fn update_report_propagates_grpc_error() {
+    let mut mock = MockReportServiceImpl::new();
+    mock.expect_update_report()
+        .returning(|_| Err(Status::not_found("no such report")));
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let err = service
+        .update_report("rep1".to_string(), vec![])
+        .await
+        .expect_err("expected error");
+
+    assert!(err.to_string().contains("failed to update report"));
 }

--- a/rust/crates/sift_mcp/src/service/runs/mod.rs
+++ b/rust/crates/sift_mcp/src/service/runs/mod.rs
@@ -1,10 +1,21 @@
 use crate::policy::{RetryPolicy, with_retry};
 use crate::service::common;
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
+use pbjson_types::{FieldMask, Timestamp};
 use sift_rs::{
     SiftChannel,
-    runs::v2::{ListRunsRequest, ListRunsResponse, Run, run_service_client::RunServiceClient},
+    metadata::v1::MetadataValue,
+    runs::v2::{
+        ListRunsRequest, ListRunsResponse, Run, UpdateRunRequest,
+        run_service_client::RunServiceClient,
+    },
 };
+
+/// Build a protobuf `Timestamp` from Unix nanoseconds via the shared helper.
+fn timestamp_from_unix_nanos(nanos: i64) -> Timestamp {
+    let (seconds, nanos) = common::unix_nanos_to_secs_and_subsec_nanos(nanos);
+    Timestamp { seconds, nanos }
+}
 
 #[cfg(test)]
 mod test;
@@ -78,5 +89,89 @@ impl RunService {
         results.truncate(record_limit);
 
         Ok(results)
+    }
+
+    /// Update a subset of an existing run's fields. Per
+    /// `protos/sift/runs/v2/runs.proto::UpdateRunRequest` the updatable fields are
+    /// `name`, `description`, `start_time`, `stop_time`, `is_pinned`, `client_key`,
+    /// `tags`, `is_archived`, and `metadata`. This service exposes all but
+    /// `is_archived` (archive flow is out of scope).
+    ///
+    /// Caveats from the proto: `start_time` may be overwritten by a later
+    /// ingestion, and `client_key` can be set only once — a second attempt errors.
+    /// `tags` and `metadata` use REPLACE semantics.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn update_run(
+        &self,
+        run_id: String,
+        name: Option<String>,
+        description: Option<String>,
+        start_time_unix_nanos: Option<i64>,
+        stop_time_unix_nanos: Option<i64>,
+        is_pinned: Option<bool>,
+        client_key: Option<String>,
+        tags: Option<Vec<String>>,
+        metadata: Option<Vec<MetadataValue>>,
+    ) -> Result<Run> {
+        let mut run = Run {
+            run_id,
+            ..Default::default()
+        };
+        let mut paths = Vec::new();
+
+        if let Some(v) = name {
+            run.name = v;
+            paths.push("name".to_string());
+        }
+        if let Some(v) = description {
+            run.description = v;
+            paths.push("description".to_string());
+        }
+        if let Some(v) = start_time_unix_nanos {
+            run.start_time = Some(timestamp_from_unix_nanos(v));
+            paths.push("start_time".to_string());
+        }
+        if let Some(v) = stop_time_unix_nanos {
+            run.stop_time = Some(timestamp_from_unix_nanos(v));
+            paths.push("stop_time".to_string());
+        }
+        if let Some(v) = is_pinned {
+            run.is_pinned = v;
+            paths.push("is_pinned".to_string());
+        }
+        if let Some(v) = client_key {
+            run.client_key = Some(v);
+            paths.push("client_key".to_string());
+        }
+        if let Some(v) = tags {
+            run.tags = v;
+            paths.push("tags".to_string());
+        }
+        if let Some(v) = metadata {
+            run.metadata = v;
+            paths.push("metadata".to_string());
+        }
+
+        let channel = self.channel.clone();
+        let resp = with_retry(&self.policy, move || {
+            let channel = channel.clone();
+            let run = run.clone();
+            let paths = paths.clone();
+            async move {
+                let mut client = RunServiceClient::new(channel);
+                client
+                    .update_run(UpdateRunRequest {
+                        run: Some(run),
+                        update_mask: Some(FieldMask { paths }),
+                    })
+                    .await
+                    .map(|resp| resp.into_inner())
+            }
+        })
+        .await
+        .context("failed to update run")?;
+
+        resp.run
+            .ok_or_else(|| anyhow!("update_run response missing run"))
     }
 }

--- a/rust/crates/sift_mcp/src/service/runs/test.rs
+++ b/rust/crates/sift_mcp/src/service/runs/test.rs
@@ -1,4 +1,6 @@
-use sift_rs::runs::v2::{ListRunsResponse, Run, run_service_server::RunServiceServer};
+use sift_rs::runs::v2::{
+    ListRunsResponse, Run, UpdateRunResponse, run_service_server::RunServiceServer,
+};
 use sift_test_util::{grpc::memory_sift_channel, mock::runs::v2::MockRunServiceImpl};
 use tokio::task::JoinHandle;
 use tonic::{Response, Status, transport::Server};
@@ -208,4 +210,79 @@ async fn list_runs_propagates_grpc_error() {
         .expect_err("expected error");
 
     assert!(err.to_string().contains("failed to query runs"));
+}
+
+#[tokio::test]
+async fn update_run_builds_mask_from_provided_fields() {
+    let mut mock = MockRunServiceImpl::new();
+    mock.expect_update_run()
+        .withf(|req| {
+            let req = req.get_ref();
+            let run = req.run.as_ref().unwrap();
+            let paths = &req.update_mask.as_ref().unwrap().paths;
+            run.run_id == "r1"
+                && run.name == "renamed"
+                && run.is_pinned
+                && run.start_time.as_ref().map(|t| t.seconds) == Some(1)
+                && paths
+                    == &vec![
+                        "name".to_string(),
+                        "start_time".to_string(),
+                        "is_pinned".to_string(),
+                    ]
+        })
+        .returning(|_| {
+            Ok(Response::new(UpdateRunResponse {
+                run: Some(Run {
+                    run_id: "r1".into(),
+                    name: "renamed".into(),
+                    ..Default::default()
+                }),
+            }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let run = service
+        .update_run(
+            "r1".to_string(),
+            Some("renamed".to_string()),
+            None,
+            Some(1_000_000_000),
+            None,
+            Some(true),
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("update_run failed");
+
+    assert_eq!(run.name, "renamed");
+}
+
+#[tokio::test]
+async fn update_run_propagates_grpc_error() {
+    let mut mock = MockRunServiceImpl::new();
+    mock.expect_update_run()
+        .returning(|_| Err(Status::not_found("no such run")));
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let err = service
+        .update_run(
+            "r1".to_string(),
+            Some("x".to_string()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect_err("expected error");
+
+    assert!(err.to_string().contains("failed to update run"));
 }

--- a/rust/crates/sift_mcp/src/service/url/mod.rs
+++ b/rust/crates/sift_mcp/src/service/url/mod.rs
@@ -32,16 +32,16 @@ pub struct ExploreUrlRequest {
 }
 
 #[derive(Clone)]
-pub struct ExploreService {
+pub struct UrlService {
     rest_uri: String,
 }
 
-impl ExploreService {
+impl UrlService {
     pub fn new(rest_uri: String) -> Self {
         Self { rest_uri }
     }
 
-    pub fn build_url(&self, request: ExploreUrlRequest) -> Result<String, ErrorData> {
+    pub fn build_explore_url(&self, request: ExploreUrlRequest) -> Result<String, ErrorData> {
         let ExploreUrlRequest {
             assets,
             runs,
@@ -89,7 +89,7 @@ impl ExploreService {
 
         let host = match explore_host {
             Some(h) => h,
-            None => derive_explore_host(&self.rest_uri)?,
+            None => derive_web_host(&self.rest_uri)?,
         };
 
         let mut query = String::from("method=single");
@@ -126,6 +126,48 @@ impl ExploreService {
 
         Ok(format!("{host}/explore?{query}"))
     }
+
+    /// Build the Sift web URL for a single report: `<host>/reports/<report_id>`.
+    /// The host is derived from `rest_uri`; there is no override for this URL
+    /// shape. Returns `INVALID_PARAMS` if the host cannot be derived (e.g. a
+    /// self-hosted `rest_uri` without an `api.` subdomain).
+    pub fn build_report_url(&self, report_id: &str) -> Result<String, ErrorData> {
+        let host = derive_web_host(&self.rest_uri)?;
+        Ok(format!("{host}/reports/{}", encode_value(report_id)))
+    }
+
+    /// Build the Sift web URL for a single rule: `<host>/rules/<rule_id>`. The
+    /// host is derived from `rest_uri`. Returns `INVALID_PARAMS` if the host
+    /// cannot be derived (e.g. a self-hosted `rest_uri` without an `api.`
+    /// subdomain).
+    pub fn build_rule_url(&self, rule_id: &str) -> Result<String, ErrorData> {
+        let host = derive_web_host(&self.rest_uri)?;
+        Ok(format!("{host}/rules/{}", encode_value(rule_id)))
+    }
+
+    /// Build the Sift web URL for a single annotation:
+    /// `<host>/annotation/<annotation_id>`. The host is derived from `rest_uri`.
+    /// Returns `INVALID_PARAMS` if the host cannot be derived.
+    pub fn build_annotation_url(&self, annotation_id: &str) -> Result<String, ErrorData> {
+        let host = derive_web_host(&self.rest_uri)?;
+        Ok(format!("{host}/annotation/{}", encode_value(annotation_id)))
+    }
+
+    /// Build the Sift web URL for a single asset: `<host>/asset/<asset_id>`. The
+    /// host is derived from `rest_uri`. Returns `INVALID_PARAMS` if the host
+    /// cannot be derived.
+    pub fn build_asset_url(&self, asset_id: &str) -> Result<String, ErrorData> {
+        let host = derive_web_host(&self.rest_uri)?;
+        Ok(format!("{host}/asset/{}", encode_value(asset_id)))
+    }
+
+    /// Build the Sift web URL for a single run: `<host>/run/<run_id>`. The host
+    /// is derived from `rest_uri`. Returns `INVALID_PARAMS` if the host cannot be
+    /// derived.
+    pub fn build_run_url(&self, run_id: &str) -> Result<String, ErrorData> {
+        let host = derive_web_host(&self.rest_uri)?;
+        Ok(format!("{host}/run/{}", encode_value(run_id)))
+    }
 }
 
 fn encode_value(s: &str) -> String {
@@ -140,7 +182,7 @@ fn join_encoded(values: &[String]) -> String {
         .join(",")
 }
 
-fn derive_explore_host(rest_uri: &str) -> Result<String, ErrorData> {
+fn derive_web_host(rest_uri: &str) -> Result<String, ErrorData> {
     let swapped = rest_uri.replacen("://api.", "://app.", 1);
     if swapped == rest_uri {
         return Err(ErrorData::invalid_params(

--- a/rust/crates/sift_mcp/src/service/url/test.rs
+++ b/rust/crates/sift_mcp/src/service/url/test.rs
@@ -2,14 +2,14 @@ use super::*;
 
 const REST_URI: &str = "https://api.siftstack.com";
 
-fn service() -> ExploreService {
-    ExploreService::new(REST_URI.to_string())
+fn service() -> UrlService {
+    UrlService::new(REST_URI.to_string())
 }
 
 #[test]
 fn full_url_with_all_params() {
     let url = service()
-        .build_url(ExploreUrlRequest {
+        .build_explore_url(ExploreUrlRequest {
             assets: Some(vec![String::from("Engine-7")]),
             runs: Some(vec![String::from("2025-thrust-test")]),
             channels: Some(vec![String::from("temperature"), String::from("pressure")]),
@@ -34,7 +34,7 @@ fn full_url_with_all_params() {
 #[test]
 fn axis_prefix_colon_is_preserved() {
     let url = service()
-        .build_url(ExploreUrlRequest {
+        .build_explore_url(ExploreUrlRequest {
             channels: Some(vec![
                 String::from("L1:temperature"),
                 String::from("L2:pressure"),
@@ -51,7 +51,7 @@ fn axis_prefix_colon_is_preserved() {
 #[test]
 fn comma_inside_single_value_is_encoded() {
     let url = service()
-        .build_url(ExploreUrlRequest {
+        .build_explore_url(ExploreUrlRequest {
             channels: Some(vec![String::from("weird,name")]),
             ..Default::default()
         })
@@ -62,7 +62,7 @@ fn comma_inside_single_value_is_encoded() {
 #[test]
 fn unknown_panel_type_is_rejected() {
     let err = service()
-        .build_url(ExploreUrlRequest {
+        .build_explore_url(ExploreUrlRequest {
             assets: Some(vec![String::from("a")]),
             panel_type: Some(String::from("bogus")),
             ..Default::default()
@@ -75,7 +75,7 @@ fn unknown_panel_type_is_rejected() {
 #[test]
 fn empty_request_is_rejected() {
     let err = service()
-        .build_url(ExploreUrlRequest::default())
+        .build_explore_url(ExploreUrlRequest::default())
         .unwrap_err();
     assert_eq!(err.code.0, -32602);
 }
@@ -83,7 +83,7 @@ fn empty_request_is_rejected() {
 #[test]
 fn empty_vecs_are_treated_as_missing() {
     let err = service()
-        .build_url(ExploreUrlRequest {
+        .build_explore_url(ExploreUrlRequest {
             assets: Some(vec![]),
             runs: Some(vec![]),
             channels: Some(vec![]),
@@ -95,9 +95,9 @@ fn empty_vecs_are_treated_as_missing() {
 
 #[test]
 fn host_derivation_strips_rest_uri_path() {
-    let svc = ExploreService::new(String::from("https://api.siftstack.com/v1"));
+    let svc = UrlService::new(String::from("https://api.siftstack.com/v1"));
     let url = svc
-        .build_url(ExploreUrlRequest {
+        .build_explore_url(ExploreUrlRequest {
             assets: Some(vec![String::from("a")]),
             ..Default::default()
         })
@@ -110,9 +110,9 @@ fn host_derivation_strips_rest_uri_path() {
 
 #[test]
 fn unsupported_rest_uri_without_explore_host_errors() {
-    let svc = ExploreService::new(String::from("https://my-self-hosted.example"));
+    let svc = UrlService::new(String::from("https://my-self-hosted.example"));
     let err = svc
-        .build_url(ExploreUrlRequest {
+        .build_explore_url(ExploreUrlRequest {
             assets: Some(vec![String::from("a")]),
             ..Default::default()
         })
@@ -123,4 +123,58 @@ fn unsupported_rest_uri_without_explore_host_errors() {
         "expected guidance to point at explore_host, got `{}`",
         err.message
     );
+}
+
+#[test]
+fn report_url_uses_derived_web_host() {
+    let url = service().build_report_url("rep-123").unwrap();
+    assert_eq!(url, "https://app.siftstack.com/reports/rep-123");
+}
+
+#[test]
+fn report_url_errors_when_host_cannot_be_derived() {
+    let svc = UrlService::new(String::from("https://my-self-hosted.example"));
+    let err = svc.build_report_url("rep-123").unwrap_err();
+    assert_eq!(err.code.0, -32602);
+}
+
+#[test]
+fn rule_url_uses_derived_web_host() {
+    let url = service().build_rule_url("rule-123").unwrap();
+    assert_eq!(url, "https://app.siftstack.com/rules/rule-123");
+}
+
+#[test]
+fn rule_url_errors_when_host_cannot_be_derived() {
+    let svc = UrlService::new(String::from("https://my-self-hosted.example"));
+    let err = svc.build_rule_url("rule-123").unwrap_err();
+    assert_eq!(err.code.0, -32602);
+}
+
+#[test]
+fn annotation_asset_run_urls_use_singular_path_segments() {
+    let svc = service();
+    assert_eq!(
+        svc.build_annotation_url("ann-1").unwrap(),
+        "https://app.siftstack.com/annotation/ann-1"
+    );
+    assert_eq!(
+        svc.build_asset_url("asset-1").unwrap(),
+        "https://app.siftstack.com/asset/asset-1"
+    );
+    assert_eq!(
+        svc.build_run_url("run-1").unwrap(),
+        "https://app.siftstack.com/run/run-1"
+    );
+}
+
+#[test]
+fn annotation_asset_run_urls_error_when_host_cannot_be_derived() {
+    let svc = UrlService::new(String::from("https://my-self-hosted.example"));
+    assert_eq!(
+        svc.build_annotation_url("ann-1").unwrap_err().code.0,
+        -32602
+    );
+    assert_eq!(svc.build_asset_url("asset-1").unwrap_err().code.0, -32602);
+    assert_eq!(svc.build_run_url("run-1").unwrap_err().code.0, -32602);
 }

--- a/rust/crates/sift_mcp/src/tool/annotations/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/annotations/mod.rs
@@ -1,0 +1,390 @@
+use rmcp::{
+    ErrorData,
+    handler::server::wrapper::Parameters,
+    model::{CallToolResult, Content},
+    schemars::{self, JsonSchema},
+    tool, tool_router,
+};
+use serde::Deserialize;
+use sift_rs::{
+    annotations::v1::{AnnotationState, AnnotationType},
+    metadata::v1::MetadataValue,
+};
+
+use crate::{
+    error::{self, from_anyhow},
+    server::SiftMcpServer,
+    tool::common::{MetadataEntry, url_clause, with_urls},
+};
+
+#[cfg(test)]
+mod test;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AnnotationListParams {
+    pub(crate) filter: String,
+    pub(crate) order_by: Option<String>,
+    pub(crate) limit: Option<u32>,
+    pub(crate) organization_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateAnnotationParams {
+    name: String,
+    description: Option<String>,
+    start_time_unix_nanos: i64,
+    end_time_unix_nanos: i64,
+    annotation_type: String,
+    state: Option<String>,
+    assets: Option<Vec<String>>,
+    tags: Option<Vec<String>>,
+    linked_channel_ids: Option<Vec<String>>,
+    run_id: Option<String>,
+    assign_to_user_id: Option<String>,
+    metadata: Option<Vec<MetadataEntry>>,
+    organization_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UpdateAnnotationParams {
+    annotation_id: String,
+    name: Option<String>,
+    description: Option<String>,
+    start_time_unix_nanos: Option<i64>,
+    end_time_unix_nanos: Option<i64>,
+    assigned_to_user_id: Option<String>,
+    state: Option<String>,
+    tags: Option<Vec<String>>,
+    linked_channel_ids: Option<Vec<String>>,
+    metadata: Option<Vec<MetadataEntry>>,
+}
+
+fn parse_annotation_type(s: &str) -> Result<AnnotationType, ErrorData> {
+    match s.to_ascii_lowercase().as_str() {
+        "data_review" => Ok(AnnotationType::DataReview),
+        "phase" => Ok(AnnotationType::Phase),
+        other => Err(ErrorData::invalid_params(
+            format!("unknown `annotation_type` `{other}`; expected `data_review` or `phase`"),
+            None,
+        )),
+    }
+}
+
+fn parse_annotation_state(s: &str) -> Result<AnnotationState, ErrorData> {
+    match s.to_ascii_lowercase().as_str() {
+        "open" => Ok(AnnotationState::Open),
+        "flagged" => Ok(AnnotationState::Flagged),
+        "resolved" => Ok(AnnotationState::Resolved),
+        other => Err(ErrorData::invalid_params(
+            format!("unknown `state` `{other}`; expected `open`, `flagged`, or `resolved`"),
+            None,
+        )),
+    }
+}
+
+#[tool_router(router = annotations_router, vis = "pub(crate)")]
+impl SiftMcpServer {
+    #[tool(
+        name = "list_annotations",
+        description = "
+            List annotations in Sift, optionally filtered by a CEL expression and ordered by one or more fields.
+
+            Output:
+              - `{ \"annotations\": [Annotation, ...] }`. Each item is the full Sift `Annotation` shape including
+                `annotation_id`, `name`, `description`, `start_time`, `end_time`, `state`, `annotation_type`,
+                `run_id`, `asset_ids`, `tags`, `linked_channels`, metadata, timestamps, and archive state, plus an
+                added `url` field with the annotation's Sift web link (`<host>/annotation/<annotation_id>`). `url`
+                is omitted when the host can't be derived. Surface these links to the user when presenting
+                annotations.
+
+            Parameters:
+              - `filter`: CEL expression. Pass an empty string to list everything. Filterable fields:
+                `annotation_id`, `start_time`, `end_time`, `created_date`, `modified_date`, `run_id`, `name`,
+                `description`, `state`, `created_by_user_id`, `created_by_rule_condition_version_id`, `rule_id`,
+                `annotation_type`, `tag_name`, `report_id`, `asset_id`, `asset_name`, `pending`, `assignee`,
+                `campaign_reports`, `metadata`, `archived_date`, `is_archived`. Reference metadata entries as
+                `metadata.{key}` (e.g. `metadata.severity == \"high\"`).
+              - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `created_date`,
+                `modified_date`, `start_time`, `end_time`, `name`, `description`. Default sort is `created_date desc`
+                (newest first). Example: `\"start_time desc,name\"`.
+              - `limit`: optional cap on returned items. Values in `1..=1000` cap the result set. Omitting it OR
+                passing a value above 1000 returns ALL matching annotations (paginated server-side).
+              - `organization_id`: optional. Required only when the caller belongs to multiple organizations.
+
+            Errors:
+              - `INVALID_PARAMS` if `filter` is not a valid CEL expression or `order_by` references an unknown field.
+              - `INTERNAL_ERROR` for upstream gRPC failures.
+
+            Guidance:
+              - Narrow with `run_id == \"...\"` or `asset_id == \"...\"` when known — those are the most selective.
+              - Use `is_archived == false` to exclude archived annotations unless they're explicitly needed.
+        ",
+        annotations(title = "annotations_router/list_annotations", read_only_hint = true)
+    )]
+    pub async fn list_annotations(
+        &self,
+        params: Parameters<AnnotationListParams>,
+    ) -> error::McpResult {
+        let Parameters(AnnotationListParams {
+            filter,
+            order_by,
+            limit,
+            organization_id,
+        }) = params;
+
+        let annotations = self
+            .annotation_service
+            .list_annotations(filter, order_by, limit, organization_id)
+            .await
+            .map_err(from_anyhow)?;
+
+        let annotations = with_urls(&annotations, |a| {
+            self.url_service.build_annotation_url(&a.annotation_id).ok()
+        })?;
+
+        Ok(CallToolResult::structured(
+            serde_json::json!({ "annotations": annotations }),
+        ))
+    }
+
+    #[tool(
+        name = "create_annotation",
+        description = "
+            Create a new annotation over a time range. Wraps `annotations/v1 CreateAnnotation`.
+
+            Output:
+              - `{ \"annotation\": Annotation, \"annotation_url\": string|null, \"next_step\": string }`. The
+                returned `Annotation` is the server-assigned state including its new `annotation_id`;
+                `annotation_url` is its Sift web link (`<host>/annotation/<annotation_id>`), or null when the host
+                can't be derived.
+
+            Parameters:
+              - `name`: required; the annotation's display name.
+              - `description`: optional free-text description.
+              - `start_time_unix_nanos` / `end_time_unix_nanos`: required time bounds in Unix nanoseconds.
+                `end_time_unix_nanos` must be >= `start_time_unix_nanos`.
+              - `annotation_type`: required; one of `data_review` or `phase`.
+              - `state`: optional; one of `open`, `flagged`, `resolved`. MUST be omitted when `annotation_type`
+                is `phase` (the server rejects a phase annotation with a state).
+              - `assets`: optional list of asset NAMES to associate.
+              - `tags`: optional list of tag names to associate.
+              - `linked_channel_ids`: optional list of channel ids to link. Only plain channels are supported;
+                bit-field and calculated-channel links are not exposed here.
+              - `run_id`: optional id of the run to associate.
+              - `assign_to_user_id`: optional id of the user to assign the annotation to.
+              - `metadata`: optional list of `{ \"name\": \"<key>\", \"value\": <scalar> }` entries; `value` is a
+                string, number, or boolean. The key must already exist in the organization's metadata schema.
+              - `organization_id`: optional. Required only when the caller belongs to multiple organizations.
+
+            Errors:
+              - `INVALID_PARAMS` if `name` is empty, the time range is inverted, `annotation_type`/`state` is not a
+                recognized value, or a `state` is supplied for a `phase` annotation.
+              - `INTERNAL_ERROR` for upstream gRPC failures (e.g. unknown metadata key, missing run/asset).
+
+            Guidance:
+              - This is a write. CONFIRM the time range, type, and associations with the user before invoking.
+        ",
+        annotations(title = "annotations_router/create_annotation", read_only_hint = false)
+    )]
+    pub async fn create_annotation(
+        &self,
+        params: Parameters<CreateAnnotationParams>,
+    ) -> error::McpResult {
+        let Parameters(CreateAnnotationParams {
+            name,
+            description,
+            start_time_unix_nanos,
+            end_time_unix_nanos,
+            annotation_type,
+            state,
+            assets,
+            tags,
+            linked_channel_ids,
+            run_id,
+            assign_to_user_id,
+            metadata,
+            organization_id,
+        }) = params;
+
+        if name.is_empty() {
+            return Err(ErrorData::invalid_params("`name` must not be empty", None));
+        }
+        if end_time_unix_nanos < start_time_unix_nanos {
+            return Err(ErrorData::invalid_params(
+                "`end_time_unix_nanos` must be >= `start_time_unix_nanos`",
+                None,
+            ));
+        }
+
+        let annotation_type = parse_annotation_type(&annotation_type)?;
+        let state = state.map(|s| parse_annotation_state(&s)).transpose()?;
+
+        if annotation_type == AnnotationType::Phase && state.is_some() {
+            return Err(ErrorData::invalid_params(
+                "`state` must be omitted when `annotation_type` is `phase`",
+                None,
+            ));
+        }
+
+        let metadata = metadata.map(|m| m.into_iter().map(MetadataValue::from).collect::<Vec<_>>());
+
+        let annotation = self
+            .annotation_service
+            .create_annotation(
+                name,
+                description,
+                start_time_unix_nanos,
+                end_time_unix_nanos,
+                annotation_type,
+                state,
+                assets,
+                tags,
+                linked_channel_ids,
+                run_id,
+                assign_to_user_id,
+                metadata,
+                organization_id,
+            )
+            .await
+            .map_err(from_anyhow)?;
+
+        let annotation_url = self
+            .url_service
+            .build_annotation_url(&annotation.annotation_id)
+            .ok();
+        let next_step = format!(
+            "Created annotation `{}` ({}).{} Surface the new annotation to the user and confirm it \
+             matches their intent.",
+            annotation.name,
+            annotation.annotation_id,
+            url_clause(annotation_url.as_deref()),
+        );
+
+        let mut result = CallToolResult::structured(serde_json::json!({
+            "annotation": annotation,
+            "annotation_url": annotation_url,
+            "next_step": next_step,
+        }));
+        result.content = vec![Content::text(next_step)];
+        Ok(result)
+    }
+
+    #[tool(
+        name = "update_annotation",
+        description = "
+            Update an existing annotation. Wraps `annotations/v1 UpdateAnnotation`.
+
+            Output:
+              - `{ \"annotation\": Annotation, \"annotation_url\": string|null, \"next_step\": string }`. The
+                returned `Annotation` is the post-update state from the server; `annotation_url` is its Sift web
+                link, or null when the host can't be derived.
+
+            Parameters:
+              - `annotation_id`: required; the id of the annotation to update.
+              - `name`: optional new name.
+              - `description`: optional new description.
+              - `start_time_unix_nanos` / `end_time_unix_nanos`: optional new time bounds in Unix nanoseconds.
+              - `assigned_to_user_id`: optional new assignee user id.
+              - `state`: optional; one of `open`, `flagged`, `resolved`.
+              - `tags`: optional; REPLACES the full tag list. Pass `[]` to clear all tags.
+              - `linked_channel_ids`: optional; REPLACES the full linked-channel list with plain channel links.
+                Pass `[]` to clear. Bit-field and calculated-channel links are not exposed here.
+              - `metadata`: optional; REPLACES the full metadata list. Each entry is
+                `{ \"name\": \"<key>\", \"value\": <scalar> }`. Pass `[]` to clear.
+
+              At least one updatable field must be set; otherwise the tool returns `INVALID_PARAMS`.
+
+            Errors:
+              - `INVALID_PARAMS` if `annotation_id` is empty, `state` is unrecognized, or no updatable field is set.
+              - `RESOURCE_NOT_FOUND` if no annotation matches `annotation_id`.
+              - `INTERNAL_ERROR` for upstream gRPC failures.
+
+            Guidance:
+              - This is a write. CONFIRM the target and the full proposed values with the user before invoking —
+                `tags`, `linked_channel_ids`, and `metadata` are REPLACE operations, not merges.
+              - For appends, read the current annotation via `list_annotations` filtered by
+                `annotation_id == \"<id>\"`, then send the union.
+        ",
+        annotations(title = "annotations_router/update_annotation", read_only_hint = false)
+    )]
+    pub async fn update_annotation(
+        &self,
+        params: Parameters<UpdateAnnotationParams>,
+    ) -> error::McpResult {
+        let Parameters(UpdateAnnotationParams {
+            annotation_id,
+            name,
+            description,
+            start_time_unix_nanos,
+            end_time_unix_nanos,
+            assigned_to_user_id,
+            state,
+            tags,
+            linked_channel_ids,
+            metadata,
+        }) = params;
+
+        if annotation_id.is_empty() {
+            return Err(ErrorData::invalid_params(
+                "`annotation_id` must not be empty",
+                None,
+            ));
+        }
+
+        let has_update = name.is_some()
+            || description.is_some()
+            || start_time_unix_nanos.is_some()
+            || end_time_unix_nanos.is_some()
+            || assigned_to_user_id.is_some()
+            || state.is_some()
+            || tags.is_some()
+            || linked_channel_ids.is_some()
+            || metadata.is_some();
+        if !has_update {
+            return Err(ErrorData::invalid_params(
+                "at least one updatable field must be provided",
+                None,
+            ));
+        }
+
+        let state = state.map(|s| parse_annotation_state(&s)).transpose()?;
+        let metadata = metadata.map(|m| m.into_iter().map(MetadataValue::from).collect::<Vec<_>>());
+
+        let annotation = self
+            .annotation_service
+            .update_annotation(
+                annotation_id,
+                name,
+                description,
+                start_time_unix_nanos,
+                end_time_unix_nanos,
+                assigned_to_user_id,
+                state,
+                tags,
+                linked_channel_ids,
+                metadata,
+            )
+            .await
+            .map_err(from_anyhow)?;
+
+        let annotation_url = self
+            .url_service
+            .build_annotation_url(&annotation.annotation_id)
+            .ok();
+        let next_step = format!(
+            "Updated annotation `{}` ({}).{} Surface the new state to the user and confirm the change \
+             matches their intent. Remember: tags, linked channels, and metadata are REPLACE operations.",
+            annotation.name,
+            annotation.annotation_id,
+            url_clause(annotation_url.as_deref()),
+        );
+
+        let mut result = CallToolResult::structured(serde_json::json!({
+            "annotation": annotation,
+            "annotation_url": annotation_url,
+            "next_step": next_step,
+        }));
+        result.content = vec![Content::text(next_step)];
+        Ok(result)
+    }
+}

--- a/rust/crates/sift_mcp/src/tool/annotations/test.rs
+++ b/rust/crates/sift_mcp/src/tool/annotations/test.rs
@@ -1,0 +1,255 @@
+use rmcp::{handler::server::wrapper::Parameters, model::ErrorCode};
+use sift_rs::annotations::v1::{
+    Annotation, CreateAnnotationResponse, ListAnnotationsResponse, UpdateAnnotationResponse,
+    annotation_service_server::AnnotationServiceServer,
+};
+use sift_test_util::{grpc::memory_sift_channel, mock::annotations::v1::MockAnnotationServiceImpl};
+use tokio::task::JoinHandle;
+use tonic::{Response, Status, transport::Server};
+
+use super::{AnnotationListParams, CreateAnnotationParams, UpdateAnnotationParams};
+use crate::{server::SiftMcpServer, tool::common::test_support::structured_field};
+
+async fn server_with_mock(mock: MockAnnotationServiceImpl) -> (SiftMcpServer, JoinHandle<()>) {
+    let (client, server) = tokio::io::duplex(1024);
+    let channel = memory_sift_channel(client).await;
+
+    let handle = tokio::spawn(async move {
+        Server::builder()
+            .add_service(AnnotationServiceServer::new(mock))
+            .serve_with_incoming(tokio_stream::once(Ok::<_, std::io::Error>(server)))
+            .await
+            .unwrap();
+    });
+
+    (
+        SiftMcpServer::new(channel, String::from("https://api.test.local")),
+        handle,
+    )
+}
+
+fn create_params() -> CreateAnnotationParams {
+    CreateAnnotationParams {
+        name: "review window".into(),
+        description: None,
+        start_time_unix_nanos: 1_000_000_000,
+        end_time_unix_nanos: 2_000_000_000,
+        annotation_type: "data_review".into(),
+        state: None,
+        assets: None,
+        tags: None,
+        linked_channel_ids: None,
+        run_id: None,
+        assign_to_user_id: None,
+        metadata: None,
+        organization_id: None,
+    }
+}
+
+fn update_params(annotation_id: &str) -> UpdateAnnotationParams {
+    UpdateAnnotationParams {
+        annotation_id: annotation_id.into(),
+        name: None,
+        description: None,
+        start_time_unix_nanos: None,
+        end_time_unix_nanos: None,
+        assigned_to_user_id: None,
+        state: None,
+        tags: None,
+        linked_channel_ids: None,
+        metadata: None,
+    }
+}
+
+#[tokio::test]
+async fn list_annotations_returns_single_page() {
+    let mut mock = MockAnnotationServiceImpl::new();
+    mock.expect_list_annotations()
+        .withf(|req| req.get_ref().filter == "name == \"liftoff\"")
+        .returning(|_| {
+            Ok(Response::new(ListAnnotationsResponse {
+                annotations: vec![Annotation {
+                    annotation_id: "ann1".into(),
+                    name: "liftoff".into(),
+                    ..Default::default()
+                }],
+                next_page_token: String::new(),
+            }))
+        });
+
+    let (server, _h) = server_with_mock(mock).await;
+
+    let resp = server
+        .list_annotations(Parameters(AnnotationListParams {
+            filter: "name == \"liftoff\"".into(),
+            order_by: None,
+            limit: None,
+            organization_id: None,
+        }))
+        .await
+        .expect("list_annotations failed");
+
+    let annotations = structured_field(resp, "annotations");
+    assert_eq!(annotations.as_array().unwrap().len(), 1);
+    assert_eq!(annotations[0]["annotationId"], "ann1");
+    assert_eq!(
+        annotations[0]["url"],
+        "https://app.test.local/annotation/ann1"
+    );
+}
+
+#[tokio::test]
+async fn create_annotation_happy_path() {
+    let mut mock = MockAnnotationServiceImpl::new();
+    mock.expect_create_annotation().returning(|_| {
+        Ok(Response::new(CreateAnnotationResponse {
+            annotation: Some(Annotation {
+                annotation_id: "ann-new".into(),
+                name: "review window".into(),
+                ..Default::default()
+            }),
+        }))
+    });
+
+    let (server, _h) = server_with_mock(mock).await;
+
+    let resp = server
+        .create_annotation(Parameters(create_params()))
+        .await
+        .expect("create_annotation failed");
+
+    let annotation = structured_field(resp, "annotation");
+    assert_eq!(annotation["annotationId"], "ann-new");
+}
+
+#[tokio::test]
+async fn create_annotation_rejects_empty_name() {
+    let (server, _h) = server_with_mock(MockAnnotationServiceImpl::new()).await;
+
+    let mut params = create_params();
+    params.name = String::new();
+
+    let err = server
+        .create_annotation(Parameters(params))
+        .await
+        .expect_err("expected error");
+
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+}
+
+#[tokio::test]
+async fn create_annotation_rejects_inverted_time_range() {
+    let (server, _h) = server_with_mock(MockAnnotationServiceImpl::new()).await;
+
+    let mut params = create_params();
+    params.start_time_unix_nanos = 5;
+    params.end_time_unix_nanos = 1;
+
+    let err = server
+        .create_annotation(Parameters(params))
+        .await
+        .expect_err("expected error");
+
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+}
+
+#[tokio::test]
+async fn create_annotation_rejects_unknown_type() {
+    let (server, _h) = server_with_mock(MockAnnotationServiceImpl::new()).await;
+
+    let mut params = create_params();
+    params.annotation_type = "bogus".into();
+
+    let err = server
+        .create_annotation(Parameters(params))
+        .await
+        .expect_err("expected error");
+
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+}
+
+#[tokio::test]
+async fn create_annotation_rejects_state_on_phase() {
+    let (server, _h) = server_with_mock(MockAnnotationServiceImpl::new()).await;
+
+    let mut params = create_params();
+    params.annotation_type = "phase".into();
+    params.state = Some("open".into());
+
+    let err = server
+        .create_annotation(Parameters(params))
+        .await
+        .expect_err("expected error");
+
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+}
+
+#[tokio::test]
+async fn update_annotation_happy_path() {
+    let mut mock = MockAnnotationServiceImpl::new();
+    mock.expect_update_annotation().returning(|_| {
+        Ok(Response::new(UpdateAnnotationResponse {
+            annotation: Some(Annotation {
+                annotation_id: "ann1".into(),
+                name: "renamed".into(),
+                ..Default::default()
+            }),
+        }))
+    });
+
+    let (server, _h) = server_with_mock(mock).await;
+
+    let mut params = update_params("ann1");
+    params.name = Some("renamed".into());
+
+    let resp = server
+        .update_annotation(Parameters(params))
+        .await
+        .expect("update_annotation failed");
+
+    let annotation = structured_field(resp, "annotation");
+    assert_eq!(annotation["name"], "renamed");
+}
+
+#[tokio::test]
+async fn update_annotation_rejects_empty_id() {
+    let (server, _h) = server_with_mock(MockAnnotationServiceImpl::new()).await;
+
+    let err = server
+        .update_annotation(Parameters(update_params("")))
+        .await
+        .expect_err("expected error");
+
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+}
+
+#[tokio::test]
+async fn update_annotation_rejects_no_fields() {
+    let (server, _h) = server_with_mock(MockAnnotationServiceImpl::new()).await;
+
+    let err = server
+        .update_annotation(Parameters(update_params("ann1")))
+        .await
+        .expect_err("expected error");
+
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+}
+
+#[tokio::test]
+async fn update_annotation_propagates_grpc_error() {
+    let mut mock = MockAnnotationServiceImpl::new();
+    mock.expect_update_annotation()
+        .returning(|_| Err(Status::not_found("no such annotation")));
+
+    let (server, _h) = server_with_mock(mock).await;
+
+    let mut params = update_params("ann1");
+    params.name = Some("x".into());
+
+    let err = server
+        .update_annotation(Parameters(params))
+        .await
+        .expect_err("expected error");
+
+    assert_eq!(err.code, ErrorCode::RESOURCE_NOT_FOUND);
+}

--- a/rust/crates/sift_mcp/src/tool/assets/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/assets/mod.rs
@@ -11,7 +11,7 @@ use sift_rs::metadata::v1::MetadataValue;
 use crate::{
     error::{self, from_anyhow},
     server::SiftMcpServer,
-    tool::{common::ListParams, data::MetadataEntry},
+    tool::common::{ListParams, MetadataEntry, url_clause, with_urls},
 };
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -33,7 +33,9 @@ impl SiftMcpServer {
 
             Output:
               - `{ \"assets\": [Asset, ...] }`. Each item is the full Sift `Asset` shape including `asset_id`, `name`,
-                tags, metadata, timestamps, and archive state.
+                tags, metadata, timestamps, and archive state, plus an added `url` field with the asset's Sift web
+                link (`<host>/asset/<asset_id>`). `url` is omitted when the host can't be derived. Surface these
+                links to the user when presenting assets.
 
             Parameters:
               - `filter`: CEL expression. Pass an empty string to list everything. Filterable fields:
@@ -63,14 +65,19 @@ impl SiftMcpServer {
             order_by,
         }) = params;
 
-        let out = self
+        let assets = self
             .asset_service
             .list_assets(filter, order_by, limit)
             .await
-            .map(|assets| serde_json::json!({ "assets": assets }))
             .map_err(from_anyhow)?;
 
-        Ok(CallToolResult::structured(out))
+        let assets = with_urls(&assets, |a| {
+            self.url_service.build_asset_url(&a.asset_id).ok()
+        })?;
+
+        Ok(CallToolResult::structured(
+            serde_json::json!({ "assets": assets }),
+        ))
     }
 
     #[tool(
@@ -79,8 +86,9 @@ impl SiftMcpServer {
             Update an existing asset's tags and/or metadata. Wraps `assets/v1 UpdateAsset`.
 
             Output:
-              - `{ \"asset\": Asset, \"next_step\": string }`. The returned `Asset` is the
-                post-update state from the server.
+              - `{ \"asset\": Asset, \"asset_url\": string|null, \"next_step\": string }`. The returned `Asset` is
+                the post-update state from the server; `asset_url` is its Sift web link
+                (`<host>/asset/<asset_id>`), or null when the host can't be derived.
 
             Parameters:
               - `asset_id`: required; the id of the asset to update.
@@ -141,15 +149,19 @@ impl SiftMcpServer {
             .await
             .map_err(from_anyhow)?;
 
+        let asset_url = self.url_service.build_asset_url(&asset.asset_id).ok();
         let next_step = format!(
-            "Updated asset `{}` ({}). Surface the new state to the user and confirm the change \
+            "Updated asset `{}` ({}).{} Surface the new state to the user and confirm the change \
              matches their intent. Remember: tags and metadata are REPLACE operations — verify \
              nothing was unintentionally dropped.",
-            asset.name, asset.asset_id,
+            asset.name,
+            asset.asset_id,
+            url_clause(asset_url.as_deref()),
         );
 
         let mut result = CallToolResult::structured(serde_json::json!({
             "asset": asset,
+            "asset_url": asset_url,
             "next_step": next_step,
         }));
         result.content = vec![Content::text(next_step)];

--- a/rust/crates/sift_mcp/src/tool/assets/test.rs
+++ b/rust/crates/sift_mcp/src/tool/assets/test.rs
@@ -62,6 +62,7 @@ async fn list_assets_returns_single_page() {
     let assets = structured_field(resp, "assets");
     assert_eq!(assets.as_array().unwrap().len(), 2);
     assert_eq!(assets[0]["assetId"], "a1");
+    assert_eq!(assets[0]["url"], "https://app.test.local/asset/a1");
     assert_eq!(assets[1]["assetId"], "a2");
 }
 

--- a/rust/crates/sift_mcp/src/tool/common/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/common/mod.rs
@@ -1,5 +1,10 @@
+use rmcp::ErrorData;
 use rmcp::schemars::{self, JsonSchema};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sift_rs::metadata::v1::{
+    MetadataKey, MetadataKeyType, MetadataValue, metadata_value::Value as MetadataValueInner,
+};
 
 /// Shared parameters for the simple `list_*` tools (assets, runs, channels).
 /// Resources with extra knobs (e.g. reports' `organization_id`) define their own
@@ -10,6 +15,84 @@ pub struct ListParams {
     pub(crate) order_by: Option<String>,
     pub(crate) limit: Option<u32>,
 }
+
+/// A single metadata scalar as it arrives over the wire. Flat (untagged) so the
+/// value round-trips as a bare JSON string/number/bool, per the flat-params rule.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum MetadataScalar {
+    String(String),
+    Number(f64),
+    Boolean(bool),
+}
+
+/// A flat `{ "name": ..., "value": <scalar> }` metadata entry shared by every
+/// tool that attaches metadata (data, assets, annotations, reports).
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct MetadataEntry {
+    pub(crate) name: String,
+    pub(crate) value: MetadataScalar,
+}
+
+/// A trailing clause for a write tool's `next_step` that points at the operated
+/// resource's Sift web URL. Empty when the URL is `None` — i.e. the host could
+/// not be derived (e.g. self-hosted deployments without an `api.` subdomain) —
+/// so URL derivation never fails an operation.
+pub(crate) fn url_clause(url: Option<&str>) -> String {
+    url.map(|u| format!(" View it in Sift: {u}"))
+        .unwrap_or_default()
+}
+
+/// Serialize each item to JSON and inject a `url` field built by `url_of`, so a
+/// listing surfaces a clickable Sift web link per row. Items whose url can't be
+/// built (host underivable on self-hosted deployments) are returned unchanged,
+/// without a `url` field. Mutates only object-shaped values.
+pub(crate) fn with_urls<T: Serialize>(
+    items: &[T],
+    url_of: impl Fn(&T) -> Option<String>,
+) -> Result<Vec<Value>, ErrorData> {
+    items
+        .iter()
+        .map(|item| {
+            let mut value = serde_json::to_value(item).map_err(|e| {
+                ErrorData::internal_error(format!("failed to serialize list item: {e}"), None)
+            })?;
+            if let (Some(obj), Some(url)) = (value.as_object_mut(), url_of(item)) {
+                obj.insert("url".to_string(), Value::String(url));
+            }
+            Ok(value)
+        })
+        .collect()
+}
+
+impl From<MetadataEntry> for MetadataValue {
+    fn from(entry: MetadataEntry) -> Self {
+        let (key_type, value) = match entry.value {
+            MetadataScalar::String(s) => {
+                (MetadataKeyType::String, MetadataValueInner::StringValue(s))
+            }
+            MetadataScalar::Number(n) => {
+                (MetadataKeyType::Number, MetadataValueInner::NumberValue(n))
+            }
+            MetadataScalar::Boolean(b) => (
+                MetadataKeyType::Boolean,
+                MetadataValueInner::BooleanValue(b),
+            ),
+        };
+        MetadataValue {
+            key: Some(MetadataKey {
+                name: entry.name,
+                r#type: key_type.into(),
+                ..Default::default()
+            }),
+            value: Some(value),
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod test;
 
 #[cfg(test)]
 pub(crate) mod test_support {

--- a/rust/crates/sift_mcp/src/tool/common/test.rs
+++ b/rust/crates/sift_mcp/src/tool/common/test.rs
@@ -1,0 +1,14 @@
+use super::url_clause;
+
+#[test]
+fn url_clause_present_renders_view_link() {
+    assert_eq!(
+        url_clause(Some("https://app.siftstack.com/rules/r-1")),
+        " View it in Sift: https://app.siftstack.com/rules/r-1"
+    );
+}
+
+#[test]
+fn url_clause_none_is_empty() {
+    assert_eq!(url_clause(None), "");
+}

--- a/rust/crates/sift_mcp/src/tool/data/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/data/mod.rs
@@ -10,9 +10,7 @@ use rmcp::{
 };
 use serde::Deserialize;
 
-use sift_rs::metadata::v1::{
-    MetadataKey, MetadataKeyType, MetadataValue, metadata_value::Value as MetadataValueInner,
-};
+use sift_rs::metadata::v1::MetadataValue;
 
 use crate::{
     error::{self, from_anyhow},
@@ -21,6 +19,7 @@ use crate::{
         data::{ChannelInput, DataService, TimeRange},
         ingest::RunForm,
     },
+    tool::common::MetadataEntry,
 };
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -44,20 +43,6 @@ pub struct SqlParams {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
-#[serde(untagged)]
-pub enum MetadataScalar {
-    String(String),
-    Number(f64),
-    Boolean(bool),
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct MetadataEntry {
-    name: String,
-    value: MetadataScalar,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
 pub struct UploadDatasetParams {
     asset: String,
     run_name: Option<String>,
@@ -66,32 +51,6 @@ pub struct UploadDatasetParams {
     #[serde(default)]
     metadata: Vec<MetadataEntry>,
     input: PathBuf,
-}
-
-impl From<MetadataEntry> for MetadataValue {
-    fn from(entry: MetadataEntry) -> Self {
-        let (key_type, value) = match entry.value {
-            MetadataScalar::String(s) => {
-                (MetadataKeyType::String, MetadataValueInner::StringValue(s))
-            }
-            MetadataScalar::Number(n) => {
-                (MetadataKeyType::Number, MetadataValueInner::NumberValue(n))
-            }
-            MetadataScalar::Boolean(b) => (
-                MetadataKeyType::Boolean,
-                MetadataValueInner::BooleanValue(b),
-            ),
-        };
-        MetadataValue {
-            key: Some(MetadataKey {
-                name: entry.name,
-                r#type: key_type.into(),
-                ..Default::default()
-            }),
-            value: Some(value),
-            ..Default::default()
-        }
-    }
 }
 
 #[tool_router(router = data_router, vis = "pub(crate)")]

--- a/rust/crates/sift_mcp/src/tool/explore/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/explore/mod.rs
@@ -6,7 +6,7 @@ use rmcp::{
 };
 use serde::Deserialize;
 
-use crate::{error, server::SiftMcpServer, service::explore::ExploreUrlRequest};
+use crate::{error, server::SiftMcpServer, service::url::ExploreUrlRequest};
 
 #[cfg(test)]
 mod test;
@@ -74,7 +74,7 @@ impl SiftMcpServer {
             explore_host,
         }) = params;
 
-        let url = self.explore_service.build_url(ExploreUrlRequest {
+        let url = self.url_service.build_explore_url(ExploreUrlRequest {
             assets,
             runs,
             channels,

--- a/rust/crates/sift_mcp/src/tool/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/mod.rs
@@ -1,3 +1,4 @@
+pub mod annotations;
 pub mod assets;
 pub mod channels;
 pub mod common;

--- a/rust/crates/sift_mcp/src/tool/reports/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/reports/mod.rs
@@ -1,14 +1,18 @@
 use rmcp::{
+    ErrorData,
     handler::server::wrapper::Parameters,
-    model::CallToolResult,
+    model::{CallToolResult, Content},
     schemars::{self, JsonSchema},
     tool, tool_router,
 };
 use serde::Deserialize;
+use sift_rs::metadata::v1::MetadataValue;
 
 use crate::{
     error::{self, from_anyhow},
     server::SiftMcpServer,
+    service::reports::{ReportSource, RuleIdentifier},
+    tool::common::{MetadataEntry, url_clause, with_urls},
 };
 
 #[cfg(test)]
@@ -22,6 +26,34 @@ pub struct ReportListParams {
     pub(crate) organization_id: Option<String>,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ReportRuleSummaryListParams {
+    report_id: String,
+    filter: String,
+    order_by: Option<String>,
+    limit: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateReportParams {
+    run_id: String,
+    name: String,
+    organization_id: Option<String>,
+    metadata: Option<Vec<MetadataEntry>>,
+    report_template_id: Option<String>,
+    description: Option<String>,
+    tag_names: Option<Vec<String>>,
+    rule_ids: Option<Vec<String>>,
+    rule_client_keys: Option<Vec<String>>,
+    rule_version_ids: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UpdateReportParams {
+    report_id: String,
+    metadata: Vec<MetadataEntry>,
+}
+
 #[tool_router(router = reports_router, vis = "pub(crate)")]
 impl SiftMcpServer {
     #[tool(
@@ -32,7 +64,9 @@ impl SiftMcpServer {
             Output:
               - `{ \"reports\": [Report, ...] }`. Each item is the full Sift `Report` shape including `report_id`,
                 `report_template_id`, `run_id`, `organization_id`, `name`, `description`, per-rule `summaries`,
-                tags, metadata, timestamps, and archive state.
+                tags, metadata, timestamps, and archive state, plus an added `url` field with the report's Sift
+                web link (`<host>/reports/<report_id>`). `url` is omitted when the host can't be derived.
+                Surface these links to the user when presenting reports.
 
             Parameters:
               - `filter`: CEL expression. Pass an empty string to list everything. Filterable fields:
@@ -66,13 +100,293 @@ impl SiftMcpServer {
             organization_id,
         }) = params;
 
-        let out = self
+        let reports = self
             .report_service
             .list_reports(filter, order_by, limit, organization_id)
             .await
-            .map(|reports| serde_json::json!({ "reports": reports }))
             .map_err(from_anyhow)?;
 
-        Ok(CallToolResult::structured(out))
+        let reports = with_urls(&reports, |r| {
+            self.url_service.build_report_url(&r.report_id).ok()
+        })?;
+
+        Ok(CallToolResult::structured(
+            serde_json::json!({ "reports": reports }),
+        ))
+    }
+
+    #[tool(
+        name = "list_report_rule_summaries",
+        description = "
+            List the per-rule summaries for a single report. Wraps `reports/v1 ListReportRuleSummaries`.
+
+            Output:
+              - `{ \"report_rule_summaries\": [ReportRuleSummary, ...], \"report_url\": string|null,
+                \"next_step\": string }`. Each summary carries `rule_id`, `rule_client_key`, `rule_version_id`,
+                `asset_id`, pass/fail/open counts (`num_passed`, `num_failed`, `num_open`), `status`,
+                `status_details`, and `display_order`. `report_url` is the report's Sift web link, or null when
+                the host can't be derived.
+
+            Parameters:
+              - `report_id`: required; the report whose rule summaries to list.
+              - `filter`: CEL expression. Pass an empty string to list everything. Filterable fields include
+                `rule_id`, `rule_version_id`, `asset_id`, and `status`.
+              - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `display_order`,
+                `created_date`, `modified_date`. Default sort is `display_order` ascending.
+              - `limit`: optional cap on returned items. Values in `1..=1000` cap the result set; omitting it OR
+                passing a value above 1000 returns ALL summaries (paginated server-side).
+
+            Errors:
+              - `INVALID_PARAMS` if `report_id` is empty or `filter`/`order_by` is invalid.
+              - `RESOURCE_NOT_FOUND` if no report matches `report_id`.
+              - `INTERNAL_ERROR` for upstream gRPC failures.
+
+            Guidance:
+              - Use this to drill into why a report passed or failed after locating it with `list_reports`.
+              - Filter by `status` (e.g. `status == \"REPORT_RULE_STATUS_FAILED\"`) to surface only failing rules.
+        ",
+        annotations(
+            title = "reports_router/list_report_rule_summaries",
+            read_only_hint = true
+        )
+    )]
+    pub async fn list_report_rule_summaries(
+        &self,
+        params: Parameters<ReportRuleSummaryListParams>,
+    ) -> error::McpResult {
+        let Parameters(ReportRuleSummaryListParams {
+            report_id,
+            filter,
+            order_by,
+            limit,
+        }) = params;
+
+        if report_id.is_empty() {
+            return Err(ErrorData::invalid_params(
+                "`report_id` must not be empty",
+                None,
+            ));
+        }
+
+        let report_url = self.url_service.build_report_url(&report_id).ok();
+
+        let summaries = self
+            .report_service
+            .list_report_rule_summaries(report_id, filter, order_by, limit)
+            .await
+            .map_err(from_anyhow)?;
+
+        let next_step = format!(
+            "Listed {} rule summaries.{} Surface the per-rule pass/fail/open breakdown to the user.",
+            summaries.len(),
+            url_clause(report_url.as_deref()),
+        );
+
+        let mut result = CallToolResult::structured(serde_json::json!({
+            "report_rule_summaries": summaries,
+            "report_url": report_url,
+            "next_step": next_step,
+        }));
+        result.content = vec![Content::text(next_step)];
+        Ok(result)
+    }
+
+    #[tool(
+        name = "create_report",
+        description = "
+            Create a report over a run, either from a report template or from an explicit set of rules. Wraps
+            `reports/v1 CreateReport`.
+
+            Output:
+              - `{ \"report\": Report, \"report_url\": string|null, \"next_step\": string }`. The returned `Report`
+                is the server-assigned state including its new `report_id` and `job_id`. `report_url` is the report's
+                Sift web link (`<host>/reports/<report_id>`), or null on self-hosted deployments where the host
+                can't be derived.
+
+            Parameters:
+              - `run_id`: required; the run the report is generated over.
+              - `name`: required; the report name.
+              - `organization_id`: optional. Required only when the caller belongs to multiple organizations.
+              - `metadata`: optional list of `{ \"name\": \"<key>\", \"value\": <scalar> }` entries.
+
+              The report SOURCE is one of two mutually exclusive shapes — provide exactly one:
+              - Template: set `report_template_id`. The template defines which rules run.
+              - Rules: leave `report_template_id` unset and provide EXACTLY ONE of `rule_ids`, `rule_client_keys`,
+                or `rule_version_ids`. `description` and `tag_names` are optional and apply only to this shape.
+
+            Errors:
+              - `INVALID_PARAMS` if `run_id` or `name` is empty, if both a template and rule identifiers are given,
+                if neither is given, or if more than one rule-identifier list is given.
+              - `INTERNAL_ERROR` for upstream gRPC failures (e.g. unknown run, template, or rule).
+
+            Guidance:
+              - This is a write that kicks off report execution. CONFIRM the run, source, and name with the user
+                before invoking.
+              - Use `list_report_rule_summaries` on the returned `report_id` to track per-rule progress.
+        ",
+        annotations(title = "reports_router/create_report", read_only_hint = false)
+    )]
+    pub async fn create_report(&self, params: Parameters<CreateReportParams>) -> error::McpResult {
+        let Parameters(CreateReportParams {
+            run_id,
+            name,
+            organization_id,
+            metadata,
+            report_template_id,
+            description,
+            tag_names,
+            rule_ids,
+            rule_client_keys,
+            rule_version_ids,
+        }) = params;
+
+        if run_id.is_empty() {
+            return Err(ErrorData::invalid_params(
+                "`run_id` must not be empty",
+                None,
+            ));
+        }
+        if name.is_empty() {
+            return Err(ErrorData::invalid_params("`name` must not be empty", None));
+        }
+
+        let rule_sources = [
+            rule_ids.map(RuleIdentifier::RuleIds),
+            rule_client_keys.map(RuleIdentifier::RuleClientKeys),
+            rule_version_ids.map(RuleIdentifier::RuleVersionIds),
+        ];
+        let rule_count = rule_sources.iter().filter(|r| r.is_some()).count();
+
+        let source = match (report_template_id, rule_count) {
+            (Some(report_template_id), 0) => ReportSource::Template { report_template_id },
+            (Some(_), _) => {
+                return Err(ErrorData::invalid_params(
+                    "provide either `report_template_id` or rule identifiers, not both",
+                    None,
+                ));
+            }
+            (None, 1) => {
+                let rules = rule_sources
+                    .into_iter()
+                    .flatten()
+                    .next()
+                    .expect("one source");
+                ReportSource::Rules {
+                    description,
+                    tag_names: tag_names.unwrap_or_default(),
+                    rules,
+                }
+            }
+            (None, 0) => {
+                return Err(ErrorData::invalid_params(
+                    "provide a report source: `report_template_id`, or exactly one of `rule_ids`, \
+                     `rule_client_keys`, `rule_version_ids`",
+                    None,
+                ));
+            }
+            (None, _) => {
+                return Err(ErrorData::invalid_params(
+                    "provide exactly one of `rule_ids`, `rule_client_keys`, `rule_version_ids`",
+                    None,
+                ));
+            }
+        };
+
+        let metadata = metadata.map(|m| m.into_iter().map(MetadataValue::from).collect::<Vec<_>>());
+
+        let report = self
+            .report_service
+            .create_report(organization_id, run_id, name, metadata, source)
+            .await
+            .map_err(from_anyhow)?;
+
+        let report_url = self.url_service.build_report_url(&report.report_id).ok();
+        let next_step = format!(
+            "Created report `{}` ({}).{} Surface it to the user. Use `list_report_rule_summaries` \
+             with this `report_id` to track per-rule progress.",
+            report.name,
+            report.report_id,
+            url_clause(report_url.as_deref()),
+        );
+
+        let mut result = CallToolResult::structured(serde_json::json!({
+            "report": report,
+            "report_url": report_url,
+            "next_step": next_step,
+        }));
+        result.content = vec![Content::text(next_step)];
+        Ok(result)
+    }
+
+    #[tool(
+        name = "update_report",
+        description = "
+            Update an existing report's metadata. Wraps `reports/v1 UpdateReport`.
+
+            Output:
+              - `{ \"report\": Report, \"report_url\": string|null, \"next_step\": string }`. The returned `Report`
+                is re-fetched after the update (the update RPC itself returns no body). `report_url` is the report's
+                Sift web link, or null when the host can't be derived.
+
+            Parameters:
+              - `report_id`: required; the id of the report to update.
+              - `metadata`: required; REPLACES the report's full metadata list. Each entry is
+                `{ \"name\": \"<key>\", \"value\": <scalar> }` where `value` is a string, number, or boolean.
+                Pass `[]` to clear all metadata. The key must already exist in the organization's metadata schema.
+
+            Note: per the API, only `metadata` is updatable through this tool. Report name/description and the
+            archive flow are not exposed here.
+
+            Errors:
+              - `INVALID_PARAMS` if `report_id` is empty.
+              - `RESOURCE_NOT_FOUND` if no report matches `report_id`.
+              - `INTERNAL_ERROR` for upstream gRPC failures (e.g. unknown metadata key).
+
+            Guidance:
+              - This is a write with REPLACE semantics. CONFIRM the full metadata list with the user — for appends,
+                read the current report via `list_reports` filtered by `report_id == \"<id>\"` and send the union.
+        ",
+        annotations(title = "reports_router/update_report", read_only_hint = false)
+    )]
+    pub async fn update_report(&self, params: Parameters<UpdateReportParams>) -> error::McpResult {
+        let Parameters(UpdateReportParams {
+            report_id,
+            metadata,
+        }) = params;
+
+        if report_id.is_empty() {
+            return Err(ErrorData::invalid_params(
+                "`report_id` must not be empty",
+                None,
+            ));
+        }
+
+        let metadata = metadata
+            .into_iter()
+            .map(MetadataValue::from)
+            .collect::<Vec<_>>();
+
+        let report = self
+            .report_service
+            .update_report(report_id, metadata)
+            .await
+            .map_err(from_anyhow)?;
+
+        let report_url = self.url_service.build_report_url(&report.report_id).ok();
+        let next_step = format!(
+            "Updated metadata on report `{}` ({}).{} Surface the new state to the user and confirm \
+             nothing was unintentionally dropped — metadata is a REPLACE operation.",
+            report.name,
+            report.report_id,
+            url_clause(report_url.as_deref()),
+        );
+
+        let mut result = CallToolResult::structured(serde_json::json!({
+            "report": report,
+            "report_url": report_url,
+            "next_step": next_step,
+        }));
+        result.content = vec![Content::text(next_step)];
+        Ok(result)
     }
 }

--- a/rust/crates/sift_mcp/src/tool/reports/test.rs
+++ b/rust/crates/sift_mcp/src/tool/reports/test.rs
@@ -1,13 +1,31 @@
 use rmcp::{handler::server::wrapper::Parameters, model::ErrorCode};
 use sift_rs::reports::v1::{
-    ListReportsResponse, Report, report_service_server::ReportServiceServer,
+    CreateReportResponse, GetReportResponse, ListReportRuleSummariesResponse, ListReportsResponse,
+    Report, ReportRuleSummary, UpdateReportResponse, report_service_server::ReportServiceServer,
 };
 use sift_test_util::{grpc::memory_sift_channel, mock::reports::v1::MockReportServiceImpl};
 use tokio::task::JoinHandle;
 use tonic::{Response, Status, transport::Server};
 
-use super::ReportListParams;
+use super::{
+    CreateReportParams, ReportListParams, ReportRuleSummaryListParams, UpdateReportParams,
+};
 use crate::{server::SiftMcpServer, tool::common::test_support::structured_field};
+
+fn create_report_params() -> CreateReportParams {
+    CreateReportParams {
+        run_id: "run-1".into(),
+        name: "nightly report".into(),
+        organization_id: None,
+        metadata: None,
+        report_template_id: None,
+        description: None,
+        tag_names: None,
+        rule_ids: None,
+        rule_client_keys: None,
+        rule_version_ids: None,
+    }
+}
 
 async fn server_with_mock(mock: MockReportServiceImpl) -> (SiftMcpServer, JoinHandle<()>) {
     let (client, server) = tokio::io::duplex(1024);
@@ -63,6 +81,7 @@ async fn list_reports_returns_single_page() {
     let reports = structured_field(resp, "reports");
     assert_eq!(reports.as_array().unwrap().len(), 1);
     assert_eq!(reports[0]["reportId"], "rep1");
+    assert_eq!(reports[0]["url"], "https://app.test.local/reports/rep1");
 }
 
 #[tokio::test]
@@ -241,4 +260,170 @@ async fn list_reports_propagates_grpc_error() {
 
     assert_eq!(err.code, ErrorCode::RESOURCE_NOT_FOUND);
     assert!(err.message.contains("no such report"));
+}
+
+#[tokio::test]
+async fn list_report_rule_summaries_returns_single_page() {
+    let mut mock = MockReportServiceImpl::new();
+    mock.expect_list_report_rule_summaries()
+        .withf(|req| req.get_ref().report_id == "rep1")
+        .returning(|_| {
+            Ok(Response::new(ListReportRuleSummariesResponse {
+                report_rule_summaries: vec![ReportRuleSummary {
+                    rule_id: "rule-1".into(),
+                    ..Default::default()
+                }],
+                next_page_token: String::new(),
+            }))
+        });
+
+    let (server, _h) = server_with_mock(mock).await;
+
+    let resp = server
+        .list_report_rule_summaries(Parameters(ReportRuleSummaryListParams {
+            report_id: "rep1".into(),
+            filter: String::new(),
+            order_by: None,
+            limit: None,
+        }))
+        .await
+        .expect("list_report_rule_summaries failed");
+
+    let summaries = structured_field(resp, "report_rule_summaries");
+    assert_eq!(summaries.as_array().unwrap().len(), 1);
+    assert_eq!(summaries[0]["ruleId"], "rule-1");
+}
+
+#[tokio::test]
+async fn list_report_rule_summaries_rejects_empty_report_id() {
+    let (server, _h) = server_with_mock(MockReportServiceImpl::new()).await;
+
+    let err = server
+        .list_report_rule_summaries(Parameters(ReportRuleSummaryListParams {
+            report_id: String::new(),
+            filter: String::new(),
+            order_by: None,
+            limit: None,
+        }))
+        .await
+        .expect_err("expected error");
+
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+}
+
+#[tokio::test]
+async fn create_report_from_rules_happy_path() {
+    let mut mock = MockReportServiceImpl::new();
+    mock.expect_create_report().returning(|_| {
+        Ok(Response::new(CreateReportResponse {
+            report: Some(Report {
+                report_id: "rep-new".into(),
+                name: "nightly report".into(),
+                ..Default::default()
+            }),
+        }))
+    });
+
+    let (server, _h) = server_with_mock(mock).await;
+
+    let mut params = create_report_params();
+    params.rule_ids = Some(vec!["rule-1".into()]);
+
+    let resp = server
+        .create_report(Parameters(params))
+        .await
+        .expect("create_report failed");
+
+    let report_url = structured_field(resp.clone(), "report_url");
+    assert_eq!(report_url, "https://app.test.local/reports/rep-new");
+    let report = structured_field(resp, "report");
+    assert_eq!(report["reportId"], "rep-new");
+}
+
+#[tokio::test]
+async fn create_report_rejects_no_source() {
+    let (server, _h) = server_with_mock(MockReportServiceImpl::new()).await;
+
+    let err = server
+        .create_report(Parameters(create_report_params()))
+        .await
+        .expect_err("expected error");
+
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+}
+
+#[tokio::test]
+async fn create_report_rejects_both_sources() {
+    let (server, _h) = server_with_mock(MockReportServiceImpl::new()).await;
+
+    let mut params = create_report_params();
+    params.report_template_id = Some("tmpl-1".into());
+    params.rule_ids = Some(vec!["rule-1".into()]);
+
+    let err = server
+        .create_report(Parameters(params))
+        .await
+        .expect_err("expected error");
+
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+}
+
+#[tokio::test]
+async fn create_report_rejects_multiple_rule_identifiers() {
+    let (server, _h) = server_with_mock(MockReportServiceImpl::new()).await;
+
+    let mut params = create_report_params();
+    params.rule_ids = Some(vec!["rule-1".into()]);
+    params.rule_client_keys = Some(vec!["ck-1".into()]);
+
+    let err = server
+        .create_report(Parameters(params))
+        .await
+        .expect_err("expected error");
+
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+}
+
+#[tokio::test]
+async fn update_report_happy_path() {
+    let mut mock = MockReportServiceImpl::new();
+    mock.expect_update_report()
+        .returning(|_| Ok(Response::new(UpdateReportResponse {})));
+    mock.expect_get_report().returning(|_| {
+        Ok(Response::new(GetReportResponse {
+            report: Some(Report {
+                report_id: "rep1".into(),
+                name: "after update".into(),
+                ..Default::default()
+            }),
+        }))
+    });
+
+    let (server, _h) = server_with_mock(mock).await;
+
+    let resp = server
+        .update_report(Parameters(UpdateReportParams {
+            report_id: "rep1".into(),
+            metadata: vec![],
+        }))
+        .await
+        .expect("update_report failed");
+
+    let report = structured_field(resp, "report");
+    assert_eq!(report["name"], "after update");
+}
+
+#[tokio::test]
+async fn update_report_rejects_empty_id() {
+    let (server, _h) = server_with_mock(MockReportServiceImpl::new()).await;
+
+    let err = server
+        .update_report(Parameters(UpdateReportParams {
+            report_id: String::new(),
+            metadata: vec![],
+        }))
+        .await
+        .expect_err("expected error");
+
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
 }

--- a/rust/crates/sift_mcp/src/tool/rules/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/rules/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     error::{self, from_anyhow},
     server::SiftMcpServer,
     service::rules::RuleUpdate,
-    tool::common::ListParams,
+    tool::common::{ListParams, url_clause, with_urls},
 };
 
 #[cfg(test)]
@@ -60,7 +60,9 @@ impl SiftMcpServer {
                 `client_key`, `name`, `description`, `is_enabled`, `is_external`, `is_archived`,
                 `archived_date`, `is_live_evaluation_enabled`, `organization_id`, `conditions`, `rule_version`,
                 `current_version_id`, `asset_configuration` (asset_ids + tag_ids), `contextual_channels`,
-                `metadata`, and timestamps.
+                `metadata`, and timestamps, plus an added `url` field with the rule's Sift web link
+                (`<host>/rules/<rule_id>`). `url` is omitted when the host can't be derived. Surface these links
+                to the user when presenting rules.
 
             Parameters:
               - `filter`: CEL expression. Pass an empty string to list everything. Filterable fields:
@@ -93,14 +95,17 @@ impl SiftMcpServer {
             limit,
         }) = params;
 
-        let out = self
+        let rules = self
             .rule_service
             .list_rules(filter, order_by, limit)
             .await
-            .map(|rules| serde_json::json!({ "rules": rules }))
             .map_err(from_anyhow)?;
 
-        Ok(CallToolResult::structured(out))
+        let rules = with_urls(&rules, |r| self.url_service.build_rule_url(&r.rule_id).ok())?;
+
+        Ok(CallToolResult::structured(
+            serde_json::json!({ "rules": rules }),
+        ))
     }
 
     #[tool(
@@ -110,8 +115,10 @@ impl SiftMcpServer {
             filtered by a CEL expression.
 
             Output:
-              - `{ \"rule_versions\": [RuleVersion, ...] }`. Each item includes `rule_id`, `rule_version_id`,
-                `version`, `created_date`, `created_by_user_id`, `version_notes`, and `generated_change_message`.
+              - `{ \"rule_versions\": [RuleVersion, ...], \"rule_url\": string|null, \"next_step\": string }`. Each
+                item includes `rule_id`, `rule_version_id`, `version`, `created_date`, `created_by_user_id`,
+                `version_notes`, and `generated_change_message`. `rule_url` is the rule's Sift web link, or null
+                when the host can't be derived.
 
             Parameters:
               - `rule_id`: required. The rule whose versions to list.
@@ -141,14 +148,27 @@ impl SiftMcpServer {
             limit,
         }) = params;
 
-        let out = self
+        let rule_url = rule_url_for(self, &rule_id);
+
+        let rule_versions = self
             .rule_service
             .list_rule_versions(rule_id, filter.unwrap_or_default(), limit)
             .await
-            .map(|rule_versions| serde_json::json!({ "rule_versions": rule_versions }))
             .map_err(from_anyhow)?;
 
-        Ok(CallToolResult::structured(out))
+        let next_step = format!(
+            "Listed {} rule versions.{} Surface the version history to the user.",
+            rule_versions.len(),
+            url_clause(rule_url.as_deref()),
+        );
+
+        let mut result = CallToolResult::structured(serde_json::json!({
+            "rule_versions": rule_versions,
+            "rule_url": rule_url,
+            "next_step": next_step,
+        }));
+        result.content = vec![Content::text(next_step)];
+        Ok(result)
     }
 
     #[tool(
@@ -157,8 +177,9 @@ impl SiftMcpServer {
             Create a Sift rule from a full rule definition supplied as a JSON string. This is a WRITE.
 
             Output:
-              - `{ \"rule_id\": \"<id>\", \"next_step\": \"...\" }`. `rule_id` is the server-assigned id of the
-                new rule.
+              - `{ \"rule_id\": \"<id>\", \"rule_url\": string|null, \"next_step\": \"...\" }`. `rule_id` is the
+                server-assigned id of the new rule; `rule_url` is its Sift web link (`<host>/rules/<rule_id>`), or
+                null when the host can't be derived.
 
             Parameters:
               - `rule_json`: a JSON object matching `protos/sift/rules/v1/rules.proto::UpdateRuleRequest`. Use the
@@ -196,14 +217,17 @@ impl SiftMcpServer {
             .await
             .map_err(from_anyhow)?;
 
+        let rule_url = self.url_service.build_rule_url(&rule_id).ok();
         let next_step = format!(
-            "Created rule with id `{rule_id}`. Tell the user the new rule id. If they haven't \
+            "Created rule with id `{rule_id}`.{} Tell the user the new rule id. If they haven't \
              indicated a next step, offer to confirm it with `list_rules` \
-             (filter `rule_id == \"{rule_id}\"`)."
+             (filter `rule_id == \"{rule_id}\"`).",
+            url_clause(rule_url.as_deref()),
         );
 
         let mut result = CallToolResult::structured(serde_json::json!({
             "rule_id": rule_id,
+            "rule_url": rule_url,
             "next_step": next_step,
         }));
         result.content = vec![Content::text(next_step)];
@@ -219,7 +243,8 @@ impl SiftMcpServer {
             want to modify.
 
             Output:
-              - `{ \"rule_id\": \"<id>\", \"next_step\": \"...\" }`.
+              - `{ \"rule_id\": \"<id>\", \"rule_url\": string|null, \"next_step\": \"...\" }`. `rule_url` is the
+                rule's Sift web link, or null when the host can't be derived.
 
             Parameters:
               - `rule_id`: required. The rule to update.
@@ -294,14 +319,17 @@ impl SiftMcpServer {
             .await
             .map_err(from_anyhow)?;
 
+        let rule_url = self.url_service.build_rule_url(&rule_id).ok();
         let next_step = format!(
-            "Updated rule `{rule_id}`. Tell the user the update succeeded. If they haven't \
+            "Updated rule `{rule_id}`.{} Tell the user the update succeeded. If they haven't \
              indicated a next step, offer to confirm it with `list_rules` \
-             (filter `rule_id == \"{rule_id}\"`)."
+             (filter `rule_id == \"{rule_id}\"`).",
+            url_clause(rule_url.as_deref()),
         );
 
         let mut result = CallToolResult::structured(serde_json::json!({
             "rule_id": rule_id,
+            "rule_url": rule_url,
             "next_step": next_step,
         }));
         result.content = vec![Content::text(next_step)];
@@ -314,7 +342,9 @@ impl SiftMcpServer {
             Archive a Sift rule so it no longer evaluates. This is a WRITE. Reversible with `unarchive_rule`.
 
             Output:
-              - `{ \"archived\": true, \"next_step\": \"...\" }`.
+              - `{ \"archived\": true, \"rule_url\": string|null, \"next_step\": \"...\" }`. `rule_url` is the
+                rule's Sift web link when targeted by `rule_id`; null when targeted by `client_key` or when the
+                host can't be derived.
 
             Parameters:
               - `rule_id`: optional. The id of the rule to archive.
@@ -339,17 +369,22 @@ impl SiftMcpServer {
 
         let (rule_id, client_key) = rule_identifier(rule_id, client_key)?;
 
+        let rule_url = rule_url_for(self, &rule_id);
+
         self.rule_service
             .archive_rule(rule_id, client_key)
             .await
             .map_err(from_anyhow)?;
 
-        let next_step = "Rule archived. Tell the user it is archived and will no longer evaluate, \
-             and that `unarchive_rule` restores it."
-            .to_string();
+        let next_step = format!(
+            "Rule archived.{} Tell the user it is archived and will no longer evaluate, \
+             and that `unarchive_rule` restores it.",
+            url_clause(rule_url.as_deref()),
+        );
 
         let mut result = CallToolResult::structured(serde_json::json!({
             "archived": true,
+            "rule_url": rule_url,
             "next_step": next_step,
         }));
         result.content = vec![Content::text(next_step)];
@@ -362,7 +397,9 @@ impl SiftMcpServer {
             Restore a previously archived Sift rule so it evaluates again. This is a WRITE.
 
             Output:
-              - `{ \"unarchived\": true, \"next_step\": \"...\" }`.
+              - `{ \"unarchived\": true, \"rule_url\": string|null, \"next_step\": \"...\" }`. `rule_url` is the
+                rule's Sift web link when targeted by `rule_id`; null when targeted by `client_key` or when the
+                host can't be derived.
 
             Parameters:
               - `rule_id`: optional. The id of the rule to unarchive.
@@ -386,21 +423,36 @@ impl SiftMcpServer {
 
         let (rule_id, client_key) = rule_identifier(rule_id, client_key)?;
 
+        let rule_url = rule_url_for(self, &rule_id);
+
         self.rule_service
             .unarchive_rule(rule_id, client_key)
             .await
             .map_err(from_anyhow)?;
 
-        let next_step =
-            "Rule unarchived. Tell the user it is restored and will evaluate again.".to_string();
+        let next_step = format!(
+            "Rule unarchived.{} Tell the user it is restored and will evaluate again.",
+            url_clause(rule_url.as_deref()),
+        );
 
         let mut result = CallToolResult::structured(serde_json::json!({
             "unarchived": true,
+            "rule_url": rule_url,
             "next_step": next_step,
         }));
         result.content = vec![Content::text(next_step)];
         Ok(result)
     }
+}
+
+/// Build the web URL for a rule when its `rule_id` is known. Returns `None` when
+/// `rule_id` is empty (the caller targeted the rule by `client_key`, so there is
+/// no id to link) or when the host can't be derived.
+fn rule_url_for(server: &SiftMcpServer, rule_id: &str) -> Option<String> {
+    if rule_id.is_empty() {
+        return None;
+    }
+    server.url_service.build_rule_url(rule_id).ok()
 }
 
 /// Deserialize a rule definition JSON string into an `UpdateRuleRequest`,

--- a/rust/crates/sift_mcp/src/tool/runs/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/runs/mod.rs
@@ -1,13 +1,34 @@
-use rmcp::{handler::server::wrapper::Parameters, model::CallToolResult, tool, tool_router};
+use rmcp::{
+    ErrorData,
+    handler::server::wrapper::Parameters,
+    model::{CallToolResult, Content},
+    schemars::{self, JsonSchema},
+    tool, tool_router,
+};
+use serde::Deserialize;
+use sift_rs::metadata::v1::MetadataValue;
 
 use crate::{
     error::{self, from_anyhow},
     server::SiftMcpServer,
-    tool::common::ListParams,
+    tool::common::{ListParams, MetadataEntry, url_clause, with_urls},
 };
 
 #[cfg(test)]
 mod test;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UpdateRunParams {
+    run_id: String,
+    name: Option<String>,
+    description: Option<String>,
+    start_time_unix_nanos: Option<i64>,
+    stop_time_unix_nanos: Option<i64>,
+    is_pinned: Option<bool>,
+    client_key: Option<String>,
+    tags: Option<Vec<String>>,
+    metadata: Option<Vec<MetadataEntry>>,
+}
 
 #[tool_router(router = runs_router, vis = "pub(crate)")]
 impl SiftMcpServer {
@@ -19,7 +40,8 @@ impl SiftMcpServer {
             Output:
               - `{ \"runs\": [Run, ...] }`. Each item is the full Sift `Run` shape including `run_id`, `name`,
                 `asset_id`/`asset_name`, `client_key`, `start_time`, `stop_time`, duration, annotation state, tags,
-                and metadata.
+                and metadata, plus an added `url` field with the run's Sift web link (`<host>/run/<run_id>`). `url`
+                is omitted when the host can't be derived. Surface these links to the user when presenting runs.
 
             Parameters:
               - `filter`: CEL expression. Pass an empty string to list everything. Filterable fields:
@@ -56,13 +78,123 @@ impl SiftMcpServer {
             limit,
         }) = params;
 
-        let out = self
+        let runs = self
             .run_service
             .list_runs(filter, order_by, limit)
             .await
-            .map(|runs| serde_json::json!({ "runs": runs }))
             .map_err(from_anyhow)?;
 
-        Ok(CallToolResult::structured(out))
+        let runs = with_urls(&runs, |r| self.url_service.build_run_url(&r.run_id).ok())?;
+
+        Ok(CallToolResult::structured(
+            serde_json::json!({ "runs": runs }),
+        ))
+    }
+
+    #[tool(
+        name = "update_run",
+        description = "
+            Update specific fields of an existing run, identified by `run_id`. This is a WRITE. Only the fields you
+            set are changed; everything else on the run is preserved. Wraps `runs/v2 UpdateRun`.
+
+            Output:
+              - `{ \"run\": Run, \"run_url\": string|null, \"next_step\": string }`. The returned `Run` is the
+                post-update state from the server; `run_url` is its Sift web link (`<host>/run/<run_id>`), or null
+                when the host can't be derived.
+
+            Parameters:
+              - `run_id`: required; the id of the run to update.
+              - `name`: optional new name.
+              - `description`: optional new description.
+              - `start_time_unix_nanos` / `stop_time_unix_nanos`: optional new bounds in Unix nanoseconds.
+              - `is_pinned`: optional; pin or unpin the run.
+              - `client_key`: optional caller-defined key. Can be set only ONCE — a second attempt errors.
+              - `tags`: optional; REPLACES the full tag list. Pass `[]` to clear all tags.
+              - `metadata`: optional; REPLACES the full metadata list. Each entry is
+                `{ \"name\": \"<key>\", \"value\": <scalar> }`. Pass `[]` to clear.
+
+              At least one updatable field besides `run_id` must be set; otherwise the tool returns `INVALID_PARAMS`.
+
+            Errors:
+              - `INVALID_PARAMS` if `run_id` is empty or no updatable field is provided.
+              - `RESOURCE_NOT_FOUND` if no run matches `run_id`.
+              - `INTERNAL_ERROR` for upstream gRPC failures (e.g. re-setting an already-set `client_key`).
+
+            Guidance:
+              - This is a write with REPLACE semantics for `tags`/`metadata`. CONFIRM the full proposed values with
+                the user before invoking; for appends, read the run via `list_runs` and send the union.
+              - Note: `start_time` may be overwritten automatically if data is later ingested for this run.
+        ",
+        annotations(title = "runs_router/update_run", read_only_hint = false)
+    )]
+    pub async fn update_run(&self, params: Parameters<UpdateRunParams>) -> error::McpResult {
+        let Parameters(UpdateRunParams {
+            run_id,
+            name,
+            description,
+            start_time_unix_nanos,
+            stop_time_unix_nanos,
+            is_pinned,
+            client_key,
+            tags,
+            metadata,
+        }) = params;
+
+        if run_id.is_empty() {
+            return Err(ErrorData::invalid_params(
+                "`run_id` must not be empty",
+                None,
+            ));
+        }
+
+        let has_update = name.is_some()
+            || description.is_some()
+            || start_time_unix_nanos.is_some()
+            || stop_time_unix_nanos.is_some()
+            || is_pinned.is_some()
+            || client_key.is_some()
+            || tags.is_some()
+            || metadata.is_some();
+        if !has_update {
+            return Err(ErrorData::invalid_params(
+                "at least one updatable field besides `run_id` must be provided",
+                None,
+            ));
+        }
+
+        let metadata = metadata.map(|m| m.into_iter().map(MetadataValue::from).collect::<Vec<_>>());
+
+        let run = self
+            .run_service
+            .update_run(
+                run_id,
+                name,
+                description,
+                start_time_unix_nanos,
+                stop_time_unix_nanos,
+                is_pinned,
+                client_key,
+                tags,
+                metadata,
+            )
+            .await
+            .map_err(from_anyhow)?;
+
+        let run_url = self.url_service.build_run_url(&run.run_id).ok();
+        let next_step = format!(
+            "Updated run `{}` ({}).{} Surface the new state to the user and confirm the change matches their \
+             intent. Remember: tags and metadata are REPLACE operations.",
+            run.name,
+            run.run_id,
+            url_clause(run_url.as_deref()),
+        );
+
+        let mut result = CallToolResult::structured(serde_json::json!({
+            "run": run,
+            "run_url": run_url,
+            "next_step": next_step,
+        }));
+        result.content = vec![Content::text(next_step)];
+        Ok(result)
     }
 }

--- a/rust/crates/sift_mcp/src/tool/runs/test.rs
+++ b/rust/crates/sift_mcp/src/tool/runs/test.rs
@@ -1,13 +1,30 @@
-use rmcp::model::ErrorCode;
-use sift_rs::runs::v2::{ListRunsResponse, Run, run_service_server::RunServiceServer};
+use rmcp::{handler::server::wrapper::Parameters, model::ErrorCode};
+use sift_rs::runs::v2::{
+    ListRunsResponse, Run, UpdateRunResponse, run_service_server::RunServiceServer,
+};
 use sift_test_util::{grpc::memory_sift_channel, mock::runs::v2::MockRunServiceImpl};
 use tokio::task::JoinHandle;
 use tonic::{Response, Status, transport::Server};
 
+use super::UpdateRunParams;
 use crate::{
     server::SiftMcpServer,
     tool::common::test_support::{list_params, structured_field},
 };
+
+fn update_run_params(run_id: &str) -> UpdateRunParams {
+    UpdateRunParams {
+        run_id: run_id.into(),
+        name: None,
+        description: None,
+        start_time_unix_nanos: None,
+        stop_time_unix_nanos: None,
+        is_pinned: None,
+        client_key: None,
+        tags: None,
+        metadata: None,
+    }
+}
 
 async fn server_with_mock(mock: MockRunServiceImpl) -> (SiftMcpServer, JoinHandle<()>) {
     let (client, server) = tokio::io::duplex(1024);
@@ -54,6 +71,7 @@ async fn list_runs_returns_single_page() {
     let runs = structured_field(resp, "runs");
     assert_eq!(runs.as_array().unwrap().len(), 1);
     assert_eq!(runs[0]["runId"], "r1");
+    assert_eq!(runs[0]["url"], "https://app.test.local/run/r1");
 }
 
 #[tokio::test]
@@ -175,4 +193,57 @@ async fn list_runs_propagates_grpc_error() {
 
     assert_eq!(err.code, ErrorCode::RESOURCE_NOT_FOUND);
     assert!(err.message.contains("no such run"));
+}
+
+#[tokio::test]
+async fn update_run_happy_path_surfaces_url() {
+    let mut run_mock = MockRunServiceImpl::new();
+    run_mock.expect_update_run().returning(|_| {
+        Ok(Response::new(UpdateRunResponse {
+            run: Some(Run {
+                run_id: "r1".into(),
+                name: "renamed".into(),
+                ..Default::default()
+            }),
+        }))
+    });
+
+    let (server, _h) = server_with_mock(run_mock).await;
+
+    let mut params = update_run_params("r1");
+    params.name = Some("renamed".into());
+
+    let resp = server
+        .update_run(Parameters(params))
+        .await
+        .expect("update_run failed");
+
+    let run_url = structured_field(resp.clone(), "run_url");
+    assert_eq!(run_url, "https://app.test.local/run/r1");
+    let run = structured_field(resp, "run");
+    assert_eq!(run["name"], "renamed");
+}
+
+#[tokio::test]
+async fn update_run_rejects_empty_id() {
+    let (server, _h) = server_with_mock(MockRunServiceImpl::new()).await;
+
+    let err = server
+        .update_run(Parameters(update_run_params("")))
+        .await
+        .expect_err("expected error");
+
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+}
+
+#[tokio::test]
+async fn update_run_rejects_no_fields() {
+    let (server, _h) = server_with_mock(MockRunServiceImpl::new()).await;
+
+    let err = server
+        .update_run(Parameters(update_run_params("r1")))
+        .await
+        .expect_err("expected error");
+
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
 }

--- a/rust/crates/sift_test_util/src/mock/annotations/mod.rs
+++ b/rust/crates/sift_test_util/src/mock/annotations/mod.rs
@@ -1,0 +1,1 @@
+pub mod v1;

--- a/rust/crates/sift_test_util/src/mock/annotations/v1.rs
+++ b/rust/crates/sift_test_util/src/mock/annotations/v1.rs
@@ -1,0 +1,90 @@
+use async_trait::async_trait;
+use mockall::mock;
+use sift_rs::annotations::v1::{
+    ArchiveAnnotationRequest, ArchiveAnnotationResponse, BatchArchiveAnnotationsRequest,
+    BatchArchiveAnnotationsResponse, BatchDeleteAnnotationsRequest, BatchDeleteAnnotationsResponse,
+    BatchUnarchiveAnnotationsRequest, BatchUnarchiveAnnotationsResponse, CreateAnnotationRequest,
+    CreateAnnotationResponse, DeleteAnnotationRequest, DeleteAnnotationResponse,
+    GetAnnotationRequest, GetAnnotationResponse, ListAnnotationsRequest, ListAnnotationsResponse,
+    UnarchiveAnnotationRequest, UnarchiveAnnotationResponse, UpdateAnnotationRequest,
+    UpdateAnnotationResponse, annotation_service_server::AnnotationService,
+};
+use tonic::{Request, Response, Status};
+
+mock! {
+    pub AnnotationServiceImpl {}
+
+    #[async_trait]
+    impl AnnotationService for AnnotationServiceImpl {
+        async fn create_annotation(
+            &self,
+            request: Request<CreateAnnotationRequest>,
+        ) -> std::result::Result<
+            Response<CreateAnnotationResponse>,
+            Status,
+        >;
+        async fn delete_annotation(
+            &self,
+            request: Request<DeleteAnnotationRequest>,
+        ) -> std::result::Result<
+            Response<DeleteAnnotationResponse>,
+            Status,
+        >;
+        async fn archive_annotation(
+            &self,
+            request: Request<ArchiveAnnotationRequest>,
+        ) -> std::result::Result<
+            Response<ArchiveAnnotationResponse>,
+            Status,
+        >;
+        async fn unarchive_annotation(
+            &self,
+            request: Request<UnarchiveAnnotationRequest>,
+        ) -> std::result::Result<
+            Response<UnarchiveAnnotationResponse>,
+            Status,
+        >;
+        async fn batch_delete_annotations(
+            &self,
+            request: Request<BatchDeleteAnnotationsRequest>,
+        ) -> std::result::Result<
+            Response<BatchDeleteAnnotationsResponse>,
+            Status,
+        >;
+        async fn batch_archive_annotations(
+            &self,
+            request: Request<BatchArchiveAnnotationsRequest>,
+        ) -> std::result::Result<
+            Response<BatchArchiveAnnotationsResponse>,
+            Status,
+        >;
+        async fn batch_unarchive_annotations(
+            &self,
+            request: Request<BatchUnarchiveAnnotationsRequest>,
+        ) -> std::result::Result<
+            Response<BatchUnarchiveAnnotationsResponse>,
+            Status,
+        >;
+        async fn list_annotations(
+            &self,
+            request: Request<ListAnnotationsRequest>,
+        ) -> std::result::Result<
+            Response<ListAnnotationsResponse>,
+            Status,
+        >;
+        async fn get_annotation(
+            &self,
+            request: Request<GetAnnotationRequest>,
+        ) -> std::result::Result<
+            Response<GetAnnotationResponse>,
+            Status,
+        >;
+        async fn update_annotation(
+            &self,
+            request: Request<UpdateAnnotationRequest>,
+        ) -> std::result::Result<
+            Response<UpdateAnnotationResponse>,
+            Status,
+        >;
+    }
+}

--- a/rust/crates/sift_test_util/src/mock/mod.rs
+++ b/rust/crates/sift_test_util/src/mock/mod.rs
@@ -1,3 +1,4 @@
+pub mod annotations;
 pub mod assets;
 pub mod channels;
 pub mod data;


### PR DESCRIPTION
## Changes

This PR fills in the gap for the following resources in MCP:
- Runs
- Reports
- Annotations
- Rules

This PR also makes is such that every resource comes down with a clickable URL back to Sift.

## Verification

- Manual testing
- Unit testing