### PR TITLE
rust(fix): Fix wording on update_asset

### DIFF
--- a/rust/crates/sift_mcp/src/tool/annotations/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/annotations/mod.rs
@@ -167,19 +167,22 @@ impl SiftMcpServer {
               - `state`: optional; one of `open`, `flagged`, `resolved`. MUST be omitted when `annotation_type`
                 is `phase` (the server rejects a phase annotation with a state).
               - `assets`: optional list of asset NAMES to associate.
-              - `tags`: optional list of tag names to associate.
+              - `tags`: optional list of tag names to associate. Names that do not yet exist are created.
               - `linked_channel_ids`: optional list of channel ids to link. Only plain channels are supported;
                 bit-field and calculated-channel links are not exposed here.
               - `run_id`: optional id of the run to associate.
               - `assign_to_user_id`: optional id of the user to assign the annotation to.
               - `metadata`: optional list of `{ \"name\": \"<key>\", \"value\": <scalar> }` entries; `value` is a
-                string, number, or boolean. The key must already exist in the organization's metadata schema.
+                string, number, or boolean. A `name` that does not yet exist in the organization's metadata
+                schema is created on the fly with type inferred from `value`; for an existing key, `value`'s
+                type must match the key's current type.
               - `organization_id`: optional. Required only when the caller belongs to multiple organizations.
 
             Errors:
               - `INVALID_PARAMS` if `name` is empty, the time range is inverted, `annotation_type`/`state` is not a
-                recognized value, or a `state` is supplied for a `phase` annotation.
-              - `INTERNAL_ERROR` for upstream gRPC failures (e.g. unknown metadata key, missing run/asset).
+                recognized value, a `state` is supplied for a `phase` annotation, the `metadata` list contains
+                duplicate key names, or a value's type does not match an existing metadata key's type.
+              - `INTERNAL_ERROR` for upstream gRPC failures (e.g. missing run/asset).
 
             Guidance:
               - This is a write. CONFIRM the time range, type, and associations with the user before invoking.

--- a/rust/crates/sift_mcp/src/tool/assets/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/assets/mod.rs
@@ -97,19 +97,20 @@ impl SiftMcpServer {
                 `asset_id == \"<id>\"` and send the union. Pass `[]` to clear all tags.
               - `metadata`: optional; REPLACES the asset's full metadata list. Each entry is
                 `{ \"name\": \"<key>\", \"value\": <scalar> }` where `value` is a string,
-                number, or boolean. Pass `[]` to clear. The key must already exist in the
-                organization's metadata schema (managed via the `metadata/v1` service); this
-                tool attaches values to existing keys, it does not create new keys.
+                number, or boolean. Pass `[]` to clear. A `name` that does not yet exist in
+                the organization's metadata schema is created on the fly with type inferred
+                from `value`; for an existing key, `value`'s type must match the key's
+                current type. Tag names that do not yet exist are likewise created.
 
               At least one of `tags` or `metadata` must be set; otherwise the update is a no-op
               and the tool returns `INVALID_PARAMS`.
 
             Errors:
-              - `INVALID_PARAMS` if `asset_id` is empty or neither `tags` nor `metadata` is
-                provided.
+              - `INVALID_PARAMS` if `asset_id` is empty, neither `tags` nor `metadata` is
+                provided, the `metadata` list contains duplicate key names, or a value's
+                type does not match an existing metadata key's type.
               - `RESOURCE_NOT_FOUND` if no asset matches `asset_id`.
-              - `INTERNAL_ERROR` for upstream gRPC failures (e.g. server rejecting a metadata
-                key that does not exist).
+              - `INTERNAL_ERROR` for upstream gRPC failures.
 
             Guidance:
               - This is a write. CONFIRM the target asset and the full proposed `tags` /

--- a/rust/crates/sift_mcp/src/tool/reports/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/reports/mod.rs
@@ -332,15 +332,18 @@ impl SiftMcpServer {
               - `report_id`: required; the id of the report to update.
               - `metadata`: required; REPLACES the report's full metadata list. Each entry is
                 `{ \"name\": \"<key>\", \"value\": <scalar> }` where `value` is a string, number, or boolean.
-                Pass `[]` to clear all metadata. The key must already exist in the organization's metadata schema.
+                Pass `[]` to clear all metadata. A `name` that does not yet exist in the organization's
+                metadata schema is created on the fly with type inferred from `value`; for an existing key,
+                `value`'s type must match the key's current type.
 
             Note: per the API, only `metadata` is updatable through this tool. Report name/description and the
             archive flow are not exposed here.
 
             Errors:
-              - `INVALID_PARAMS` if `report_id` is empty.
+              - `INVALID_PARAMS` if `report_id` is empty, the `metadata` list contains duplicate key names, or
+                a value's type does not match an existing metadata key's type.
               - `RESOURCE_NOT_FOUND` if no report matches `report_id`.
-              - `INTERNAL_ERROR` for upstream gRPC failures (e.g. unknown metadata key).
+              - `INTERNAL_ERROR` for upstream gRPC failures.
 
             Guidance:
               - This is a write with REPLACE semantics. CONFIRM the full metadata list with the user — for appends,


### PR DESCRIPTION
# Description
Fixes wording on update_asset to describe actual behavior.
Won't create new metadata/tags -> Will create new metadata/tags