### PR TITLE
rust(fix): add help tip for completions

### DIFF
--- a/rust/crates/sift_cli/src/cli/mod.rs
+++ b/rust/crates/sift_cli/src/cli/mod.rs
@@ -72,6 +72,7 @@ pub struct DocArgs {
 /// Install optional Sift tooling such as autocompletions or Agent skills
 #[derive(Subcommand)]
 pub enum InstallCmd {
+    /// Install or print shell completions for sift-cli
     #[command(subcommand)]
     Completions(CompletionsCmd),
 


### PR DESCRIPTION
# Description
Adds help tip for `sift-cli install -h` so it gives the tip for completions

# Verification
<img width="527" height="191" alt="Screenshot 2026-06-26 at 6 24 47 PM" src="https://github.com/user-attachments/assets/511f34c1-0596-4af4-99b5-d4d08f816b26" />
