### PR TITLE
rust(feat): return url after import

### DIFF
--- a/rust/crates/sift_cli/Cargo.toml
+++ b/rust/crates/sift_cli/Cargo.toml
@@ -32,6 +32,7 @@ flate2 = { workspace = true }
 indicatif = { workspace = true }
 parquet = { workspace = true }
 pbjson-types = { workspace = true }
+percent-encoding = { workspace = true }
 reqwest = { workspace = true }
 serde_json = { workspace = true }
 sift_mcp.workspace = true

--- a/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
+++ b/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
@@ -83,6 +83,16 @@ apply per subcommand invocation:
    subsequent `sift-cli` call in this session. Do not silently default
    when several profiles exist — the user may have prod and staging side
    by side and writing to the wrong one is a real foot-gun.
+
+   **Never switch profiles to recover from a failure.** Once a profile is
+   chosen for the session, stick with it. If a command fails — bad
+   credentials, host unreachable, the default profile doesn't resolve,
+   gRPC errors, anything — surface the failure and ask the user before
+   moving to a different profile. Do not retry the same command against
+   another profile to "make it work"; that risks writing the user's data
+   into the wrong environment. The same applies in reverse: if the user
+   has not named a profile and only one exists but it fails, stop and
+   report — don't probe other profiles.
 2. **Discover the subcommand.** Before constructing the command for a
    subcommand you have not used recently, run `sift-cli <subcommand>
    --help` (or `sift-cli --help` for the top level). The clap-generated

--- a/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
+++ b/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
@@ -127,16 +127,15 @@ apply per subcommand invocation:
    line. Without it you cannot confirm the data actually landed. Relay
    the final stdout line to the user verbatim.
 7. **Surface the Explore link from import output.** `sift-cli import`
-   prints a tip line after a successful upload. It is either
-   `View in Sift: <URL>` (when the profile sets `app_uri`, or the API
-   host is a recognized Sift SaaS environment) or a fallback note of the
-   form `Run `sift-cli config update --app-uri <SIFT_WEB_URL>` so future
-   imports include a Sift Explore link.` (custom or on-prem deployments
-   without `app_uri` set). When a URL line appears, surface that URL to
-   the user as plain text, in full. Do not wrap it in a markdown link,
-   do not summarize it away — the URL is part of the deliverable, and
-   not every IDE renders markdown. When the fallback note appears, relay
-   it verbatim and do not invent a URL.
+   prints a `View in Sift: <URL>` tip line after a successful upload when
+   the URL can be resolved — either because the profile sets `app_uri`
+   or because the API host is a recognized Sift environment (prod, gov,
+   or Sift's dev SaaS). Surface that URL to the user as plain text, in
+   full. Do not wrap it in a markdown link, do not summarize it away —
+   the URL is part of the deliverable, and not every IDE renders
+   markdown. Otherwise the CLI prints a fallback note telling the user
+   how to configure `app_uri`; relay that note verbatim and do not
+   invent a URL.
 8. **On failure, read stderr and retry.** A non-zero exit usually means a
    bad flag combination or missing required argument; the CLI's stderr
    names the exact issue. Adjust the command and run again rather than

--- a/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
+++ b/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
@@ -114,7 +114,16 @@ apply per subcommand invocation:
    until the server-side import job finishes and emits a final status
    line. Without it you cannot confirm the data actually landed. Relay
    the final stdout line to the user verbatim.
-7. **On failure, read stderr and retry.** A non-zero exit usually means a
+7. **Surface the Explore link from import output.** When the user's
+   profile has `app_uri` set, `sift-cli import` emits an OSC 8 hyperlink
+   in stdout with the visible label `View in Sift`. The raw escape
+   sequence is `\x1b]8;;<URL>\x07View in Sift\x1b]8;;\x07` — extract the
+   URL between `]8;;` and the first `\x07` (or `ESC \`) and render it to
+   the user as a clickable markdown link, e.g. `[View in Sift](<URL>)`.
+   Do not summarize the link away; the URL is part of the deliverable.
+   If no link appears in stdout, the profile has no `app_uri` configured
+   — do not invent one.
+8. **On failure, read stderr and retry.** A non-zero exit usually means a
    bad flag combination or missing required argument; the CLI's stderr
    names the exact issue. Adjust the command and run again rather than
    treating the failure as terminal.

--- a/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
+++ b/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
@@ -126,13 +126,17 @@ apply per subcommand invocation:
    until the server-side import job finishes and emits a final status
    line. Without it you cannot confirm the data actually landed. Relay
    the final stdout line to the user verbatim.
-7. **Surface the Explore link from import output.** When the user's
-   profile has `app_uri` set, `sift-cli import` prints a line of the form
-   `View in Sift: <URL>` in stdout. Surface that URL to the user as plain
-   text, in full. Do not wrap it in a markdown link, do not summarize it
-   away — the URL is part of the deliverable, and not every IDE renders
-   markdown. If no `View in Sift:` line appears, the profile has no
-   `app_uri` configured — do not invent a URL.
+7. **Surface the Explore link from import output.** `sift-cli import`
+   prints a tip line after a successful upload. It is either
+   `View in Sift: <URL>` (when the profile sets `app_uri`, or the API
+   host is a recognized Sift SaaS environment) or a fallback note of the
+   form `Run `sift-cli config update --app-uri <SIFT_WEB_URL>` so future
+   imports include a Sift Explore link.` (custom or on-prem deployments
+   without `app_uri` set). When a URL line appears, surface that URL to
+   the user as plain text, in full. Do not wrap it in a markdown link,
+   do not summarize it away — the URL is part of the deliverable, and
+   not every IDE renders markdown. When the fallback note appears, relay
+   it verbatim and do not invent a URL.
 8. **On failure, read stderr and retry.** A non-zero exit usually means a
    bad flag combination or missing required argument; the CLI's stderr
    names the exact issue. Adjust the command and run again rather than

--- a/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
+++ b/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
@@ -21,7 +21,10 @@ to combine them when working with Sift.
    - `list_report_rule_summaries`: per-rule pass/fail/open breakdown for a report.
    - `get_data`: download channel data for an asset/run to a Parquet file.
    - `sql`: run SQL over one or more Parquet files (chain after `get_data`).
-   - `upload_dataset`: stream a Parquet dataset into Sift.
+   - `upload_dataset`: stream a Parquet dataset into Sift. Returns an
+     `explore_url` field when the user's profile has `app_uri` configured —
+     surface it inline as a clickable markdown link. If `explore_url` is null,
+     do not invent a link.
    - `update_asset`: replace an existing asset's tags and/or metadata (write —
      replace semantics, so read-modify-write when appending).
    - `update_run`: update a run's name, time bounds, pin state, tags, or metadata
@@ -33,7 +36,9 @@ to combine them when working with Sift.
    - `create_report`, `update_report`: manage reports (writes — confirm first).
    - `explore_url`: build a Sift Explore deep-link for an asset/run/channel
      selection, with an optional panel/chart pre-defined. Surface the URL
-     inline as a clickable link so the user can open the view.
+     inline as a clickable link so the user can open the view. Requires
+     `app_uri` configured in the user's `sift-cli` profile (or pass
+     `explore_host` per-call); fails with `INVALID_PARAMS` otherwise.
 2. **`sift-cli`** — the command-line tool. Key subcommands:
    - `import`: `csv`, `parquet flat-dataset`, `tdms`, `hdf5`, `backups`.
    - `export`: `run`, `asset` (to CSV and other formats).
@@ -121,7 +126,9 @@ the output is text or a new dataset — pull the source data locally with
 `get_data` (writes a Parquet file) and run `sql` over it. Chain
 `get_data` → `sql` for filtering, aggregation, or feature derivation. If the
 result should land back in Sift as a new dataset, follow with
-`upload_dataset`, and confirm the target asset/run with the user first.
+`upload_dataset`, and confirm the target asset/run with the user first. When
+`upload_dataset` returns an `explore_url`, render it inline as a clickable
+markdown link so the user can jump straight to the imported data.
 
 ## Visualizing in Sift Explore
 

--- a/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
+++ b/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
@@ -23,7 +23,8 @@ to combine them when working with Sift.
    - `sql`: run SQL over one or more Parquet files (chain after `get_data`).
    - `upload_dataset`: stream a Parquet dataset into Sift. Returns an
      `explore_url` field when the user's profile has `app_uri` configured —
-     surface it inline as a clickable markdown link. If `explore_url` is null,
+     surface it to the user as plain text, in full. Do not wrap it in a
+     markdown link; not every IDE renders markdown. If `explore_url` is null,
      do not invent a link.
    - `update_asset`: replace an existing asset's tags and/or metadata (write —
      replace semantics, so read-modify-write when appending).
@@ -35,10 +36,11 @@ to combine them when working with Sift.
      collections use replace semantics, so confirm the change first).
    - `create_report`, `update_report`: manage reports (writes — confirm first).
    - `explore_url`: build a Sift Explore deep-link for an asset/run/channel
-     selection, with an optional panel/chart pre-defined. Surface the URL
-     inline as a clickable link so the user can open the view. Requires
-     `app_uri` configured in the user's `sift-cli` profile (or pass
-     `explore_host` per-call); fails with `INVALID_PARAMS` otherwise.
+     selection, with an optional panel/chart pre-defined. Surface the URL to
+     the user as plain text, in full, so the user can open the view. Do not
+     wrap it in a markdown link. Requires `app_uri` configured in the user's
+     `sift-cli` profile (or pass `explore_host` per-call); fails with
+     `INVALID_PARAMS` otherwise.
 2. **`sift-cli`** — the command-line tool. Key subcommands:
    - `import`: `csv`, `parquet flat-dataset`, `tdms`, `hdf5`, `backups`.
    - `export`: `run`, `asset` (to CSV and other formats).
@@ -125,14 +127,12 @@ apply per subcommand invocation:
    line. Without it you cannot confirm the data actually landed. Relay
    the final stdout line to the user verbatim.
 7. **Surface the Explore link from import output.** When the user's
-   profile has `app_uri` set, `sift-cli import` emits an OSC 8 hyperlink
-   in stdout with the visible label `View in Sift`. The raw escape
-   sequence is `\x1b]8;;<URL>\x07View in Sift\x1b]8;;\x07` — extract the
-   URL between `]8;;` and the first `\x07` (or `ESC \`) and render it to
-   the user as a clickable markdown link, e.g. `[View in Sift](<URL>)`.
-   Do not summarize the link away; the URL is part of the deliverable.
-   If no link appears in stdout, the profile has no `app_uri` configured
-   — do not invent one.
+   profile has `app_uri` set, `sift-cli import` prints a line of the form
+   `View in Sift: <URL>` in stdout. Surface that URL to the user as plain
+   text, in full. Do not wrap it in a markdown link, do not summarize it
+   away — the URL is part of the deliverable, and not every IDE renders
+   markdown. If no `View in Sift:` line appears, the profile has no
+   `app_uri` configured — do not invent a URL.
 8. **On failure, read stderr and retry.** A non-zero exit usually means a
    bad flag combination or missing required argument; the CLI's stderr
    names the exact issue. Adjust the command and run again rather than
@@ -146,14 +146,16 @@ the output is text or a new dataset — pull the source data locally with
 `get_data` → `sql` for filtering, aggregation, or feature derivation. If the
 result should land back in Sift as a new dataset, follow with
 `upload_dataset`, and confirm the target asset/run with the user first. When
-`upload_dataset` returns an `explore_url`, render it inline as a clickable
-markdown link so the user can jump straight to the imported data.
+`upload_dataset` returns an `explore_url`, surface it to the user as plain
+text, in full, so they can jump straight to the imported data. Do not wrap it
+in a markdown link.
 
 ## Visualizing in Sift Explore
 
 When the user wants to see, view, graph, plot, or open data in Sift, build
-a link with `explore_url` and render the URL inline as a clickable markdown
-link. The URL is the deliverable — do not summarize it away. Pick the
+a link with `explore_url` and surface the URL to the user as plain text, in
+full. The URL is the deliverable — do not wrap it in a markdown link, do not
+summarize it away. Pick the
 `panel_type` that fits the request: `timeseries` (default), `histogram`,
 `table`, `fft`, `metrics`, `scatter-plot`, or `geo-map`. Prefix channels
 with `L1:` / `L2:` for multi-axis plots; with `x:` / `y:` / `color:` for

--- a/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
@@ -97,6 +97,16 @@ apply per subcommand invocation:
    subsequent `sift-cli` call in this session. Do not silently default
    when several profiles exist — the user may have prod and staging side
    by side and writing to the wrong one is a real foot-gun.
+
+   **Never switch profiles to recover from a failure.** Once a profile is
+   chosen for the session, stick with it. If a command fails — bad
+   credentials, host unreachable, the default profile doesn't resolve,
+   gRPC errors, anything — surface the failure and ask the user before
+   moving to a different profile. Do not retry the same command against
+   another profile to "make it work"; that risks writing the user's data
+   into the wrong environment. The same applies in reverse: if the user
+   has not named a profile and only one exists but it fails, stop and
+   report — don't probe other profiles.
 2. **Discover the subcommand.** Before constructing the command for a
    subcommand you have not used recently, run `sift-cli <subcommand>
    --help` (or `sift-cli --help` for the top level). The clap-generated

--- a/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
@@ -141,16 +141,15 @@ apply per subcommand invocation:
    line. Without it you cannot confirm the data actually landed. Relay
    the final stdout line to the user verbatim.
 7. **Surface the Explore link from import output.** `sift-cli import`
-   prints a tip line after a successful upload. It is either
-   `View in Sift: <URL>` (when the profile sets `app_uri`, or the API
-   host is a recognized Sift SaaS environment) or a fallback note of the
-   form `Run `sift-cli config update --app-uri <SIFT_WEB_URL>` so future
-   imports include a Sift Explore link.` (custom or on-prem deployments
-   without `app_uri` set). When a URL line appears, surface that URL to
-   the user as plain text, in full. Do not wrap it in a markdown link,
-   do not summarize it away — the URL is part of the deliverable, and
-   not every IDE renders markdown. When the fallback note appears, relay
-   it verbatim and do not invent a URL.
+   prints a `View in Sift: <URL>` tip line after a successful upload when
+   the URL can be resolved — either because the profile sets `app_uri`
+   or because the API host is a recognized Sift environment (prod, gov,
+   or Sift's dev SaaS). Surface that URL to the user as plain text, in
+   full. Do not wrap it in a markdown link, do not summarize it away —
+   the URL is part of the deliverable, and not every IDE renders
+   markdown. Otherwise the CLI prints a fallback note telling the user
+   how to configure `app_uri`; relay that note verbatim and do not
+   invent a URL.
 8. **On failure, read stderr and retry.** A non-zero exit usually means a
    bad flag combination or missing required argument; the CLI's stderr
    names the exact issue. Adjust the command and run again rather than

--- a/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
@@ -128,7 +128,16 @@ apply per subcommand invocation:
    until the server-side import job finishes and emits a final status
    line. Without it you cannot confirm the data actually landed. Relay
    the final stdout line to the user verbatim.
-7. **On failure, read stderr and retry.** A non-zero exit usually means a
+7. **Surface the Explore link from import output.** When the user's
+   profile has `app_uri` set, `sift-cli import` emits an OSC 8 hyperlink
+   in stdout with the visible label `View in Sift`. The raw escape
+   sequence is `\x1b]8;;<URL>\x07View in Sift\x1b]8;;\x07` — extract the
+   URL between `]8;;` and the first `\x07` (or `ESC \`) and render it to
+   the user as a clickable markdown link, e.g. `[View in Sift](<URL>)`.
+   Do not summarize the link away; the URL is part of the deliverable.
+   If no link appears in stdout, the profile has no `app_uri` configured
+   — do not invent one.
+8. **On failure, read stderr and retry.** A non-zero exit usually means a
    bad flag combination or missing required argument; the CLI's stderr
    names the exact issue. Adjust the command and run again rather than
    treating the failure as terminal.

--- a/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
@@ -140,13 +140,17 @@ apply per subcommand invocation:
    until the server-side import job finishes and emits a final status
    line. Without it you cannot confirm the data actually landed. Relay
    the final stdout line to the user verbatim.
-7. **Surface the Explore link from import output.** When the user's
-   profile has `app_uri` set, `sift-cli import` prints a line of the form
-   `View in Sift: <URL>` in stdout. Surface that URL to the user as plain
-   text, in full. Do not wrap it in a markdown link, do not summarize it
-   away — the URL is part of the deliverable, and not every IDE renders
-   markdown. If no `View in Sift:` line appears, the profile has no
-   `app_uri` configured — do not invent a URL.
+7. **Surface the Explore link from import output.** `sift-cli import`
+   prints a tip line after a successful upload. It is either
+   `View in Sift: <URL>` (when the profile sets `app_uri`, or the API
+   host is a recognized Sift SaaS environment) or a fallback note of the
+   form `Run `sift-cli config update --app-uri <SIFT_WEB_URL>` so future
+   imports include a Sift Explore link.` (custom or on-prem deployments
+   without `app_uri` set). When a URL line appears, surface that URL to
+   the user as plain text, in full. Do not wrap it in a markdown link,
+   do not summarize it away — the URL is part of the deliverable, and
+   not every IDE renders markdown. When the fallback note appears, relay
+   it verbatim and do not invent a URL.
 8. **On failure, read stderr and retry.** A non-zero exit usually means a
    bad flag combination or missing required argument; the CLI's stderr
    names the exact issue. Adjust the command and run again rather than

--- a/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
@@ -35,7 +35,10 @@ to combine them when working with Sift.
    - `list_report_rule_summaries`: per-rule pass/fail/open breakdown for a report.
    - `get_data`: download channel data for an asset/run to a Parquet file.
    - `sql`: run SQL over one or more Parquet files (chain after `get_data`).
-   - `upload_dataset`: stream a Parquet dataset into Sift.
+   - `upload_dataset`: stream a Parquet dataset into Sift. Returns an
+     `explore_url` field when the user's profile has `app_uri` configured —
+     surface it inline as a clickable markdown link. If `explore_url` is null,
+     do not invent a link.
    - `update_asset`: replace an existing asset's tags and/or metadata (write —
      replace semantics, so read-modify-write when appending).
    - `update_run`: update a run's name, time bounds, pin state, tags, or metadata
@@ -47,7 +50,9 @@ to combine them when working with Sift.
    - `create_report`, `update_report`: manage reports (writes — confirm first).
    - `explore_url`: build a Sift Explore deep-link for an asset/run/channel
      selection, with an optional panel/chart pre-defined. Surface the URL
-     inline as a clickable link so the user can open the view.
+     inline as a clickable link so the user can open the view. Requires
+     `app_uri` configured in the user's `sift-cli` profile (or pass
+     `explore_host` per-call); fails with `INVALID_PARAMS` otherwise.
 2. **`sift-cli`** — the command-line tool. Key subcommands:
    - `import`: `csv`, `parquet flat-dataset`, `tdms`, `hdf5`, `backups`.
    - `export`: `run`, `asset` (to CSV and other formats).
@@ -135,7 +140,9 @@ the output is text or a new dataset — pull the source data locally with
 `get_data` (writes a Parquet file) and run `sql` over it. Chain
 `get_data` → `sql` for filtering, aggregation, or feature derivation. If the
 result should land back in Sift as a new dataset, follow with
-`upload_dataset`, and confirm the target asset/run with the user first.
+`upload_dataset`, and confirm the target asset/run with the user first. When
+`upload_dataset` returns an `explore_url`, render it inline as a clickable
+markdown link so the user can jump straight to the imported data.
 
 ## Visualizing in Sift Explore
 

--- a/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
@@ -37,7 +37,8 @@ to combine them when working with Sift.
    - `sql`: run SQL over one or more Parquet files (chain after `get_data`).
    - `upload_dataset`: stream a Parquet dataset into Sift. Returns an
      `explore_url` field when the user's profile has `app_uri` configured —
-     surface it inline as a clickable markdown link. If `explore_url` is null,
+     surface it to the user as plain text, in full. Do not wrap it in a
+     markdown link; not every IDE renders markdown. If `explore_url` is null,
      do not invent a link.
    - `update_asset`: replace an existing asset's tags and/or metadata (write —
      replace semantics, so read-modify-write when appending).
@@ -49,10 +50,11 @@ to combine them when working with Sift.
      collections use replace semantics, so confirm the change first).
    - `create_report`, `update_report`: manage reports (writes — confirm first).
    - `explore_url`: build a Sift Explore deep-link for an asset/run/channel
-     selection, with an optional panel/chart pre-defined. Surface the URL
-     inline as a clickable link so the user can open the view. Requires
-     `app_uri` configured in the user's `sift-cli` profile (or pass
-     `explore_host` per-call); fails with `INVALID_PARAMS` otherwise.
+     selection, with an optional panel/chart pre-defined. Surface the URL to
+     the user as plain text, in full, so the user can open the view. Do not
+     wrap it in a markdown link. Requires `app_uri` configured in the user's
+     `sift-cli` profile (or pass `explore_host` per-call); fails with
+     `INVALID_PARAMS` otherwise.
 2. **`sift-cli`** — the command-line tool. Key subcommands:
    - `import`: `csv`, `parquet flat-dataset`, `tdms`, `hdf5`, `backups`.
    - `export`: `run`, `asset` (to CSV and other formats).
@@ -139,14 +141,12 @@ apply per subcommand invocation:
    line. Without it you cannot confirm the data actually landed. Relay
    the final stdout line to the user verbatim.
 7. **Surface the Explore link from import output.** When the user's
-   profile has `app_uri` set, `sift-cli import` emits an OSC 8 hyperlink
-   in stdout with the visible label `View in Sift`. The raw escape
-   sequence is `\x1b]8;;<URL>\x07View in Sift\x1b]8;;\x07` — extract the
-   URL between `]8;;` and the first `\x07` (or `ESC \`) and render it to
-   the user as a clickable markdown link, e.g. `[View in Sift](<URL>)`.
-   Do not summarize the link away; the URL is part of the deliverable.
-   If no link appears in stdout, the profile has no `app_uri` configured
-   — do not invent one.
+   profile has `app_uri` set, `sift-cli import` prints a line of the form
+   `View in Sift: <URL>` in stdout. Surface that URL to the user as plain
+   text, in full. Do not wrap it in a markdown link, do not summarize it
+   away — the URL is part of the deliverable, and not every IDE renders
+   markdown. If no `View in Sift:` line appears, the profile has no
+   `app_uri` configured — do not invent a URL.
 8. **On failure, read stderr and retry.** A non-zero exit usually means a
    bad flag combination or missing required argument; the CLI's stderr
    names the exact issue. Adjust the command and run again rather than
@@ -160,14 +160,16 @@ the output is text or a new dataset — pull the source data locally with
 `get_data` → `sql` for filtering, aggregation, or feature derivation. If the
 result should land back in Sift as a new dataset, follow with
 `upload_dataset`, and confirm the target asset/run with the user first. When
-`upload_dataset` returns an `explore_url`, render it inline as a clickable
-markdown link so the user can jump straight to the imported data.
+`upload_dataset` returns an `explore_url`, surface it to the user as plain
+text, in full, so they can jump straight to the imported data. Do not wrap it
+in a markdown link.
 
 ## Visualizing in Sift Explore
 
 When the user wants to see, view, graph, plot, or open data in Sift, build
-a link with `explore_url` and render the URL inline as a clickable markdown
-link. The URL is the deliverable — do not summarize it away. Pick the
+a link with `explore_url` and surface the URL to the user as plain text, in
+full. The URL is the deliverable — do not wrap it in a markdown link, do not
+summarize it away. Pick the
 `panel_type` that fits the request: `timeseries` (default), `histogram`,
 `table`, `fft`, `metrics`, `scatter-plot`, or `geo-map`. Prefix channels
 with `L1:` / `L2:` for multi-axis plots; with `x:` / `y:` / `color:` for

--- a/rust/crates/sift_cli/src/cli/mod.rs
+++ b/rust/crates/sift_cli/src/cli/mod.rs
@@ -247,10 +247,9 @@ pub struct ConfigUpdateArgs {
     #[arg(short = 'k', long)]
     pub api_key: Option<String>,
 
-    /// Sift web app URL — the address you visit in your browser when signed in
-    /// to Sift (e.g. https://app.siftstack.com). Used to build Sift Explore
-    /// links after imports. Optional for standard Sift hosts; required for
-    /// custom or on-prem deployments to render Explore links.
+    /// Sift web app URL (e.g. https://app.siftstack.com). Optional for standard
+    /// Sift hosts; required for custom or on-prem deployments to render Explore
+    /// links.
     #[arg(long)]
     pub app_uri: Option<String>,
 }

--- a/rust/crates/sift_cli/src/cli/mod.rs
+++ b/rust/crates/sift_cli/src/cli/mod.rs
@@ -246,6 +246,12 @@ pub struct ConfigUpdateArgs {
     /// API key used for authentication
     #[arg(short = 'k', long)]
     pub api_key: Option<String>,
+
+    /// Sift web app URL — the address you visit in your browser when signed in
+    /// to Sift (e.g. https://app.siftstack.com). Used to build clickable
+    /// Explore links after imports. Optional; links are omitted when unset.
+    #[arg(long)]
+    pub app_uri: Option<String>,
 }
 
 #[derive(clap::Args)]

--- a/rust/crates/sift_cli/src/cli/mod.rs
+++ b/rust/crates/sift_cli/src/cli/mod.rs
@@ -248,8 +248,9 @@ pub struct ConfigUpdateArgs {
     pub api_key: Option<String>,
 
     /// Sift web app URL — the address you visit in your browser when signed in
-    /// to Sift (e.g. https://app.siftstack.com). Used to build clickable
-    /// Explore links after imports. Optional; links are omitted when unset.
+    /// to Sift (e.g. https://app.siftstack.com). Used to build Sift Explore
+    /// links after imports. Optional for standard Sift hosts; required for
+    /// custom or on-prem deployments to render Explore links.
     #[arg(long)]
     pub app_uri: Option<String>,
 }

--- a/rust/crates/sift_cli/src/cmd/config/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/config/mod.rs
@@ -83,8 +83,9 @@ pub fn update(profile: Option<String>, args: ConfigUpdateArgs) -> Result<ExitCod
                 .prompt("  Provide your Sift API key: ")
                 .prompt(
                     "  Specify the Sift web app URL — the address you visit in your browser \
-                     when signed in to Sift (e.g. https://app.siftstack.com). Optional; \
-                     leave blank to disable clickable links: ",
+                     when signed in to Sift (e.g. https://app.siftstack.com). Optional for \
+                     standard Sift hosts; set it for custom or on-prem deployments to enable \
+                     Explore links: ",
                 )
                 .run()?
                 .try_into()

--- a/rust/crates/sift_cli/src/cmd/config/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/config/mod.rs
@@ -67,14 +67,25 @@ pub fn update(profile: Option<String>, args: ConfigUpdateArgs) -> Result<ExitCod
                 Output::new().line("Nothing to update.").print();
                 return Ok(ExitCode::SUCCESS);
             }
-            get_updated_config(profile, args.grpc_uri, args.rest_uri, args.api_key)?
+            get_updated_config(
+                profile,
+                args.grpc_uri,
+                args.rest_uri,
+                args.api_key,
+                args.app_uri,
+            )?
         } else {
-            let [prof, grpc, rest, key]: [Option<String>; 4] = PromptUser::new()
+            let [prof, grpc, rest, key, app]: [Option<String>; 5] = PromptUser::new()
                 .header("Any blank values will be ignored preserving the original.")
                 .prompt("  Specify the profile to configure (leave blank for default profile): ")
                 .prompt("  Specify the gRPC API base URL: ")
                 .prompt("  Specify the REST API base URL: ")
                 .prompt("  Provide your Sift API key: ")
+                .prompt(
+                    "  Specify the Sift web app URL — the address you visit in your browser \
+                     when signed in to Sift (e.g. https://app.siftstack.com). Optional; \
+                     leave blank to disable clickable links: ",
+                )
                 .run()?
                 .try_into()
                 .unwrap();
@@ -82,7 +93,7 @@ pub fn update(profile: Option<String>, args: ConfigUpdateArgs) -> Result<ExitCod
             if let Some(p) = prof.as_ref() {
                 target = p.clone();
             }
-            let updated = get_updated_config(prof, grpc, rest, key)?;
+            let updated = get_updated_config(prof, grpc, rest, key, app)?;
             let divider = "-".repeat(40);
 
             let [confirmation]: [Option<String>; 1] = PromptUser::new()
@@ -155,6 +166,7 @@ fn get_updated_config(
     grpc_uri: Option<String>,
     rest_uri: Option<String>,
     api_key: Option<String>,
+    app_uri: Option<String>,
 ) -> Result<String> {
     let path = get_config_file_path()?;
 
@@ -184,6 +196,9 @@ fn get_updated_config(
     if let Some(token) = api_key {
         target.insert(String::from("apikey"), Value::String(token));
     }
+    if let Some(uri) = app_uri {
+        target.insert(String::from("app_uri"), Value::String(uri));
+    }
 
     Ok(config_toml.to_string())
 }
@@ -205,9 +220,11 @@ fn is_update_empty(args: &ConfigUpdateArgs) -> bool {
         grpc_uri,
         rest_uri,
         api_key,
+        app_uri,
         ..
     } = args;
     grpc_uri.as_ref().is_none_or(|s| s.is_empty())
         && rest_uri.as_ref().is_none_or(|s| s.is_empty())
         && api_key.as_ref().is_none_or(|s| s.is_empty())
+        && app_uri.as_ref().is_none_or(|s| s.is_empty())
 }

--- a/rust/crates/sift_cli/src/cmd/config/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/config/tests.rs
@@ -6,34 +6,47 @@ mod test_is_update_empty {
         grpc_uri: Option<&str>,
         rest_uri: Option<&str>,
         api_key: Option<&str>,
+        app_uri: Option<&str>,
     ) -> ConfigUpdateArgs {
         ConfigUpdateArgs {
             interactive: false,
             grpc_uri: grpc_uri.map(String::from),
             rest_uri: rest_uri.map(String::from),
             api_key: api_key.map(String::from),
+            app_uri: app_uri.map(String::from),
         }
     }
 
     #[test]
     fn no_flags_is_empty() {
-        assert!(is_update_empty(&args(None, None, None)));
+        assert!(is_update_empty(&args(None, None, None, None)));
     }
 
     #[test]
     fn all_empty_strings_is_empty() {
-        assert!(is_update_empty(&args(Some(""), Some(""), Some(""))));
+        assert!(is_update_empty(&args(
+            Some(""),
+            Some(""),
+            Some(""),
+            Some("")
+        )));
     }
 
     #[test]
     fn any_single_flag_is_not_empty() {
-        assert!(!is_update_empty(&args(Some("g"), None, None)));
-        assert!(!is_update_empty(&args(None, Some("r"), None)));
-        assert!(!is_update_empty(&args(None, None, Some("k"))));
+        assert!(!is_update_empty(&args(Some("g"), None, None, None)));
+        assert!(!is_update_empty(&args(None, Some("r"), None, None)));
+        assert!(!is_update_empty(&args(None, None, Some("k"), None)));
+        assert!(!is_update_empty(&args(None, None, None, Some("a"))));
     }
 
     #[test]
     fn all_flags_set_is_not_empty() {
-        assert!(!is_update_empty(&args(Some("g"), Some("r"), Some("k"))));
+        assert!(!is_update_empty(&args(
+            Some("g"),
+            Some("r"),
+            Some("k"),
+            Some("a")
+        )));
     }
 }

--- a/rust/crates/sift_cli/src/cmd/import/csv.rs
+++ b/rust/crates/sift_cli/src/cmd/import/csv.rs
@@ -24,7 +24,7 @@ use crate::{
         Context,
         import::utils::{try_parse_bit_field_config, try_parse_enum_config},
     },
-    util::{api::create_grpc_channel, tty::Output},
+    util::{api::create_grpc_channel, explore_url::build_explore_url, tty::Output},
 };
 
 use super::{
@@ -76,22 +76,28 @@ pub async fn run(ctx: Context, args: ImportCsvArgs) -> Result<ExitCode> {
         .await
         .context("failed to upload CSV file")?;
 
+    let explore_url = build_explore_url(ctx.rest_uri.clone(), args.asset.clone(), args.run.clone());
+
     let location = args.run.as_ref().map_or_else(
         || format!("asset '{}'", args.asset.cyan()),
         |r| format!("run '{}'", r.clone().cyan()),
     );
 
     if !args.wait {
-        Output::new()
+        let mut output = Output::new();
+        output
             .line(format!("{} file for processing", "Uploaded".green()))
             .tip(format!(
                 "Once processing is complete the data will be available on the {location}."
-            ))
-            .print();
+            ));
+        if let Some(url) = &explore_url {
+            output.tip(format!("View in Sift: {url}"));
+        }
+        output.print();
 
         return Ok(ExitCode::SUCCESS);
     }
-    wait_for_job_completion(grpc_channel, job_id, location).await
+    wait_for_job_completion(grpc_channel, job_id, location, explore_url).await
 }
 
 fn create_data_import_request<R: io::Read>(

--- a/rust/crates/sift_cli/src/cmd/import/csv.rs
+++ b/rust/crates/sift_cli/src/cmd/import/csv.rs
@@ -24,7 +24,11 @@ use crate::{
         Context,
         import::utils::{try_parse_bit_field_config, try_parse_enum_config},
     },
-    util::{api::create_grpc_channel, explore_url::build_explore_url, tty::Output},
+    util::{
+        api::create_grpc_channel,
+        explore_url::build_explore_url,
+        tty::{Output, hyperlink},
+    },
 };
 
 use super::{
@@ -76,7 +80,7 @@ pub async fn run(ctx: Context, args: ImportCsvArgs) -> Result<ExitCode> {
         .await
         .context("failed to upload CSV file")?;
 
-    let explore_url = build_explore_url(ctx.rest_uri.clone(), args.asset.clone(), args.run.clone());
+    let explore_url = build_explore_url(ctx.app_uri.as_deref(), &args.asset, args.run.as_deref());
 
     let location = args.run.as_ref().map_or_else(
         || format!("asset '{}'", args.asset.cyan()),
@@ -84,16 +88,15 @@ pub async fn run(ctx: Context, args: ImportCsvArgs) -> Result<ExitCode> {
     );
 
     if !args.wait {
-        let mut output = Output::new();
-        output
-            .line(format!("{} file for processing", "Uploaded".green()))
-            .tip(format!(
-                "Once processing is complete the data will be available on the {location}."
-            ));
+        let mut tip_text =
+            format!("Once processing is complete the data will be available on the {location}.");
         if let Some(url) = &explore_url {
-            output.tip(format!("View in Sift: {url}"));
+            tip_text.push_str(&format!("\n{}", hyperlink(url, "View in Sift")));
         }
-        output.print();
+        Output::new()
+            .line(format!("{} file for processing", "Uploaded".green()))
+            .tip(tip_text)
+            .print();
 
         return Ok(ExitCode::SUCCESS);
     }

--- a/rust/crates/sift_cli/src/cmd/import/csv.rs
+++ b/rust/crates/sift_cli/src/cmd/import/csv.rs
@@ -26,7 +26,7 @@ use crate::{
     },
     util::{
         api::create_grpc_channel,
-        explore_url::build_explore_url,
+        explore_url::{build_explore_url, pending_import_tip},
         tty::Output,
     },
 };
@@ -88,14 +88,9 @@ pub async fn run(ctx: Context, args: ImportCsvArgs) -> Result<ExitCode> {
     );
 
     if !args.wait {
-        let mut tip_text =
-            format!("Once processing is complete the data will be available on the {location}.");
-        if let Some(url) = &explore_url {
-            tip_text.push_str(&format!("\nView in Sift: {url}"));
-        }
         Output::new()
             .line(format!("{} file for processing", "Uploaded".green()))
-            .tip(tip_text)
+            .tip(pending_import_tip(&location, explore_url.as_deref()))
             .print();
 
         return Ok(ExitCode::SUCCESS);

--- a/rust/crates/sift_cli/src/cmd/import/csv.rs
+++ b/rust/crates/sift_cli/src/cmd/import/csv.rs
@@ -7,7 +7,6 @@ use std::{
 
 use anyhow::{Context as AnyhowContext, Result, anyhow};
 use chrono::DateTime;
-use crossterm::style::Stylize;
 use pbjson_types::Timestamp;
 use sift_rs::{
     common::r#type::v1::{ChannelConfig, ChannelDataType},
@@ -24,17 +23,12 @@ use crate::{
         Context,
         import::utils::{try_parse_bit_field_config, try_parse_enum_config},
     },
-    util::{
-        api::create_grpc_channel,
-        explore_url::{build_explore_url, pending_import_tip},
-        tty::Output,
-    },
+    util::api::create_grpc_channel,
 };
 
 use super::{
-    preview_import_config,
+    finish_import, preview_import_config,
     utils::{upload_gzipped_file, validate_time_format},
-    wait_for_job_completion,
 };
 
 pub async fn run(ctx: Context, args: ImportCsvArgs) -> Result<ExitCode> {
@@ -80,22 +74,16 @@ pub async fn run(ctx: Context, args: ImportCsvArgs) -> Result<ExitCode> {
         .await
         .context("failed to upload CSV file")?;
 
-    let explore_url = build_explore_url(ctx.app_uri.as_deref(), &args.asset, args.run.as_deref());
-
-    let location = args.run.as_ref().map_or_else(
-        || format!("asset '{}'", args.asset.cyan()),
-        |r| format!("run '{}'", r.clone().cyan()),
-    );
-
-    if !args.wait {
-        Output::new()
-            .line(format!("{} file for processing", "Uploaded".green()))
-            .tip(pending_import_tip(&location, explore_url.as_deref()))
-            .print();
-
-        return Ok(ExitCode::SUCCESS);
-    }
-    wait_for_job_completion(grpc_channel, job_id, location, explore_url).await
+    finish_import(
+        &ctx,
+        grpc_channel,
+        job_id,
+        &args.asset,
+        args.run.as_deref(),
+        None,
+        args.wait,
+    )
+    .await
 }
 
 fn create_data_import_request<R: io::Read>(

--- a/rust/crates/sift_cli/src/cmd/import/csv.rs
+++ b/rust/crates/sift_cli/src/cmd/import/csv.rs
@@ -27,7 +27,7 @@ use crate::{
     util::{
         api::create_grpc_channel,
         explore_url::build_explore_url,
-        tty::{Output, hyperlink},
+        tty::Output,
     },
 };
 
@@ -91,7 +91,7 @@ pub async fn run(ctx: Context, args: ImportCsvArgs) -> Result<ExitCode> {
         let mut tip_text =
             format!("Once processing is complete the data will be available on the {location}.");
         if let Some(url) = &explore_url {
-            tip_text.push_str(&format!("\n{}", hyperlink(url, "View in Sift")));
+            tip_text.push_str(&format!("\nView in Sift: {url}"));
         }
         Output::new()
             .line(format!("{} file for processing", "Uploaded".green()))

--- a/rust/crates/sift_cli/src/cmd/import/hdf5/import.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/import.rs
@@ -25,7 +25,7 @@ use crate::{
     },
     util::{
         api::create_grpc_channel,
-        explore_url::build_explore_url,
+        explore_url::{build_explore_url, pending_import_tip},
         tty::Output,
     },
 };
@@ -133,14 +133,9 @@ pub async fn run(ctx: Context, args: ImportHdf5Args) -> Result<ExitCode> {
     );
 
     if !args.common.wait {
-        let mut tip_text =
-            format!("Once processing is complete the data will be available on the {location}.");
-        if let Some(url) = &explore_url {
-            tip_text.push_str(&format!("\nView in Sift: {url}"));
-        }
         Output::new()
             .line(format!("{} file for processing", "Uploaded".green()))
-            .tip(tip_text)
+            .tip(pending_import_tip(&location, explore_url.as_deref()))
             .print();
 
         return Ok(ExitCode::SUCCESS);

--- a/rust/crates/sift_cli/src/cmd/import/hdf5/import.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/import.rs
@@ -23,7 +23,11 @@ use crate::{
             wait_for_job_completion,
         },
     },
-    util::{api::create_grpc_channel, explore_url::build_explore_url, tty::Output},
+    util::{
+        api::create_grpc_channel,
+        explore_url::build_explore_url,
+        tty::{Output, hyperlink},
+    },
 };
 
 fn print_skipped_block(skipped: &[SkippedDataset]) {
@@ -117,9 +121,9 @@ pub async fn run(ctx: Context, args: ImportHdf5Args) -> Result<ExitCode> {
     .context("failed to upload hdf5 file")?;
 
     let explore_url = build_explore_url(
-        ctx.rest_uri.clone(),
-        args.common.asset.clone(),
-        args.common.run.clone(),
+        ctx.app_uri.as_deref(),
+        &args.common.asset,
+        args.common.run.as_deref(),
     );
 
     let location = args.common.run.as_ref().map_or_else(
@@ -128,16 +132,15 @@ pub async fn run(ctx: Context, args: ImportHdf5Args) -> Result<ExitCode> {
     );
 
     if !args.common.wait {
-        let mut output = Output::new();
-        output
-            .line(format!("{} file for processing", "Uploaded".green()))
-            .tip(format!(
-                "Once processing is complete the data will be available on the {location}."
-            ));
+        let mut tip_text =
+            format!("Once processing is complete the data will be available on the {location}.");
         if let Some(url) = &explore_url {
-            output.tip(format!("View in Sift: {url}"));
+            tip_text.push_str(&format!("\n{}", hyperlink(url, "View in Sift")));
         }
-        output.print();
+        Output::new()
+            .line(format!("{} file for processing", "Uploaded".green()))
+            .tip(tip_text)
+            .print();
 
         return Ok(ExitCode::SUCCESS);
     }

--- a/rust/crates/sift_cli/src/cmd/import/hdf5/import.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/import.rs
@@ -26,7 +26,7 @@ use crate::{
     util::{
         api::create_grpc_channel,
         explore_url::build_explore_url,
-        tty::{Output, hyperlink},
+        tty::Output,
     },
 };
 
@@ -135,7 +135,7 @@ pub async fn run(ctx: Context, args: ImportHdf5Args) -> Result<ExitCode> {
         let mut tip_text =
             format!("Once processing is complete the data will be available on the {location}.");
         if let Some(url) = &explore_url {
-            tip_text.push_str(&format!("\n{}", hyperlink(url, "View in Sift")));
+            tip_text.push_str(&format!("\nView in Sift: {url}"));
         }
         Output::new()
             .line(format!("{} file for processing", "Uploaded".green()))

--- a/rust/crates/sift_cli/src/cmd/import/hdf5/import.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/import.rs
@@ -23,7 +23,7 @@ use crate::{
             wait_for_job_completion,
         },
     },
-    util::{api::create_grpc_channel, tty::Output},
+    util::{api::create_grpc_channel, explore_url::build_explore_url, tty::Output},
 };
 
 fn print_skipped_block(skipped: &[SkippedDataset]) {
@@ -116,23 +116,33 @@ pub async fn run(ctx: Context, args: ImportHdf5Args) -> Result<ExitCode> {
     .await
     .context("failed to upload hdf5 file")?;
 
+    let explore_url = build_explore_url(
+        ctx.rest_uri.clone(),
+        args.common.asset.clone(),
+        args.common.run.clone(),
+    );
+
     let location = args.common.run.as_ref().map_or_else(
         || format!("asset '{}'", args.common.asset.cyan()),
         |r| format!("run '{}'", r.clone().cyan()),
     );
 
     if !args.common.wait {
-        Output::new()
+        let mut output = Output::new();
+        output
             .line(format!("{} file for processing", "Uploaded".green()))
             .tip(format!(
                 "Once processing is complete the data will be available on the {location}."
-            ))
-            .print();
+            ));
+        if let Some(url) = &explore_url {
+            output.tip(format!("View in Sift: {url}"));
+        }
+        output.print();
 
         return Ok(ExitCode::SUCCESS);
     }
 
-    wait_for_job_completion(grpc_channel, job_id, location).await
+    wait_for_job_completion(grpc_channel, job_id, location, explore_url).await
 }
 
 pub fn build_hdf5_config(args: &ImportHdf5Args) -> Result<Hdf5Config> {

--- a/rust/crates/sift_cli/src/cmd/import/hdf5/import.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/import.rs
@@ -120,11 +120,7 @@ pub async fn run(ctx: Context, args: ImportHdf5Args) -> Result<ExitCode> {
     .await
     .context("failed to upload hdf5 file")?;
 
-    let run_identifier = args
-        .common
-        .run_id
-        .as_deref()
-        .or(args.common.run.as_deref());
+    let run_identifier = args.common.run_id.as_deref().or(args.common.run.as_deref());
     let explore_url = build_explore_url(ctx.app_uri.as_deref(), &args.common.asset, run_identifier);
 
     let location = run_identifier.map_or_else(

--- a/rust/crates/sift_cli/src/cmd/import/hdf5/import.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/import.rs
@@ -120,15 +120,16 @@ pub async fn run(ctx: Context, args: ImportHdf5Args) -> Result<ExitCode> {
     .await
     .context("failed to upload hdf5 file")?;
 
-    let explore_url = build_explore_url(
-        ctx.app_uri.as_deref(),
-        &args.common.asset,
-        args.common.run.as_deref(),
-    );
+    let run_identifier = args
+        .common
+        .run_id
+        .as_deref()
+        .or(args.common.run.as_deref());
+    let explore_url = build_explore_url(ctx.app_uri.as_deref(), &args.common.asset, run_identifier);
 
-    let location = args.common.run.as_ref().map_or_else(
+    let location = run_identifier.map_or_else(
         || format!("asset '{}'", args.common.asset.cyan()),
-        |r| format!("run '{}'", r.clone().cyan()),
+        |r| format!("run '{}'", r.cyan()),
     );
 
     if !args.common.wait {

--- a/rust/crates/sift_cli/src/cmd/import/hdf5/import.rs
+++ b/rust/crates/sift_cli/src/cmd/import/hdf5/import.rs
@@ -17,17 +17,13 @@ use crate::{
     cmd::{
         Context,
         import::{
+            finish_import,
             hdf5::detect_hdf5_schema::{SUPPORTED_TYPES_BLURB, SkippedDataset, detect_config},
             preview_import_config,
             utils::{upload_gzipped_file, validate_time_format},
-            wait_for_job_completion,
         },
     },
-    util::{
-        api::create_grpc_channel,
-        explore_url::{build_explore_url, pending_import_tip},
-        tty::Output,
-    },
+    util::{api::create_grpc_channel, tty::Output},
 };
 
 fn print_skipped_block(skipped: &[SkippedDataset]) {
@@ -120,24 +116,16 @@ pub async fn run(ctx: Context, args: ImportHdf5Args) -> Result<ExitCode> {
     .await
     .context("failed to upload hdf5 file")?;
 
-    let run_identifier = args.common.run_id.as_deref().or(args.common.run.as_deref());
-    let explore_url = build_explore_url(ctx.app_uri.as_deref(), &args.common.asset, run_identifier);
-
-    let location = run_identifier.map_or_else(
-        || format!("asset '{}'", args.common.asset.cyan()),
-        |r| format!("run '{}'", r.cyan()),
-    );
-
-    if !args.common.wait {
-        Output::new()
-            .line(format!("{} file for processing", "Uploaded".green()))
-            .tip(pending_import_tip(&location, explore_url.as_deref()))
-            .print();
-
-        return Ok(ExitCode::SUCCESS);
-    }
-
-    wait_for_job_completion(grpc_channel, job_id, location, explore_url).await
+    finish_import(
+        &ctx,
+        grpc_channel,
+        job_id,
+        &args.common.asset,
+        args.common.run.as_deref(),
+        args.common.run_id.as_deref(),
+        args.common.wait,
+    )
+    .await
 }
 
 pub fn build_hdf5_config(args: &ImportHdf5Args) -> Result<Hdf5Config> {

--- a/rust/crates/sift_cli/src/cmd/import/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/import/mod.rs
@@ -8,7 +8,7 @@ use sift_rs::{SiftChannel, common::r#type::v1::ChannelConfig, jobs::v1::JobStatu
 use crate::util::{
     job::JobServiceWrapper,
     progress::Spinner,
-    tty::{Output, hyperlink},
+    tty::Output,
 };
 
 pub mod backup;
@@ -88,7 +88,7 @@ pub async fn wait_for_job_completion(
                 let mut tip_text =
                     format!("The data should be available on the {import_output_location}");
                 if let Some(url) = &explore_url {
-                    tip_text.push_str(&format!("\n{}", hyperlink(url, "View in Sift")));
+                    tip_text.push_str(&format!("\nView in Sift: {url}"));
                 }
                 Output::new()
                     .line(format!("{} data import job", "Completed".green()))

--- a/rust/crates/sift_cli/src/cmd/import/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/import/mod.rs
@@ -5,11 +5,7 @@ use tokio::time::sleep;
 
 use sift_rs::{SiftChannel, common::r#type::v1::ChannelConfig, jobs::v1::JobStatus};
 
-use crate::util::{
-    job::JobServiceWrapper,
-    progress::Spinner,
-    tty::Output,
-};
+use crate::util::{job::JobServiceWrapper, progress::Spinner, tty::Output};
 
 pub mod backup;
 pub mod csv;

--- a/rust/crates/sift_cli/src/cmd/import/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/import/mod.rs
@@ -23,6 +23,7 @@ pub async fn wait_for_job_completion(
     grpc_channel: SiftChannel,
     job_id: String,
     import_output_location: String,
+    explore_url: Option<String>,
 ) -> Result<ExitCode> {
     let spinner = Spinner::new();
     spinner.set_message(format!("{} file for processing", "Uploaded".green()));
@@ -80,12 +81,16 @@ pub async fn wait_for_job_completion(
             }
             JobStatus::Finished => {
                 spinner.finish_and_clear();
-                Output::new()
+                let mut output = Output::new();
+                output
                     .line(format!("{} data import job", "Completed".green()))
                     .tip(format!(
                         "The data should be available on the {import_output_location}"
-                    ))
-                    .print();
+                    ));
+                if let Some(url) = &explore_url {
+                    output.tip(format!("View in Sift: {url}"));
+                }
+                output.print();
                 break;
             }
             _ => (),

--- a/rust/crates/sift_cli/src/cmd/import/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/import/mod.rs
@@ -25,11 +25,6 @@ const INDENT_2: &str = "    ";
 const INDENT_3: &str = "      ";
 const INDENT_4: &str = "        ";
 
-/// Final step of every import: resolve the destination, then either report the
-/// pending state and exit or block on the server-side job. All format-specific
-/// work (parsing, schema detection, upload) happens before this; everything
-/// after upload is identical across CSV, Parquet, TDMS, HDF5, and backups, so
-/// it lives in one place here.
 pub async fn finish_import(
     ctx: &Context,
     grpc_channel: SiftChannel,

--- a/rust/crates/sift_cli/src/cmd/import/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/import/mod.rs
@@ -5,7 +5,11 @@ use tokio::time::sleep;
 
 use sift_rs::{SiftChannel, common::r#type::v1::ChannelConfig, jobs::v1::JobStatus};
 
-use crate::util::{job::JobServiceWrapper, progress::Spinner, tty::Output};
+use crate::util::{
+    job::JobServiceWrapper,
+    progress::Spinner,
+    tty::{Output, hyperlink},
+};
 
 pub mod backup;
 pub mod csv;
@@ -81,16 +85,15 @@ pub async fn wait_for_job_completion(
             }
             JobStatus::Finished => {
                 spinner.finish_and_clear();
-                let mut output = Output::new();
-                output
-                    .line(format!("{} data import job", "Completed".green()))
-                    .tip(format!(
-                        "The data should be available on the {import_output_location}"
-                    ));
+                let mut tip_text =
+                    format!("The data should be available on the {import_output_location}");
                 if let Some(url) = &explore_url {
-                    output.tip(format!("View in Sift: {url}"));
+                    tip_text.push_str(&format!("\n{}", hyperlink(url, "View in Sift")));
                 }
-                output.print();
+                Output::new()
+                    .line(format!("{} data import job", "Completed".green()))
+                    .tip(tip_text)
+                    .print();
                 break;
             }
             _ => (),

--- a/rust/crates/sift_cli/src/cmd/import/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/import/mod.rs
@@ -5,7 +5,13 @@ use tokio::time::sleep;
 
 use sift_rs::{SiftChannel, common::r#type::v1::ChannelConfig, jobs::v1::JobStatus};
 
-use crate::util::{job::JobServiceWrapper, progress::Spinner, tty::Output};
+use crate::cmd::Context;
+use crate::util::{
+    explore_url::{explore_or_note, import_target, pending_import_tip, resolve_app_uri},
+    job::JobServiceWrapper,
+    progress::Spinner,
+    tty::Output,
+};
 
 pub mod backup;
 pub mod csv;
@@ -18,6 +24,37 @@ const INDENT_1: &str = "  ";
 const INDENT_2: &str = "    ";
 const INDENT_3: &str = "      ";
 const INDENT_4: &str = "        ";
+
+/// Final step of every import: resolve the destination, then either report the
+/// pending state and exit or block on the server-side job. All format-specific
+/// work (parsing, schema detection, upload) happens before this; everything
+/// after upload is identical across CSV, Parquet, TDMS, HDF5, and backups, so
+/// it lives in one place here.
+pub async fn finish_import(
+    ctx: &Context,
+    grpc_channel: SiftChannel,
+    job_id: String,
+    asset: &str,
+    run_name: Option<&str>,
+    run_id: Option<&str>,
+    wait: bool,
+) -> Result<ExitCode> {
+    let app_uri = resolve_app_uri(ctx.app_uri.as_deref(), &ctx.rest_uri);
+    let target = import_target(asset, run_name, run_id, app_uri.as_deref());
+
+    if !wait {
+        Output::new()
+            .line(format!("{} file for processing", "Uploaded".green()))
+            .tip(pending_import_tip(
+                &target.location,
+                target.explore_url.as_deref(),
+            ))
+            .print();
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    wait_for_job_completion(grpc_channel, job_id, target.location, target.explore_url).await
+}
 
 pub async fn wait_for_job_completion(
     grpc_channel: SiftChannel,
@@ -83,9 +120,7 @@ pub async fn wait_for_job_completion(
                 spinner.finish_and_clear();
                 let mut tip_text =
                     format!("The data should be available on the {import_output_location}");
-                if let Some(url) = &explore_url {
-                    tip_text.push_str(&format!("\nView in Sift: {url}"));
-                }
+                tip_text.push_str(&explore_or_note(explore_url.as_deref()));
                 Output::new()
                     .line(format!("{} data import job", "Completed".green()))
                     .tip(tip_text)

--- a/rust/crates/sift_cli/src/cmd/import/parquet/channel_per_row_dataset.rs
+++ b/rust/crates/sift_cli/src/cmd/import/parquet/channel_per_row_dataset.rs
@@ -27,7 +27,7 @@ use crate::cmd::{
         wait_for_job_completion,
     },
 };
-use crate::util::{api::create_grpc_channel, tty::Output};
+use crate::util::{api::create_grpc_channel, explore_url::build_explore_url, tty::Output};
 
 pub async fn run(ctx: Context, args: ChannelPerRowArgs) -> Result<ExitCode> {
     let grpc_channel = create_grpc_channel(&ctx)?;
@@ -125,22 +125,32 @@ pub async fn run(ctx: Context, args: ChannelPerRowArgs) -> Result<ExitCode> {
     .await
     .context("failed to upload Parquet file")?;
 
+    let explore_url = build_explore_url(
+        ctx.rest_uri.clone(),
+        args.common.asset.clone(),
+        args.common.run.clone(),
+    );
+
     let location = args.common.run.as_ref().map_or_else(
         || format!("asset '{}'", args.common.asset.cyan()),
         |r| format!("run '{}'", r.clone().cyan()),
     );
 
     if !args.common.wait {
-        Output::new()
+        let mut output = Output::new();
+        output
             .line(format!("{} file for processing", "Uploaded".green()))
             .tip(format!(
                 "Once processing is complete the data will be available on the {location}."
-            ))
-            .print();
+            ));
+        if let Some(url) = &explore_url {
+            output.tip(format!("View in Sift: {url}"));
+        }
+        output.print();
         return Ok(ExitCode::SUCCESS);
     }
 
-    wait_for_job_completion(grpc_channel, job_id, location).await
+    wait_for_job_completion(grpc_channel, job_id, location, explore_url).await
 }
 
 fn create_data_import_request(

--- a/rust/crates/sift_cli/src/cmd/import/parquet/channel_per_row_dataset.rs
+++ b/rust/crates/sift_cli/src/cmd/import/parquet/channel_per_row_dataset.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashSet, fs::File, io::Seek, process::ExitCode};
 
 use anyhow::{Context as AnyhowContext, Result, anyhow};
-use crossterm::style::Stylize;
 use parquet::file::reader::{ChunkReader, FileReader, SerializedFileReader};
 use parquet::record::Field;
 use parquet::schema::types::Type as ParquetSchemaType;
@@ -23,15 +22,11 @@ use crate::cmd::import::parquet::proto_time_format_display;
 use crate::cmd::{
     Context,
     import::{
-        TimePreview, parquet::FooterMetadata, preview_import_config, utils::upload_gzipped_file,
-        wait_for_job_completion,
+        TimePreview, finish_import, parquet::FooterMetadata, preview_import_config,
+        utils::upload_gzipped_file,
     },
 };
-use crate::util::{
-    api::create_grpc_channel,
-    explore_url::{build_explore_url, pending_import_tip},
-    tty::Output,
-};
+use crate::util::api::create_grpc_channel;
 
 pub async fn run(ctx: Context, args: ChannelPerRowArgs) -> Result<ExitCode> {
     let grpc_channel = create_grpc_channel(&ctx)?;
@@ -129,23 +124,16 @@ pub async fn run(ctx: Context, args: ChannelPerRowArgs) -> Result<ExitCode> {
     .await
     .context("failed to upload Parquet file")?;
 
-    let run_identifier = args.common.run_id.as_deref().or(args.common.run.as_deref());
-    let explore_url = build_explore_url(ctx.app_uri.as_deref(), &args.common.asset, run_identifier);
-
-    let location = run_identifier.map_or_else(
-        || format!("asset '{}'", args.common.asset.cyan()),
-        |r| format!("run '{}'", r.cyan()),
-    );
-
-    if !args.common.wait {
-        Output::new()
-            .line(format!("{} file for processing", "Uploaded".green()))
-            .tip(pending_import_tip(&location, explore_url.as_deref()))
-            .print();
-        return Ok(ExitCode::SUCCESS);
-    }
-
-    wait_for_job_completion(grpc_channel, job_id, location, explore_url).await
+    finish_import(
+        &ctx,
+        grpc_channel,
+        job_id,
+        &args.common.asset,
+        args.common.run.as_deref(),
+        args.common.run_id.as_deref(),
+        args.common.wait,
+    )
+    .await
 }
 
 fn create_data_import_request(

--- a/rust/crates/sift_cli/src/cmd/import/parquet/channel_per_row_dataset.rs
+++ b/rust/crates/sift_cli/src/cmd/import/parquet/channel_per_row_dataset.rs
@@ -129,11 +129,7 @@ pub async fn run(ctx: Context, args: ChannelPerRowArgs) -> Result<ExitCode> {
     .await
     .context("failed to upload Parquet file")?;
 
-    let run_identifier = args
-        .common
-        .run_id
-        .as_deref()
-        .or(args.common.run.as_deref());
+    let run_identifier = args.common.run_id.as_deref().or(args.common.run.as_deref());
     let explore_url = build_explore_url(ctx.app_uri.as_deref(), &args.common.asset, run_identifier);
 
     let location = run_identifier.map_or_else(

--- a/rust/crates/sift_cli/src/cmd/import/parquet/channel_per_row_dataset.rs
+++ b/rust/crates/sift_cli/src/cmd/import/parquet/channel_per_row_dataset.rs
@@ -27,7 +27,11 @@ use crate::cmd::{
         wait_for_job_completion,
     },
 };
-use crate::util::{api::create_grpc_channel, explore_url::build_explore_url, tty::Output};
+use crate::util::{
+    api::create_grpc_channel,
+    explore_url::build_explore_url,
+    tty::{Output, hyperlink},
+};
 
 pub async fn run(ctx: Context, args: ChannelPerRowArgs) -> Result<ExitCode> {
     let grpc_channel = create_grpc_channel(&ctx)?;
@@ -126,9 +130,9 @@ pub async fn run(ctx: Context, args: ChannelPerRowArgs) -> Result<ExitCode> {
     .context("failed to upload Parquet file")?;
 
     let explore_url = build_explore_url(
-        ctx.rest_uri.clone(),
-        args.common.asset.clone(),
-        args.common.run.clone(),
+        ctx.app_uri.as_deref(),
+        &args.common.asset,
+        args.common.run.as_deref(),
     );
 
     let location = args.common.run.as_ref().map_or_else(
@@ -137,16 +141,15 @@ pub async fn run(ctx: Context, args: ChannelPerRowArgs) -> Result<ExitCode> {
     );
 
     if !args.common.wait {
-        let mut output = Output::new();
-        output
-            .line(format!("{} file for processing", "Uploaded".green()))
-            .tip(format!(
-                "Once processing is complete the data will be available on the {location}."
-            ));
+        let mut tip_text =
+            format!("Once processing is complete the data will be available on the {location}.");
         if let Some(url) = &explore_url {
-            output.tip(format!("View in Sift: {url}"));
+            tip_text.push_str(&format!("\n{}", hyperlink(url, "View in Sift")));
         }
-        output.print();
+        Output::new()
+            .line(format!("{} file for processing", "Uploaded".green()))
+            .tip(tip_text)
+            .print();
         return Ok(ExitCode::SUCCESS);
     }
 

--- a/rust/crates/sift_cli/src/cmd/import/parquet/channel_per_row_dataset.rs
+++ b/rust/crates/sift_cli/src/cmd/import/parquet/channel_per_row_dataset.rs
@@ -129,15 +129,16 @@ pub async fn run(ctx: Context, args: ChannelPerRowArgs) -> Result<ExitCode> {
     .await
     .context("failed to upload Parquet file")?;
 
-    let explore_url = build_explore_url(
-        ctx.app_uri.as_deref(),
-        &args.common.asset,
-        args.common.run.as_deref(),
-    );
+    let run_identifier = args
+        .common
+        .run_id
+        .as_deref()
+        .or(args.common.run.as_deref());
+    let explore_url = build_explore_url(ctx.app_uri.as_deref(), &args.common.asset, run_identifier);
 
-    let location = args.common.run.as_ref().map_or_else(
+    let location = run_identifier.map_or_else(
         || format!("asset '{}'", args.common.asset.cyan()),
-        |r| format!("run '{}'", r.clone().cyan()),
+        |r| format!("run '{}'", r.cyan()),
     );
 
     if !args.common.wait {

--- a/rust/crates/sift_cli/src/cmd/import/parquet/channel_per_row_dataset.rs
+++ b/rust/crates/sift_cli/src/cmd/import/parquet/channel_per_row_dataset.rs
@@ -30,7 +30,7 @@ use crate::cmd::{
 use crate::util::{
     api::create_grpc_channel,
     explore_url::build_explore_url,
-    tty::{Output, hyperlink},
+    tty::Output,
 };
 
 pub async fn run(ctx: Context, args: ChannelPerRowArgs) -> Result<ExitCode> {
@@ -144,7 +144,7 @@ pub async fn run(ctx: Context, args: ChannelPerRowArgs) -> Result<ExitCode> {
         let mut tip_text =
             format!("Once processing is complete the data will be available on the {location}.");
         if let Some(url) = &explore_url {
-            tip_text.push_str(&format!("\n{}", hyperlink(url, "View in Sift")));
+            tip_text.push_str(&format!("\nView in Sift: {url}"));
         }
         Output::new()
             .line(format!("{} file for processing", "Uploaded".green()))

--- a/rust/crates/sift_cli/src/cmd/import/parquet/channel_per_row_dataset.rs
+++ b/rust/crates/sift_cli/src/cmd/import/parquet/channel_per_row_dataset.rs
@@ -29,7 +29,7 @@ use crate::cmd::{
 };
 use crate::util::{
     api::create_grpc_channel,
-    explore_url::build_explore_url,
+    explore_url::{build_explore_url, pending_import_tip},
     tty::Output,
 };
 
@@ -142,14 +142,9 @@ pub async fn run(ctx: Context, args: ChannelPerRowArgs) -> Result<ExitCode> {
     );
 
     if !args.common.wait {
-        let mut tip_text =
-            format!("Once processing is complete the data will be available on the {location}.");
-        if let Some(url) = &explore_url {
-            tip_text.push_str(&format!("\nView in Sift: {url}"));
-        }
         Output::new()
             .line(format!("{} file for processing", "Uploaded".green()))
-            .tip(tip_text)
+            .tip(pending_import_tip(&location, explore_url.as_deref()))
             .print();
         return Ok(ExitCode::SUCCESS);
     }

--- a/rust/crates/sift_cli/src/cmd/import/parquet/flat_dataset.rs
+++ b/rust/crates/sift_cli/src/cmd/import/parquet/flat_dataset.rs
@@ -27,7 +27,7 @@ use crate::{
             wait_for_job_completion,
         },
     },
-    util::{api::create_grpc_channel, tty::Output},
+    util::{api::create_grpc_channel, explore_url::build_explore_url, tty::Output},
 };
 
 pub async fn run(ctx: Context, args: FlatDatasetArgs) -> Result<ExitCode> {
@@ -105,22 +105,32 @@ pub async fn run(ctx: Context, args: FlatDatasetArgs) -> Result<ExitCode> {
     .await
     .context("failed to upload Parquet file")?;
 
+    let explore_url = build_explore_url(
+        ctx.rest_uri.clone(),
+        args.common.asset.clone(),
+        args.common.run.clone(),
+    );
+
     let location = args.common.run.as_ref().map_or_else(
         || format!("asset '{}'", args.common.asset.cyan()),
         |r| format!("run '{}'", r.clone().cyan()),
     );
 
     if !args.common.wait {
-        Output::new()
+        let mut output = Output::new();
+        output
             .line(format!("{} file for processing", "Uploaded".green()))
             .tip(format!(
                 "Once processing is complete the data will be available on the {location}."
-            ))
-            .print();
+            ));
+        if let Some(url) = &explore_url {
+            output.tip(format!("View in Sift: {url}"));
+        }
+        output.print();
 
         return Ok(ExitCode::SUCCESS);
     }
-    wait_for_job_completion(grpc_channel, job_id, location).await
+    wait_for_job_completion(grpc_channel, job_id, location, explore_url).await
 }
 
 fn update_config_with_overrides(

--- a/rust/crates/sift_cli/src/cmd/import/parquet/flat_dataset.rs
+++ b/rust/crates/sift_cli/src/cmd/import/parquet/flat_dataset.rs
@@ -29,7 +29,7 @@ use crate::{
     },
     util::{
         api::create_grpc_channel,
-        explore_url::build_explore_url,
+        explore_url::{build_explore_url, pending_import_tip},
         tty::Output,
     },
 };
@@ -122,14 +122,9 @@ pub async fn run(ctx: Context, args: FlatDatasetArgs) -> Result<ExitCode> {
     );
 
     if !args.common.wait {
-        let mut tip_text =
-            format!("Once processing is complete the data will be available on the {location}.");
-        if let Some(url) = &explore_url {
-            tip_text.push_str(&format!("\nView in Sift: {url}"));
-        }
         Output::new()
             .line(format!("{} file for processing", "Uploaded".green()))
-            .tip(tip_text)
+            .tip(pending_import_tip(&location, explore_url.as_deref()))
             .print();
 
         return Ok(ExitCode::SUCCESS);

--- a/rust/crates/sift_cli/src/cmd/import/parquet/flat_dataset.rs
+++ b/rust/crates/sift_cli/src/cmd/import/parquet/flat_dataset.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, fs::File, io::Seek, process::ExitCode};
 
 use anyhow::{Context as AnyhowContext, Result, anyhow};
-use crossterm::style::Stylize;
 use sift_rs::{
     common::r#type::v1::{ChannelConfig, ChannelDataType},
     data_imports::v2::{
@@ -21,17 +20,13 @@ use crate::{
         Context,
         import::{
             TimePreview,
+            finish_import,
             parquet::FooterMetadata,
             preview_import_config,
             utils::{try_parse_bit_field_config, try_parse_enum_config, upload_gzipped_file},
-            wait_for_job_completion,
         },
     },
-    util::{
-        api::create_grpc_channel,
-        explore_url::{build_explore_url, pending_import_tip},
-        tty::Output,
-    },
+    util::api::create_grpc_channel,
 };
 
 pub async fn run(ctx: Context, args: FlatDatasetArgs) -> Result<ExitCode> {
@@ -109,23 +104,16 @@ pub async fn run(ctx: Context, args: FlatDatasetArgs) -> Result<ExitCode> {
     .await
     .context("failed to upload Parquet file")?;
 
-    let run_identifier = args.common.run_id.as_deref().or(args.common.run.as_deref());
-    let explore_url = build_explore_url(ctx.app_uri.as_deref(), &args.common.asset, run_identifier);
-
-    let location = run_identifier.map_or_else(
-        || format!("asset '{}'", args.common.asset.cyan()),
-        |r| format!("run '{}'", r.cyan()),
-    );
-
-    if !args.common.wait {
-        Output::new()
-            .line(format!("{} file for processing", "Uploaded".green()))
-            .tip(pending_import_tip(&location, explore_url.as_deref()))
-            .print();
-
-        return Ok(ExitCode::SUCCESS);
-    }
-    wait_for_job_completion(grpc_channel, job_id, location, explore_url).await
+    finish_import(
+        &ctx,
+        grpc_channel,
+        job_id,
+        &args.common.asset,
+        args.common.run.as_deref(),
+        args.common.run_id.as_deref(),
+        args.common.wait,
+    )
+    .await
 }
 
 fn update_config_with_overrides(

--- a/rust/crates/sift_cli/src/cmd/import/parquet/flat_dataset.rs
+++ b/rust/crates/sift_cli/src/cmd/import/parquet/flat_dataset.rs
@@ -109,11 +109,7 @@ pub async fn run(ctx: Context, args: FlatDatasetArgs) -> Result<ExitCode> {
     .await
     .context("failed to upload Parquet file")?;
 
-    let run_identifier = args
-        .common
-        .run_id
-        .as_deref()
-        .or(args.common.run.as_deref());
+    let run_identifier = args.common.run_id.as_deref().or(args.common.run.as_deref());
     let explore_url = build_explore_url(ctx.app_uri.as_deref(), &args.common.asset, run_identifier);
 
     let location = run_identifier.map_or_else(

--- a/rust/crates/sift_cli/src/cmd/import/parquet/flat_dataset.rs
+++ b/rust/crates/sift_cli/src/cmd/import/parquet/flat_dataset.rs
@@ -19,8 +19,7 @@ use crate::{
     cmd::{
         Context,
         import::{
-            TimePreview,
-            finish_import,
+            TimePreview, finish_import,
             parquet::FooterMetadata,
             preview_import_config,
             utils::{try_parse_bit_field_config, try_parse_enum_config, upload_gzipped_file},

--- a/rust/crates/sift_cli/src/cmd/import/parquet/flat_dataset.rs
+++ b/rust/crates/sift_cli/src/cmd/import/parquet/flat_dataset.rs
@@ -30,7 +30,7 @@ use crate::{
     util::{
         api::create_grpc_channel,
         explore_url::build_explore_url,
-        tty::{Output, hyperlink},
+        tty::Output,
     },
 };
 
@@ -124,7 +124,7 @@ pub async fn run(ctx: Context, args: FlatDatasetArgs) -> Result<ExitCode> {
         let mut tip_text =
             format!("Once processing is complete the data will be available on the {location}.");
         if let Some(url) = &explore_url {
-            tip_text.push_str(&format!("\n{}", hyperlink(url, "View in Sift")));
+            tip_text.push_str(&format!("\nView in Sift: {url}"));
         }
         Output::new()
             .line(format!("{} file for processing", "Uploaded".green()))

--- a/rust/crates/sift_cli/src/cmd/import/parquet/flat_dataset.rs
+++ b/rust/crates/sift_cli/src/cmd/import/parquet/flat_dataset.rs
@@ -109,15 +109,16 @@ pub async fn run(ctx: Context, args: FlatDatasetArgs) -> Result<ExitCode> {
     .await
     .context("failed to upload Parquet file")?;
 
-    let explore_url = build_explore_url(
-        ctx.app_uri.as_deref(),
-        &args.common.asset,
-        args.common.run.as_deref(),
-    );
+    let run_identifier = args
+        .common
+        .run_id
+        .as_deref()
+        .or(args.common.run.as_deref());
+    let explore_url = build_explore_url(ctx.app_uri.as_deref(), &args.common.asset, run_identifier);
 
-    let location = args.common.run.as_ref().map_or_else(
+    let location = run_identifier.map_or_else(
         || format!("asset '{}'", args.common.asset.cyan()),
-        |r| format!("run '{}'", r.clone().cyan()),
+        |r| format!("run '{}'", r.cyan()),
     );
 
     if !args.common.wait {

--- a/rust/crates/sift_cli/src/cmd/import/parquet/flat_dataset.rs
+++ b/rust/crates/sift_cli/src/cmd/import/parquet/flat_dataset.rs
@@ -27,7 +27,11 @@ use crate::{
             wait_for_job_completion,
         },
     },
-    util::{api::create_grpc_channel, explore_url::build_explore_url, tty::Output},
+    util::{
+        api::create_grpc_channel,
+        explore_url::build_explore_url,
+        tty::{Output, hyperlink},
+    },
 };
 
 pub async fn run(ctx: Context, args: FlatDatasetArgs) -> Result<ExitCode> {
@@ -106,9 +110,9 @@ pub async fn run(ctx: Context, args: FlatDatasetArgs) -> Result<ExitCode> {
     .context("failed to upload Parquet file")?;
 
     let explore_url = build_explore_url(
-        ctx.rest_uri.clone(),
-        args.common.asset.clone(),
-        args.common.run.clone(),
+        ctx.app_uri.as_deref(),
+        &args.common.asset,
+        args.common.run.as_deref(),
     );
 
     let location = args.common.run.as_ref().map_or_else(
@@ -117,16 +121,15 @@ pub async fn run(ctx: Context, args: FlatDatasetArgs) -> Result<ExitCode> {
     );
 
     if !args.common.wait {
-        let mut output = Output::new();
-        output
-            .line(format!("{} file for processing", "Uploaded".green()))
-            .tip(format!(
-                "Once processing is complete the data will be available on the {location}."
-            ));
+        let mut tip_text =
+            format!("Once processing is complete the data will be available on the {location}.");
         if let Some(url) = &explore_url {
-            output.tip(format!("View in Sift: {url}"));
+            tip_text.push_str(&format!("\n{}", hyperlink(url, "View in Sift")));
         }
-        output.print();
+        Output::new()
+            .line(format!("{} file for processing", "Uploaded".green()))
+            .tip(tip_text)
+            .print();
 
         return Ok(ExitCode::SUCCESS);
     }

--- a/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
+++ b/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
@@ -26,7 +26,7 @@ use crate::{
             wait_for_job_completion,
         },
     },
-    util::{api::create_grpc_channel, tty::Output},
+    util::{api::create_grpc_channel, explore_url::build_explore_url, tty::Output},
 };
 
 pub async fn run(ctx: Context, args: ImportTdmsArgs) -> Result<ExitCode> {
@@ -79,23 +79,33 @@ pub async fn run(ctx: Context, args: ImportTdmsArgs) -> Result<ExitCode> {
     .await
     .context("failed to upload tdms file")?;
 
+    let explore_url = build_explore_url(
+        ctx.rest_uri.clone(),
+        args.common.asset.clone(),
+        args.common.run.clone(),
+    );
+
     let location = args.common.run.as_ref().map_or_else(
         || format!("asset '{}'", args.common.asset.cyan()),
         |r| format!("run '{}'", r.clone().cyan()),
     );
 
     if !args.common.wait {
-        Output::new()
+        let mut output = Output::new();
+        output
             .line(format!("{} file for processing", "Uploaded".green()))
             .tip(format!(
                 "Once processing is complete the data will be available on the {location}."
-            ))
-            .print();
+            ));
+        if let Some(url) = &explore_url {
+            output.tip(format!("View in Sift: {url}"));
+        }
+        output.print();
 
         return Ok(ExitCode::SUCCESS);
     }
 
-    wait_for_job_completion(grpc_channel, job_id, location).await
+    wait_for_job_completion(grpc_channel, job_id, location, explore_url).await
 }
 
 pub fn build_tdms_config(args: &ImportTdmsArgs) -> Result<TdmsConfig> {

--- a/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
+++ b/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
@@ -29,7 +29,7 @@ use crate::{
     util::{
         api::create_grpc_channel,
         explore_url::build_explore_url,
-        tty::{Output, hyperlink},
+        tty::Output,
     },
 };
 
@@ -98,7 +98,7 @@ pub async fn run(ctx: Context, args: ImportTdmsArgs) -> Result<ExitCode> {
         let mut tip_text =
             format!("Once processing is complete the data will be available on the {location}.");
         if let Some(url) = &explore_url {
-            tip_text.push_str(&format!("\n{}", hyperlink(url, "View in Sift")));
+            tip_text.push_str(&format!("\nView in Sift: {url}"));
         }
         Output::new()
             .line(format!("{} file for processing", "Uploaded".green()))

--- a/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
+++ b/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
@@ -83,15 +83,16 @@ pub async fn run(ctx: Context, args: ImportTdmsArgs) -> Result<ExitCode> {
     .await
     .context("failed to upload tdms file")?;
 
-    let explore_url = build_explore_url(
-        ctx.app_uri.as_deref(),
-        &args.common.asset,
-        args.common.run.as_deref(),
-    );
+    let run_identifier = args
+        .common
+        .run_id
+        .as_deref()
+        .or(args.common.run.as_deref());
+    let explore_url = build_explore_url(ctx.app_uri.as_deref(), &args.common.asset, run_identifier);
 
-    let location = args.common.run.as_ref().map_or_else(
+    let location = run_identifier.map_or_else(
         || format!("asset '{}'", args.common.asset.cyan()),
-        |r| format!("run '{}'", r.clone().cyan()),
+        |r| format!("run '{}'", r.cyan()),
     );
 
     if !args.common.wait {

--- a/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
+++ b/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
@@ -28,7 +28,7 @@ use crate::{
     },
     util::{
         api::create_grpc_channel,
-        explore_url::build_explore_url,
+        explore_url::{build_explore_url, pending_import_tip},
         tty::Output,
     },
 };
@@ -96,14 +96,9 @@ pub async fn run(ctx: Context, args: ImportTdmsArgs) -> Result<ExitCode> {
     );
 
     if !args.common.wait {
-        let mut tip_text =
-            format!("Once processing is complete the data will be available on the {location}.");
-        if let Some(url) = &explore_url {
-            tip_text.push_str(&format!("\nView in Sift: {url}"));
-        }
         Output::new()
             .line(format!("{} file for processing", "Uploaded".green()))
-            .tip(tip_text)
+            .tip(pending_import_tip(&location, explore_url.as_deref()))
             .print();
 
         return Ok(ExitCode::SUCCESS);

--- a/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
+++ b/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
@@ -2,7 +2,6 @@ use std::{fs::File, path::Path, process::ExitCode};
 
 use anyhow::{Context as AnyhowContext, Result, anyhow};
 use chrono::DateTime;
-use crossterm::style::Stylize;
 use pbjson_types::Timestamp;
 use sift_rs::{
     common::r#type::v1::{ChannelConfig, ChannelDataType},
@@ -21,16 +20,11 @@ use crate::{
     cmd::{
         Context,
         import::{
-            preview_import_config,
+            finish_import, preview_import_config,
             utils::{upload_gzipped_file, validate_time_format},
-            wait_for_job_completion,
         },
     },
-    util::{
-        api::create_grpc_channel,
-        explore_url::{build_explore_url, pending_import_tip},
-        tty::Output,
-    },
+    util::{api::create_grpc_channel, tty::Output},
 };
 
 pub async fn run(ctx: Context, args: ImportTdmsArgs) -> Result<ExitCode> {
@@ -83,24 +77,16 @@ pub async fn run(ctx: Context, args: ImportTdmsArgs) -> Result<ExitCode> {
     .await
     .context("failed to upload tdms file")?;
 
-    let run_identifier = args.common.run_id.as_deref().or(args.common.run.as_deref());
-    let explore_url = build_explore_url(ctx.app_uri.as_deref(), &args.common.asset, run_identifier);
-
-    let location = run_identifier.map_or_else(
-        || format!("asset '{}'", args.common.asset.cyan()),
-        |r| format!("run '{}'", r.cyan()),
-    );
-
-    if !args.common.wait {
-        Output::new()
-            .line(format!("{} file for processing", "Uploaded".green()))
-            .tip(pending_import_tip(&location, explore_url.as_deref()))
-            .print();
-
-        return Ok(ExitCode::SUCCESS);
-    }
-
-    wait_for_job_completion(grpc_channel, job_id, location, explore_url).await
+    finish_import(
+        &ctx,
+        grpc_channel,
+        job_id,
+        &args.common.asset,
+        args.common.run.as_deref(),
+        args.common.run_id.as_deref(),
+        args.common.wait,
+    )
+    .await
 }
 
 pub fn build_tdms_config(args: &ImportTdmsArgs) -> Result<TdmsConfig> {

--- a/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
+++ b/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
@@ -26,7 +26,11 @@ use crate::{
             wait_for_job_completion,
         },
     },
-    util::{api::create_grpc_channel, explore_url::build_explore_url, tty::Output},
+    util::{
+        api::create_grpc_channel,
+        explore_url::build_explore_url,
+        tty::{Output, hyperlink},
+    },
 };
 
 pub async fn run(ctx: Context, args: ImportTdmsArgs) -> Result<ExitCode> {
@@ -80,9 +84,9 @@ pub async fn run(ctx: Context, args: ImportTdmsArgs) -> Result<ExitCode> {
     .context("failed to upload tdms file")?;
 
     let explore_url = build_explore_url(
-        ctx.rest_uri.clone(),
-        args.common.asset.clone(),
-        args.common.run.clone(),
+        ctx.app_uri.as_deref(),
+        &args.common.asset,
+        args.common.run.as_deref(),
     );
 
     let location = args.common.run.as_ref().map_or_else(
@@ -91,16 +95,15 @@ pub async fn run(ctx: Context, args: ImportTdmsArgs) -> Result<ExitCode> {
     );
 
     if !args.common.wait {
-        let mut output = Output::new();
-        output
-            .line(format!("{} file for processing", "Uploaded".green()))
-            .tip(format!(
-                "Once processing is complete the data will be available on the {location}."
-            ));
+        let mut tip_text =
+            format!("Once processing is complete the data will be available on the {location}.");
         if let Some(url) = &explore_url {
-            output.tip(format!("View in Sift: {url}"));
+            tip_text.push_str(&format!("\n{}", hyperlink(url, "View in Sift")));
         }
-        output.print();
+        Output::new()
+            .line(format!("{} file for processing", "Uploaded".green()))
+            .tip(tip_text)
+            .print();
 
         return Ok(ExitCode::SUCCESS);
     }

--- a/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
+++ b/rust/crates/sift_cli/src/cmd/import/tdms/detect_tdms_config.rs
@@ -83,11 +83,7 @@ pub async fn run(ctx: Context, args: ImportTdmsArgs) -> Result<ExitCode> {
     .await
     .context("failed to upload tdms file")?;
 
-    let run_identifier = args
-        .common
-        .run_id
-        .as_deref()
-        .or(args.common.run.as_deref());
+    let run_identifier = args.common.run_id.as_deref().or(args.common.run.as_deref());
     let explore_url = build_explore_url(ctx.app_uri.as_deref(), &args.common.asset, run_identifier);
 
     let location = run_identifier.map_or_else(

--- a/rust/crates/sift_cli/src/cmd/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/mod.rs
@@ -19,9 +19,6 @@ pub struct Context {
     pub disable_tls: bool,
     #[allow(dead_code)]
     pub rest_uri: String,
-    /// Sift web app URL configured by the user (e.g. https://app.siftstack.com).
-    /// `None` when the profile omits `app_uri`; Explore links are omitted unless
-    /// the host can be derived from `rest_uri` via `resolve_app_uri`.
     pub app_uri: Option<String>,
 }
 

--- a/rust/crates/sift_cli/src/cmd/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/mod.rs
@@ -20,7 +20,8 @@ pub struct Context {
     #[allow(dead_code)]
     pub rest_uri: String,
     /// Sift web app URL configured by the user (e.g. https://app.siftstack.com).
-    /// `None` when the profile omits `app_uri` — clickable links are disabled.
+    /// `None` when the profile omits `app_uri`; Explore links are omitted unless
+    /// the host can be derived from `rest_uri` via `resolve_app_uri`.
     pub app_uri: Option<String>,
 }
 

--- a/rust/crates/sift_cli/src/cmd/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/mod.rs
@@ -19,6 +19,9 @@ pub struct Context {
     pub disable_tls: bool,
     #[allow(dead_code)]
     pub rest_uri: String,
+    /// Sift web app URL configured by the user (e.g. https://app.siftstack.com).
+    /// `None` when the profile omits `app_uri` — clickable links are disabled.
+    pub app_uri: Option<String>,
 }
 
 impl Context {
@@ -82,6 +85,11 @@ impl Context {
             ));
         }
 
+        let app_uri = match target_profile.get("app_uri") {
+            Some(Value::String(s)) if !s.is_empty() => Some(s.clone()),
+            _ => None,
+        };
+
         let Some(Value::String(api_key)) = target_profile.get("apikey").cloned() else {
             return Err(anyhow!(
                 "Expected value of '{}' to be a string",
@@ -100,6 +108,7 @@ impl Context {
             rest_uri,
             api_key,
             disable_tls,
+            app_uri,
         })
     }
 }

--- a/rust/crates/sift_cli/src/util/explore_url.rs
+++ b/rust/crates/sift_cli/src/util/explore_url.rs
@@ -1,0 +1,30 @@
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
+
+const VALUE_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'_')
+    .remove(b'.')
+    .remove(b'~')
+    .remove(b':');
+
+fn encode(s: &str) -> String {
+    utf8_percent_encode(s, VALUE_ENCODE_SET).to_string()
+}
+
+pub fn build_explore_url(
+    rest_uri: String,
+    asset_name: String,
+    run_name: Option<String>,
+) -> Option<String> {
+    let swapped = rest_uri.replacen("://api", "://app", 1);
+    if swapped == rest_uri {
+        return None;
+    }
+    let host = swapped.split('/').take(3).collect::<Vec<_>>().join("/");
+
+    let mut url = format!("{host}/explore?method=single&assets={}", encode(&asset_name));
+    if let Some(run) = run_name {
+        url.push_str(&format!("&runs={}", encode(&run)));
+    }
+    Some(url)
+}

--- a/rust/crates/sift_cli/src/util/explore_url.rs
+++ b/rust/crates/sift_cli/src/util/explore_url.rs
@@ -39,15 +39,11 @@ pub fn resolve_app_uri(app_uri: Option<&str>, rest_uri: &str) -> Option<String> 
     if let Some(uri) = app_uri.map(str::trim).filter(|s| !s.is_empty()) {
         return Some(uri.to_string());
     }
-    let host = host_of(rest_uri)?;
-    match host {
+    match host_of(rest_uri)? {
         "api.siftstack.com" => Some("https://app.siftstack.com".to_string()),
         "gov.api.siftstack.com" => Some("https://gov.siftstack.com".to_string()),
         "api.development.siftstack.com" => {
             Some("https://app.development.siftstack.com".to_string())
-        }
-        "localhost" | "127.0.0.1" if rest_uri.starts_with("http://") => {
-            Some("http://localhost:3000".to_string())
         }
         _ => None,
     }

--- a/rust/crates/sift_cli/src/util/explore_url.rs
+++ b/rust/crates/sift_cli/src/util/explore_url.rs
@@ -15,16 +15,19 @@ fn encode(s: &str) -> String {
 /// `None` when `app_uri` is unset or empty — Sift URLs are not deterministic
 /// from the API host (e.g. `gov.siftstack.com` / `gov.grpc-api.siftstack.com`),
 /// so the user must configure the web app URL explicitly in their profile.
+///
+/// `run` accepts either a run name or a run UUID — Sift Explore resolves both
+/// when passed as the `runs=` query value.
 pub fn build_explore_url(
     app_uri: Option<&str>,
     asset_name: &str,
-    run_name: Option<&str>,
+    run: Option<&str>,
 ) -> Option<String> {
     let host = app_uri.map(str::trim).filter(|s| !s.is_empty())?;
     let host = host.trim_end_matches('/');
 
     let mut url = format!("{host}/explore?method=single&assets={}", encode(asset_name));
-    if let Some(run) = run_name {
+    if let Some(run) = run {
         url.push_str(&format!("&runs={}", encode(run)));
     }
     Some(url)

--- a/rust/crates/sift_cli/src/util/explore_url.rs
+++ b/rust/crates/sift_cli/src/util/explore_url.rs
@@ -43,6 +43,9 @@ pub fn resolve_app_uri(app_uri: Option<&str>, rest_uri: &str) -> Option<String> 
     match host {
         "api.siftstack.com" => Some("https://app.siftstack.com".to_string()),
         "gov.api.siftstack.com" => Some("https://gov.siftstack.com".to_string()),
+        "api.development.siftstack.com" => {
+            Some("https://app.development.siftstack.com".to_string())
+        }
         "localhost" | "127.0.0.1" if rest_uri.starts_with("http://") => {
             Some("http://localhost:3000".to_string())
         }

--- a/rust/crates/sift_cli/src/util/explore_url.rs
+++ b/rust/crates/sift_cli/src/util/explore_url.rs
@@ -11,20 +11,21 @@ fn encode(s: &str) -> String {
     utf8_percent_encode(s, VALUE_ENCODE_SET).to_string()
 }
 
+/// Build a Sift Explore deep-link from the user-configured `app_uri`. Returns
+/// `None` when `app_uri` is unset or empty — Sift URLs are not deterministic
+/// from the API host (e.g. `gov.siftstack.com` / `gov.grpc-api.siftstack.com`),
+/// so the user must configure the web app URL explicitly in their profile.
 pub fn build_explore_url(
-    rest_uri: String,
-    asset_name: String,
-    run_name: Option<String>,
+    app_uri: Option<&str>,
+    asset_name: &str,
+    run_name: Option<&str>,
 ) -> Option<String> {
-    let swapped = rest_uri.replacen("://api", "://app", 1);
-    if swapped == rest_uri {
-        return None;
-    }
-    let host = swapped.split('/').take(3).collect::<Vec<_>>().join("/");
+    let host = app_uri.map(str::trim).filter(|s| !s.is_empty())?;
+    let host = host.trim_end_matches('/');
 
-    let mut url = format!("{host}/explore?method=single&assets={}", encode(&asset_name));
+    let mut url = format!("{host}/explore?method=single&assets={}", encode(asset_name));
     if let Some(run) = run_name {
-        url.push_str(&format!("&runs={}", encode(&run)));
+        url.push_str(&format!("&runs={}", encode(run)));
     }
     Some(url)
 }

--- a/rust/crates/sift_cli/src/util/explore_url.rs
+++ b/rust/crates/sift_cli/src/util/explore_url.rs
@@ -11,6 +11,19 @@ fn encode(s: &str) -> String {
     utf8_percent_encode(s, VALUE_ENCODE_SET).to_string()
 }
 
+/// Tip text shown immediately after an import is uploaded but before the
+/// server-side job has finished processing. Appends a `View in Sift: <url>`
+/// line when `explore_url` is present. Used by every import subcommand so the
+/// wording stays uniform across formats.
+pub fn pending_import_tip(location: &str, explore_url: Option<&str>) -> String {
+    let mut tip =
+        format!("Once processing is complete the data will be available on the {location}.");
+    if let Some(url) = explore_url {
+        tip.push_str(&format!("\nView in Sift: {url}"));
+    }
+    tip
+}
+
 /// Build a Sift Explore deep-link from the user-configured `app_uri`. Returns
 /// `None` when `app_uri` is unset or empty — Sift URLs are not deterministic
 /// from the API host (e.g. `gov.siftstack.com` / `gov.grpc-api.siftstack.com`),

--- a/rust/crates/sift_cli/src/util/explore_url.rs
+++ b/rust/crates/sift_cli/src/util/explore_url.rs
@@ -35,8 +35,6 @@ pub fn import_target(
     }
 }
 
-/// Resolve the Sift web app URL. The host table mirrors the Python client's
-/// `_internal/urls.py` — keep them in sync.
 pub fn resolve_app_uri(app_uri: Option<&str>, rest_uri: &str) -> Option<String> {
     if let Some(uri) = app_uri.map(str::trim).filter(|s| !s.is_empty()) {
         return Some(uri.to_string());
@@ -74,7 +72,6 @@ pub fn pending_import_tip(location: &str, explore_url: Option<&str>) -> String {
     tip
 }
 
-/// `run` accepts a name or UUID; Sift Explore resolves both.
 pub fn build_explore_url(
     app_uri: Option<&str>,
     asset_name: &str,

--- a/rust/crates/sift_cli/src/util/explore_url.rs
+++ b/rust/crates/sift_cli/src/util/explore_url.rs
@@ -48,15 +48,22 @@ pub fn import_target(
 /// 2. A built-in mapping for the standard SaaS hosts (`api.siftstack.com` and
 ///    `gov.api.siftstack.com`). This mirrors the Python client's
 ///    `_internal/urls.py` table so the two clients agree.
-/// 3. `None` — the user has a non-standard `rest_uri` and no `app_uri` set; the
-///    caller should surface a note pointing them at the config.
+/// 3. A plaintext-HTTP localhost rest_uri resolves to `http://localhost:3000` —
+///    the Sift local dev web app convention. Gated on `http://` so a
+///    `https://localhost` setup (non-standard) falls through to `None`.
+/// 4. `None` — non-standard `rest_uri` without `app_uri` set; the caller should
+///    surface a note pointing the user at the config.
 pub fn resolve_app_uri(app_uri: Option<&str>, rest_uri: &str) -> Option<String> {
     if let Some(uri) = app_uri.map(str::trim).filter(|s| !s.is_empty()) {
         return Some(uri.to_string());
     }
-    match host_of(rest_uri)? {
+    let host = host_of(rest_uri)?;
+    match host {
         "api.siftstack.com" => Some("https://app.siftstack.com".to_string()),
         "gov.api.siftstack.com" => Some("https://gov.siftstack.com".to_string()),
+        "localhost" | "127.0.0.1" if rest_uri.starts_with("http://") => {
+            Some("http://localhost:3000".to_string())
+        }
         _ => None,
     }
 }

--- a/rust/crates/sift_cli/src/util/explore_url.rs
+++ b/rust/crates/sift_cli/src/util/explore_url.rs
@@ -1,3 +1,4 @@
+use crossterm::style::Stylize;
 use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
 
 const VALUE_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
@@ -11,25 +12,91 @@ fn encode(s: &str) -> String {
     utf8_percent_encode(s, VALUE_ENCODE_SET).to_string()
 }
 
+/// Where an import is going to land, packaged for output. `location` is the
+/// human-readable phrase (`run '<id>'` or `asset '<name>'`) that gets dropped
+/// into tip text; `explore_url` is the Sift Explore deep-link when the user's
+/// profile has `app_uri` set.
+pub struct ImportTarget {
+    pub location: String,
+    pub explore_url: Option<String>,
+}
+
+/// Resolve the run identifier (preferring `run_id` over `run_name`), format the
+/// "asset 'X'" / "run 'Y'" location phrase, and build the Sift Explore deep-link
+/// in one call. Used by every import subcommand so the wording and precedence
+/// stay uniform across formats.
+pub fn import_target(
+    asset: &str,
+    run_name: Option<&str>,
+    run_id: Option<&str>,
+    app_uri: Option<&str>,
+) -> ImportTarget {
+    let run = run_id.or(run_name);
+    let location = run.map_or_else(
+        || format!("asset '{}'", asset.cyan()),
+        |r| format!("run '{}'", r.cyan()),
+    );
+    let explore_url = build_explore_url(app_uri, asset, run);
+    ImportTarget {
+        location,
+        explore_url,
+    }
+}
+
+/// Resolve the Sift web app URL for link-rendering. Order of precedence:
+/// 1. The user's configured `app_uri` (whatever they set in their profile).
+/// 2. A built-in mapping for the standard SaaS hosts (`api.siftstack.com` and
+///    `gov.api.siftstack.com`). This mirrors the Python client's
+///    `_internal/urls.py` table so the two clients agree.
+/// 3. `None` — the user has a non-standard `rest_uri` and no `app_uri` set; the
+///    caller should surface a note pointing them at the config.
+pub fn resolve_app_uri(app_uri: Option<&str>, rest_uri: &str) -> Option<String> {
+    if let Some(uri) = app_uri.map(str::trim).filter(|s| !s.is_empty()) {
+        return Some(uri.to_string());
+    }
+    match host_of(rest_uri)? {
+        "api.siftstack.com" => Some("https://app.siftstack.com".to_string()),
+        "gov.api.siftstack.com" => Some("https://gov.siftstack.com".to_string()),
+        _ => None,
+    }
+}
+
+fn host_of(url: &str) -> Option<&str> {
+    let after_scheme = url.split_once("://").map(|(_, rest)| rest).unwrap_or(url);
+    let host_with_port = after_scheme.split('/').next()?;
+    Some(host_with_port.split(':').next().unwrap_or(host_with_port))
+}
+
+/// Line appended to import-output tips: a `View in Sift: <url>` link when
+/// `explore_url` is present, or a note telling the user how to enable links
+/// when it isn't.
+pub fn explore_or_note(explore_url: Option<&str>) -> String {
+    match explore_url {
+        Some(url) => format!("\nView in Sift: {url}"),
+        None => "\nRun `sift-cli config update --app-uri <SIFT_WEB_URL>` so future imports \
+                 include a Sift Explore link."
+            .to_string(),
+    }
+}
+
 /// Tip text shown immediately after an import is uploaded but before the
-/// server-side job has finished processing. Appends a `View in Sift: <url>`
-/// line when `explore_url` is present. Used by every import subcommand so the
-/// wording stays uniform across formats.
+/// server-side job has finished processing. Appends either a `View in Sift`
+/// link or a "set `app_uri`" note via [`explore_or_note`]. Used by every
+/// import subcommand so the wording stays uniform across formats.
 pub fn pending_import_tip(location: &str, explore_url: Option<&str>) -> String {
     let mut tip =
         format!("Once processing is complete the data will be available on the {location}.");
-    if let Some(url) = explore_url {
-        tip.push_str(&format!("\nView in Sift: {url}"));
-    }
+    tip.push_str(&explore_or_note(explore_url));
     tip
 }
 
 /// Build a Sift Explore deep-link from the user-configured `app_uri`. Returns
-/// `None` when `app_uri` is unset or empty — Sift URLs are not deterministic
-/// from the API host (e.g. `gov.siftstack.com` / `gov.grpc-api.siftstack.com`),
-/// so the user must configure the web app URL explicitly in their profile.
+/// `None` when `app_uri` is unset or empty. Sift URLs are not deterministic
+/// from the API host (e.g. `gov.siftstack.com` pairs with
+/// `gov.api.siftstack.com`), so callers should pass the resolved web URL —
+/// see [`resolve_app_uri`].
 ///
-/// `run` accepts either a run name or a run UUID — Sift Explore resolves both
+/// `run` accepts either a run name or a run UUID; Sift Explore resolves both
 /// when passed as the `runs=` query value.
 pub fn build_explore_url(
     app_uri: Option<&str>,

--- a/rust/crates/sift_cli/src/util/explore_url.rs
+++ b/rust/crates/sift_cli/src/util/explore_url.rs
@@ -12,19 +12,11 @@ fn encode(s: &str) -> String {
     utf8_percent_encode(s, VALUE_ENCODE_SET).to_string()
 }
 
-/// Where an import is going to land, packaged for output. `location` is the
-/// human-readable phrase (`run '<id>'` or `asset '<name>'`) that gets dropped
-/// into tip text; `explore_url` is the Sift Explore deep-link when the user's
-/// profile has `app_uri` set.
 pub struct ImportTarget {
     pub location: String,
     pub explore_url: Option<String>,
 }
 
-/// Resolve the run identifier (preferring `run_id` over `run_name`), format the
-/// "asset 'X'" / "run 'Y'" location phrase, and build the Sift Explore deep-link
-/// in one call. Used by every import subcommand so the wording and precedence
-/// stay uniform across formats.
 pub fn import_target(
     asset: &str,
     run_name: Option<&str>,
@@ -43,16 +35,8 @@ pub fn import_target(
     }
 }
 
-/// Resolve the Sift web app URL for link-rendering. Order of precedence:
-/// 1. The user's configured `app_uri` (whatever they set in their profile).
-/// 2. A built-in mapping for the standard SaaS hosts (`api.siftstack.com` and
-///    `gov.api.siftstack.com`). This mirrors the Python client's
-///    `_internal/urls.py` table so the two clients agree.
-/// 3. A plaintext-HTTP localhost rest_uri resolves to `http://localhost:3000` —
-///    the Sift local dev web app convention. Gated on `http://` so a
-///    `https://localhost` setup (non-standard) falls through to `None`.
-/// 4. `None` — non-standard `rest_uri` without `app_uri` set; the caller should
-///    surface a note pointing the user at the config.
+/// Resolve the Sift web app URL. The host table mirrors the Python client's
+/// `_internal/urls.py` — keep them in sync.
 pub fn resolve_app_uri(app_uri: Option<&str>, rest_uri: &str) -> Option<String> {
     if let Some(uri) = app_uri.map(str::trim).filter(|s| !s.is_empty()) {
         return Some(uri.to_string());
@@ -74,9 +58,6 @@ fn host_of(url: &str) -> Option<&str> {
     Some(host_with_port.split(':').next().unwrap_or(host_with_port))
 }
 
-/// Line appended to import-output tips: a `View in Sift: <url>` link when
-/// `explore_url` is present, or a note telling the user how to enable links
-/// when it isn't.
 pub fn explore_or_note(explore_url: Option<&str>) -> String {
     match explore_url {
         Some(url) => format!("\nView in Sift: {url}"),
@@ -86,10 +67,6 @@ pub fn explore_or_note(explore_url: Option<&str>) -> String {
     }
 }
 
-/// Tip text shown immediately after an import is uploaded but before the
-/// server-side job has finished processing. Appends either a `View in Sift`
-/// link or a "set `app_uri`" note via [`explore_or_note`]. Used by every
-/// import subcommand so the wording stays uniform across formats.
 pub fn pending_import_tip(location: &str, explore_url: Option<&str>) -> String {
     let mut tip =
         format!("Once processing is complete the data will be available on the {location}.");
@@ -97,14 +74,7 @@ pub fn pending_import_tip(location: &str, explore_url: Option<&str>) -> String {
     tip
 }
 
-/// Build a Sift Explore deep-link from the user-configured `app_uri`. Returns
-/// `None` when `app_uri` is unset or empty. Sift URLs are not deterministic
-/// from the API host (e.g. `gov.siftstack.com` pairs with
-/// `gov.api.siftstack.com`), so callers should pass the resolved web URL —
-/// see [`resolve_app_uri`].
-///
-/// `run` accepts either a run name or a run UUID; Sift Explore resolves both
-/// when passed as the `runs=` query value.
+/// `run` accepts a name or UUID; Sift Explore resolves both.
 pub fn build_explore_url(
     app_uri: Option<&str>,
     asset_name: &str,

--- a/rust/crates/sift_cli/src/util/mod.rs
+++ b/rust/crates/sift_cli/src/util/mod.rs
@@ -2,5 +2,6 @@ pub mod api;
 pub mod calculated_channel;
 pub mod channel;
 pub mod job;
+pub mod explore_url;
 pub mod progress;
 pub mod tty;

--- a/rust/crates/sift_cli/src/util/mod.rs
+++ b/rust/crates/sift_cli/src/util/mod.rs
@@ -1,7 +1,7 @@
 pub mod api;
 pub mod calculated_channel;
 pub mod channel;
-pub mod job;
 pub mod explore_url;
+pub mod job;
 pub mod progress;
 pub mod tty;

--- a/rust/crates/sift_cli/src/util/tty.rs
+++ b/rust/crates/sift_cli/src/util/tty.rs
@@ -3,6 +3,15 @@ use std::io::{self, Write};
 use anyhow::Result;
 use crossterm::style::Stylize;
 
+/// Wrap `label` in an OSC 8 hyperlink escape pointing at `url`, with cyan +
+/// underline styling so it still reads as a link in terminals that ignore
+/// OSC 8. Uses BEL (`\x07`) as the string terminator — more widely supported
+/// than the `ESC \` alternative.
+pub fn hyperlink(url: &str, label: &str) -> String {
+    let styled = label.cyan().underlined();
+    format!("\x1b]8;;{url}\x07{styled}\x1b]8;;\x07")
+}
+
 #[derive(Default)]
 pub struct PromptUser {
     header: Option<String>,

--- a/rust/crates/sift_cli/src/util/tty.rs
+++ b/rust/crates/sift_cli/src/util/tty.rs
@@ -3,15 +3,6 @@ use std::io::{self, Write};
 use anyhow::Result;
 use crossterm::style::Stylize;
 
-/// Wrap `label` in an OSC 8 hyperlink escape pointing at `url`, with cyan +
-/// underline styling so it still reads as a link in terminals that ignore
-/// OSC 8. Uses BEL (`\x07`) as the string terminator — more widely supported
-/// than the `ESC \` alternative.
-pub fn hyperlink(url: &str, label: &str) -> String {
-    let styled = label.cyan().underlined();
-    format!("\x1b]8;;{url}\x07{styled}\x1b]8;;\x07")
-}
-
 #[derive(Default)]
 pub struct PromptUser {
     header: Option<String>,


### PR DESCRIPTION
# Description
This PR adds functionality to build deep explore urls directly linking to the asset/run that the user just imported. 
Adds a section in the CLI config for users to input their web-uri to properly resolve links back to sift. Adds extra flow to config creation to handle optional `web_uri`. If users omit `web_uri` the CLI will not produce links and the agent will also surface no link to the user. Also adds a helper to help with url building, and percent encoding.

If a URL is provided in the config, that overrides and we use that. If not, we check their api and see if they are on prod or gov, if so we resolve the link to be on prod or gov. If not, we check and see if they are on dev and if so we resolve it to dev. Otherwise, we just provide no link and surface to the user why.

Note: If a `--run-id` is provided we will build the link using that. We follow the same idiomatic system that the CLI already follow: `--run-id` takes precedence over `--run`

Bundled with this PR is also:
- Skills for Claude to surface the link back to the user
- Fixes for service/explore_url that was assuming that urls are deterministic, so we can have the user include their web-url to adjust for on prem deployments and other web urls user can have
- Skill update so that the agent does not auto-swap profiles on failure and instead surfaces it to the user and asks what is best to do
- Adds `explore_url` param to `wait for completion` so that it can resolve the link on both `--wait` imports and non `--wait` imports

# Validation
- Manual imports and checking if links resolve
- Mass imports via MCP of all import types and ensuring it gets returned properly

**Local Host w/ web_uri in config**
<img width="1318" height="180" alt="Screenshot 2026-06-26 at 9 37 19 AM" src="https://github.com/user-attachments/assets/5ef7321d-fb39-4ce1-9561-70bbdaf8986f" />

**Dev Resolving**
<img width="722" height="223" alt="Screenshot 2026-06-26 at 9 45 40 AM" src="https://github.com/user-attachments/assets/1a5cd3cb-8317-4435-9b6d-0116f1ce95b3" />

**MCP Prompt**
<img width="419" height="132" alt="Screenshot 2026-06-26 at 10 16 41 AM" src="https://github.com/user-attachments/assets/081ae3f0-e0d9-48bd-a166-b7c7e6a5a1b7" />

**MCP Response**

```
All three imports completed on the dev profile.

- Parquet → asset `sample_parquet_flat`, run `sample_parquet_flat_run`
  https://app.development.siftstack.com/explore?method=single&assets=sample_parquet_flat&runs=sample_parquet_flat_run
- TDMS → asset `sift_example_tdms`, run `sift_example_tdms_run`
  https://app.development.siftstack.com/explore?method=single&assets=sift_example_tdms&runs=sift_example_tdms_run
- HDF5 → asset `test_1d_datasets`, run `test_1d_datasets_run` (schema `one-d`, time `absolute-unix-nanoseconds`)
  https://app.development.siftstack.com/explore?method=single&assets=test_1d_datasets&runs=test_1d_datasets_run
```
