### PR TITLE
rust(feat): soft approval gates on mcp calls

### DIFF
--- a/rust/crates/sift_mcp/CLAUDE.md
+++ b/rust/crates/sift_mcp/CLAUDE.md
@@ -46,7 +46,8 @@ Non-negotiables. These hold regardless of context pressure:
 3. Do not write retry logic anywhere except `policy::with_retry`. Call it; don't reinvent it.
 4. Set `read_only_hint` honestly. Read tools are `true`; anything that writes is `false`. Write
    tools must also set `destructive_hint` and `idempotent_hint` — see Step 4 for the mapping
-   (additive vs. update vs. state-flip).
+   (additive vs. update vs. state-flip). These fields follow the MCP tool annotations spec:
+   <https://modelcontextprotocol.io/specification/2025-11-25/server/tools>.
 5. Do not mirror the API one-to-one. Run Step 0 before writing anything.
 
 ---

--- a/rust/crates/sift_mcp/CLAUDE.md
+++ b/rust/crates/sift_mcp/CLAUDE.md
@@ -44,7 +44,9 @@ Non-negotiables. These hold regardless of context pressure:
    objects or enums. (See "Keep parameters flat" below for why.)
 2. Every service function gets a test. Testing tools and other code is encouraged.
 3. Do not write retry logic anywhere except `policy::with_retry`. Call it; don't reinvent it.
-4. Set `read_only_hint` honestly. Read tools are `true`; anything that writes is `false`.
+4. Set `read_only_hint` honestly. Read tools are `true`; anything that writes is `false`. Write
+   tools must also set `destructive_hint` and `idempotent_hint` — see Step 4 for the mapping
+   (additive vs. update vs. state-flip).
 5. Do not mirror the API one-to-one. Run Step 0 before writing anything.
 
 ---
@@ -245,7 +247,15 @@ pub async fn list_webhooks(&self, params: Parameters<ListParams>) -> error::McpR
 - Validate before calling the service. Return `ErrorData::invalid_params(...)` or
   `ErrorData::resource_not_found(...)` for bad input. `get_data` shows multi-field validation.
 - Always return `CallToolResult::structured(json!({ ... }))`.
-- Annotate: `annotations(title = "<domain>_router/<tool>", read_only_hint = <bool>)`.
+- Annotate: `annotations(title = "<domain>_router/<tool>", read_only_hint = <bool>, destructive_hint = <bool>, idempotent_hint = <bool>)`.
+  Read tools set `read_only_hint = true` and may omit the other two. Write tools set
+  `read_only_hint = false` and MUST set both `destructive_hint` and `idempotent_hint` honestly so
+  the calling client can render an accurate confirmation prompt:
+  - Additive writes (creates, ingest, append) → `destructive_hint = false`, `idempotent_hint = false`.
+  - Updates (mask-based or REPLACE-semantics) → `destructive_hint = true`, `idempotent_hint = true`.
+  - State flips (archive/unarchive) → `destructive_hint = true`, `idempotent_hint = true`.
+  The spec defaults `destructive_hint` to `true` when omitted, so being explicit on additive
+  writes is the only way to tell clients those are safe to surface with a softer prompt.
 - **`next_step`.** When the tool writes a file, opens a follow-on workflow, or performs a write,
   set both the structured `next_step` field and `result.content = vec![Content::text(next_step)]`
   so the calling agent sees it. `get_data` and `explore_url` are the reference patterns. Write
@@ -599,7 +609,8 @@ Run through this before declaring the tool done:
       services follow their own proto shape.
 - [ ] Description follows the five-section structure and the style rules. `list_*` descriptions
       match the current proto comments.
-- [ ] `read_only_hint` is correct. Write tools confirm the destination via `next_step`.
+- [ ] `read_only_hint` is correct, and write tools set `destructive_hint` / `idempotent_hint`
+      per the Step 4 mapping. Write tools confirm the destination via `next_step`.
 - [ ] Service registered in `server/mod.rs` and the router merged.
 - [ ] Service tests added, covering single page, pagination, `limit`, and an error path. A mock
       was added to `sift_test_util` if one did not exist.

--- a/rust/crates/sift_mcp/src/tool/annotations/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/annotations/mod.rs
@@ -187,7 +187,12 @@ impl SiftMcpServer {
             Guidance:
               - This is a write. CONFIRM the time range, type, and associations with the user before invoking.
         ",
-        annotations(title = "annotations_router/create_annotation", read_only_hint = false)
+        annotations(
+            title = "annotations_router/create_annotation",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+        )
     )]
     pub async fn create_annotation(
         &self,
@@ -308,7 +313,12 @@ impl SiftMcpServer {
               - For appends, read the current annotation via `list_annotations` filtered by
                 `annotation_id == \"<id>\"`, then send the union.
         ",
-        annotations(title = "annotations_router/update_annotation", read_only_hint = false)
+        annotations(
+            title = "annotations_router/update_annotation",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = true,
+        )
     )]
     pub async fn update_annotation(
         &self,

--- a/rust/crates/sift_mcp/src/tool/assets/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/assets/mod.rs
@@ -120,7 +120,12 @@ impl SiftMcpServer {
                 entry to the existing collection, then call this tool with the union.
               - The asset proto has no `description` field — there is no equivalent to update.
         ",
-        annotations(title = "assets_router/update_asset", read_only_hint = false)
+        annotations(
+            title = "assets_router/update_asset",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = true,
+        )
     )]
     pub async fn update_asset(&self, params: Parameters<UpdateAssetParams>) -> error::McpResult {
         let Parameters(UpdateAssetParams {

--- a/rust/crates/sift_mcp/src/tool/data/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/data/mod.rs
@@ -382,7 +382,12 @@ impl SiftMcpServer {
               - The tool does not return until the entire stream has been consumed by the server, so large
                 datasets translate to long-running calls.
         ",
-        annotations(title = "data_router/upload_dataset", read_only_hint = false)
+        annotations(
+            title = "data_router/upload_dataset",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+        )
     )]
     pub async fn upload_dataset(
         &self,

--- a/rust/crates/sift_mcp/src/tool/reports/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/reports/mod.rs
@@ -224,7 +224,12 @@ impl SiftMcpServer {
                 before invoking.
               - Use `list_report_rule_summaries` on the returned `report_id` to track per-rule progress.
         ",
-        annotations(title = "reports_router/create_report", read_only_hint = false)
+        annotations(
+            title = "reports_router/create_report",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+        )
     )]
     pub async fn create_report(&self, params: Parameters<CreateReportParams>) -> error::McpResult {
         let Parameters(CreateReportParams {
@@ -349,7 +354,12 @@ impl SiftMcpServer {
               - This is a write with REPLACE semantics. CONFIRM the full metadata list with the user — for appends,
                 read the current report via `list_reports` filtered by `report_id == \"<id>\"` and send the union.
         ",
-        annotations(title = "reports_router/update_report", read_only_hint = false)
+        annotations(
+            title = "reports_router/update_report",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = true,
+        )
     )]
     pub async fn update_report(&self, params: Parameters<UpdateReportParams>) -> error::McpResult {
         let Parameters(UpdateReportParams {

--- a/rust/crates/sift_mcp/src/tool/rules/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/rules/mod.rs
@@ -204,7 +204,12 @@ impl SiftMcpServer {
               - This creates a live resource. Confirm the rule's name, the target assets/tags, and the conditions
                 with the user before calling. Do not silently default them.
         ",
-        annotations(title = "rules_router/create_rule", read_only_hint = false)
+        annotations(
+            title = "rules_router/create_rule",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+        )
     )]
     pub async fn create_rule(&self, params: Parameters<RuleDefinitionParams>) -> error::McpResult {
         let Parameters(RuleDefinitionParams { rule_json }) = params;
@@ -270,7 +275,12 @@ impl SiftMcpServer {
                 conditions, metadata, and asset targeting are preserved automatically.
               - Confirm the intended changes with the user before calling.
         ",
-        annotations(title = "rules_router/update_rule", read_only_hint = false)
+        annotations(
+            title = "rules_router/update_rule",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = true,
+        )
     )]
     pub async fn update_rule(&self, params: Parameters<UpdateRuleParams>) -> error::McpResult {
         let Parameters(UpdateRuleParams {
@@ -359,7 +369,12 @@ impl SiftMcpServer {
               - Archiving stops live evaluation but does not delete the rule; it can be restored with
                 `unarchive_rule`. Confirm the target rule with the user before calling.
         ",
-        annotations(title = "rules_router/archive_rule", read_only_hint = false)
+        annotations(
+            title = "rules_router/archive_rule",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = true,
+        )
     )]
     pub async fn archive_rule(&self, params: Parameters<RuleArchiveParams>) -> error::McpResult {
         let Parameters(RuleArchiveParams {
@@ -413,7 +428,12 @@ impl SiftMcpServer {
             Guidance:
               - Confirm the target rule with the user before calling.
         ",
-        annotations(title = "rules_router/unarchive_rule", read_only_hint = false)
+        annotations(
+            title = "rules_router/unarchive_rule",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = true,
+        )
     )]
     pub async fn unarchive_rule(&self, params: Parameters<RuleArchiveParams>) -> error::McpResult {
         let Parameters(RuleArchiveParams {

--- a/rust/crates/sift_mcp/src/tool/runs/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/runs/mod.rs
@@ -125,7 +125,12 @@ impl SiftMcpServer {
                 the user before invoking; for appends, read the run via `list_runs` and send the union.
               - Note: `start_time` may be overwritten automatically if data is later ingested for this run.
         ",
-        annotations(title = "runs_router/update_run", read_only_hint = false)
+        annotations(
+            title = "runs_router/update_run",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = true,
+        )
     )]
     pub async fn update_run(&self, params: Parameters<UpdateRunParams>) -> error::McpResult {
         let Parameters(UpdateRunParams {

--- a/rust/crates/sift_mcp/src/tool/test_reports/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/test_reports/mod.rs
@@ -340,7 +340,9 @@ impl SiftMcpServer {
         ",
         annotations(
             title = "test_reports_router/create_test_report",
-            read_only_hint = false
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
         )
     )]
     pub async fn create_test_report(
@@ -415,7 +417,9 @@ impl SiftMcpServer {
         ",
         annotations(
             title = "test_reports_router/append_test_measurements",
-            read_only_hint = false
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
         )
     )]
     pub async fn append_test_measurements(


### PR DESCRIPTION
# Description
Uses the destructive flag on tools that are destructive actions. This flag is read by the harness and makes sure to ask the user if they want to make the tool call, assuming the client honors the hints. If the user has YOLO mode on, or has already selected "accept all tool calls like this" options when using the mcp this prompt will be skipped. 

This acts as a soft approval wall, which the user can bypass if they decide to. The way these prompts are shown to the user depends on the harness they are using, and may look different across different agents.

Note: This is closer to hints as outlined in the [MCP tool spec](https://modelcontextprotocol.io/specification/2025-11-25/server/tools)

# Validation
Soft confirmation on `list_assets`
<img width="932" height="411" alt="Screenshot 2026-07-01 at 11 48 41 AM" src="https://github.com/user-attachments/assets/e10fb630-7a8a-4d15-9709-098978cd8498" />
Tool confirmation on imports
<img width="984" height="347" alt="Screenshot 2026-07-01 at 12 10 27 PM" src="https://github.com/user-attachments/assets/c13260e2-22eb-4765-bdff-63528eab1d7d" />
Annotation confirmation
<img width="987" height="623" alt="Screenshot 2026-07-01 at 12 30 14 PM" src="https://github.com/user-attachments/assets/8f3361d5-aef3-4dca-97f4-9dad76c27b22" />
Updating tags on an asset
<img width="993" height="480" alt="Screenshot 2026-07-01 at 12 33 40 PM" src="https://github.com/user-attachments/assets/665c2b9a-8209-4537-a194-f6793f5a42b2" />

