### PR TITLE
rust(fix): fix clickable URL for sift-cli doc server

### DIFF
--- a/rust/crates/sift_cli/src/cmd/doc/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/doc/mod.rs
@@ -32,8 +32,6 @@ pub async fn serve(args: DocArgs) -> Result<ExitCode> {
     Ok(ExitCode::SUCCESS)
 }
 
-/// An unspecified bind address (`0.0.0.0` or `[::]`) isn't routable in a
-/// browser, so show `localhost`. An explicit address is shown as-is.
 fn doc_url(addr: SocketAddr) -> String {
     if addr.ip().is_unspecified() {
         format!("http://localhost:{}", addr.port())

--- a/rust/crates/sift_cli/src/cmd/doc/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/doc/mod.rs
@@ -1,7 +1,10 @@
+#[cfg(test)]
+mod tests;
+
 use anyhow::{Context, Result};
 use axum::Router;
 use include_dir::{Dir, include_dir};
-use std::process::ExitCode;
+use std::{net::SocketAddr, process::ExitCode};
 use tokio::net::TcpListener;
 use tower_serve_static::ServeDir;
 
@@ -20,11 +23,21 @@ pub async fn serve(args: DocArgs) -> Result<ExitCode> {
         .await
         .context("failed to bind socket address")?;
 
-    println!("documentation available at tcp://{addr}");
+    println!("documentation available at {}", doc_url(addr));
 
     axum::serve(ln, router)
         .await
         .context("server exited due to error")?;
 
     Ok(ExitCode::SUCCESS)
+}
+
+/// An unspecified bind address (`0.0.0.0` or `[::]`) isn't routable in a
+/// browser, so show `localhost`. An explicit address is shown as-is.
+fn doc_url(addr: SocketAddr) -> String {
+    if addr.ip().is_unspecified() {
+        format!("http://localhost:{}", addr.port())
+    } else {
+        format!("http://{addr}")
+    }
 }

--- a/rust/crates/sift_cli/src/cmd/doc/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/doc/tests.rs
@@ -1,0 +1,25 @@
+use std::net::SocketAddr;
+
+use crate::cmd::doc::doc_url;
+
+fn addr(s: &str) -> SocketAddr {
+    s.parse().expect("valid socket address")
+}
+
+#[test]
+fn unspecified_bind_prints_clickable_localhost_url() {
+    assert_eq!(doc_url(addr("0.0.0.0:3000")), "http://localhost:3000");
+}
+
+#[test]
+fn explicit_host_is_preserved() {
+    assert_eq!(
+        doc_url(addr("192.168.1.10:8080")),
+        "http://192.168.1.10:8080"
+    );
+}
+
+#[test]
+fn explicit_ipv6_host_is_bracketed() {
+    assert_eq!(doc_url(addr("[::1]:8080")), "http://[::1]:8080");
+}


### PR DESCRIPTION
`sift-cli doc` printed `documentation available at tcp://0.0.0.0:3000`, which is neither clickable nor routable in a browser. It now prints an `http://` URL and maps an unspecified bind address (`0.0.0.0` or `[::]`) to `localhost`. Explicit bind addresses are printed as-is.

**Test plan**

- Default response: `documentation available at http://localhost:3000`
- `sift-cli doc --addr 0.0.0.0:8123` prints `http://localhost:8123`; `--addr 127.0.0.1:8099` prints `http://127.0.0.1:8099`.
