### PR TITLE
rust(feat): Remove _router wording

### DIFF
--- a/rust/crates/sift_mcp/CLAUDE.md
+++ b/rust/crates/sift_mcp/CLAUDE.md
@@ -248,7 +248,7 @@ pub async fn list_webhooks(&self, params: Parameters<ListParams>) -> error::McpR
 - Validate before calling the service. Return `ErrorData::invalid_params(...)` or
   `ErrorData::resource_not_found(...)` for bad input. `get_data` shows multi-field validation.
 - Always return `CallToolResult::structured(json!({ ... }))`.
-- Annotate: `annotations(title = "<domain>_router/<tool>", read_only_hint = <bool>, destructive_hint = <bool>, idempotent_hint = <bool>)`.
+- Annotate: `annotations(title = "<domain>/<tool>", read_only_hint = <bool>, destructive_hint = <bool>, idempotent_hint = <bool>)`.
   Read tools set `read_only_hint = true` and may omit the other two. Write tools set
   `read_only_hint = false` and MUST set both `destructive_hint` and `idempotent_hint` honestly so
   the calling client can render an accurate confirmation prompt:

--- a/rust/crates/sift_mcp/src/server/mod.rs
+++ b/rust/crates/sift_mcp/src/server/mod.rs
@@ -1,8 +1,11 @@
 use rmcp::{
-    RoleServer, ServerHandler,
+    ErrorData, RoleServer, ServerHandler,
     handler::server::router::prompt::PromptRouter,
     handler::server::tool::ToolRouter,
-    model::{GetPromptRequestParams, GetPromptResult, ListPromptsResult, PaginatedRequestParams},
+    model::{
+        GetPromptRequestParams, GetPromptResult, ListPromptsResult, ListToolsResult,
+        PaginatedRequestParams,
+    },
     prompt_handler,
     service::RequestContext,
     tool_handler,
@@ -43,7 +46,38 @@ pub struct SiftMcpServer {
     instructions = "Sift MCP Server",
 )]
 #[prompt_handler(router = self.prompt_router)]
-impl ServerHandler for SiftMcpServer {}
+impl ServerHandler for SiftMcpServer {
+    // Override rmcp's default `list_tools` (which sorts by tool `name`) so
+    // tools group by domain in `tools/list`. Because our titles are
+    // `<domain>/<tool>`, sorting by title alphabetically clusters all tools
+    // of the same domain together. Falls back to `name` for any tool that
+    // omits a title.
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        let mut tools = self.tool_router.list_all();
+        tools.sort_by(|a, b| {
+            let a_key: &str = a
+                .annotations
+                .as_ref()
+                .and_then(|ann| ann.title.as_deref())
+                .unwrap_or(a.name.as_ref());
+            let b_key: &str = b
+                .annotations
+                .as_ref()
+                .and_then(|ann| ann.title.as_deref())
+                .unwrap_or(b.name.as_ref());
+            a_key.cmp(b_key)
+        });
+        Ok(ListToolsResult {
+            tools,
+            meta: None,
+            next_cursor: None,
+        })
+    }
+}
 
 impl SiftMcpServer {
     pub fn new(channel: SiftChannel, rest_uri: String) -> Self {

--- a/rust/crates/sift_mcp/src/server/mod.rs
+++ b/rust/crates/sift_mcp/src/server/mod.rs
@@ -47,11 +47,6 @@ pub struct SiftMcpServer {
 )]
 #[prompt_handler(router = self.prompt_router)]
 impl ServerHandler for SiftMcpServer {
-    // Override rmcp's default `list_tools` (which sorts by tool `name`) so
-    // tools group by domain in `tools/list`. Because our titles are
-    // `<domain>/<tool>`, sorting by title alphabetically clusters all tools
-    // of the same domain together. Falls back to `name` for any tool that
-    // omits a title.
     async fn list_tools(
         &self,
         _request: Option<PaginatedRequestParams>,

--- a/rust/crates/sift_mcp/src/tool/annotations/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/annotations/mod.rs
@@ -119,7 +119,7 @@ impl SiftMcpServer {
               - Narrow with `run_id == \"...\"` or `asset_id == \"...\"` when known — those are the most selective.
               - Use `is_archived == false` to exclude archived annotations unless they're explicitly needed.
         ",
-        annotations(title = "annotations_router/list_annotations", read_only_hint = true)
+        annotations(title = "annotations/list_annotations", read_only_hint = true)
     )]
     pub async fn list_annotations(
         &self,
@@ -188,7 +188,7 @@ impl SiftMcpServer {
               - This is a write. CONFIRM the time range, type, and associations with the user before invoking.
         ",
         annotations(
-            title = "annotations_router/create_annotation",
+            title = "annotations/create_annotation",
             read_only_hint = false,
             destructive_hint = false,
             idempotent_hint = false,
@@ -314,7 +314,7 @@ impl SiftMcpServer {
                 `annotation_id == \"<id>\"`, then send the union.
         ",
         annotations(
-            title = "annotations_router/update_annotation",
+            title = "annotations/update_annotation",
             read_only_hint = false,
             destructive_hint = true,
             idempotent_hint = true,

--- a/rust/crates/sift_mcp/src/tool/assets/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/assets/mod.rs
@@ -56,7 +56,7 @@ impl SiftMcpServer {
               - Always prefer narrowing the filter over relying on `limit` — very large unfiltered listings can be slow.
               - Use `is_archived == false` to exclude archived assets unless they're explicitly needed.
         ",
-        annotations(title = "assets_router/list_assets", read_only_hint = true)
+        annotations(title = "assets/list_assets", read_only_hint = true)
     )]
     pub async fn list_assets(&self, params: Parameters<ListParams>) -> error::McpResult {
         let Parameters(ListParams {
@@ -121,7 +121,7 @@ impl SiftMcpServer {
               - The asset proto has no `description` field — there is no equivalent to update.
         ",
         annotations(
-            title = "assets_router/update_asset",
+            title = "assets/update_asset",
             read_only_hint = false,
             destructive_hint = true,
             idempotent_hint = true,

--- a/rust/crates/sift_mcp/src/tool/channels/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/channels/mod.rs
@@ -40,7 +40,7 @@ impl SiftMcpServer {
                 and unscoped queries return cross-asset results.
               - To enumerate channels recorded by a specific run, filter on `run_id` rather than joining client-side.
         ",
-        annotations(title = "channels_router/list_channels", read_only_hint = true)
+        annotations(title = "channels/list_channels", read_only_hint = true)
     )]
     pub async fn list_channels(&self, params: Parameters<ListParams>) -> error::McpResult {
         let Parameters(ListParams {

--- a/rust/crates/sift_mcp/src/tool/data/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/data/mod.rs
@@ -98,7 +98,7 @@ impl SiftMcpServer {
               - After a successful call, if the user hasn't already indicated a next step, offer to run a SQL query
                 against the resulting Parquet file using the `sql` tool.
         ",
-        annotations(title = "data_router/get_data", read_only_hint = true)
+        annotations(title = "data/get_data", read_only_hint = true)
     )]
     pub async fn get_data(&self, params: Parameters<GetDataParams>) -> error::McpResult {
         let Parameters(GetDataParams {
@@ -290,7 +290,7 @@ impl SiftMcpServer {
                 `timestamp_unix_nanos` — bucket on it (e.g. group by a time expression derived from it) or pick a
                 representative via `MIN(timestamp_unix_nanos)`.
         ",
-        annotations(title = "data_router/sql", read_only_hint = true)
+        annotations(title = "data/sql", read_only_hint = true)
     )]
     pub async fn sql(&self, params: Parameters<SqlParams>) -> error::McpResult {
         let Parameters(SqlParams {
@@ -383,7 +383,7 @@ impl SiftMcpServer {
                 datasets translate to long-running calls.
         ",
         annotations(
-            title = "data_router/upload_dataset",
+            title = "data/upload_dataset",
             read_only_hint = false,
             destructive_hint = false,
             idempotent_hint = false,

--- a/rust/crates/sift_mcp/src/tool/docs/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/docs/mod.rs
@@ -64,7 +64,7 @@ impl SiftMcpServer {
                 service rejects the request.
               - `RESOURCE_NOT_FOUND` if `path` does not match a doc page.
         ",
-        annotations(title = "docs_router/search_docs", read_only_hint = true)
+        annotations(title = "docs/search_docs", read_only_hint = true)
     )]
     pub async fn search_docs(&self, params: Parameters<SearchDocsParams>) -> error::McpResult {
         let Parameters(SearchDocsParams {

--- a/rust/crates/sift_mcp/src/tool/explore/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/explore/mod.rs
@@ -61,7 +61,7 @@ impl SiftMcpServer {
               - The tool does not validate that the named asset/run/channel exists — Explore resolves at page
                 load. Use names you have already retrieved from `list_*` tools to avoid 404s on click.
         ",
-        annotations(title = "explore_router/explore_url", read_only_hint = true)
+        annotations(title = "explore/explore_url", read_only_hint = true)
     )]
     pub async fn explore_url(&self, params: Parameters<ExploreUrlParams>) -> error::McpResult {
         let Parameters(ExploreUrlParams {

--- a/rust/crates/sift_mcp/src/tool/ping/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/ping/mod.rs
@@ -37,7 +37,7 @@ impl SiftMcpServer {
               - Useful as a connectivity smoke check. If `ping` fails, the broader Sift toolset is
                 likely also failing — surface that to the user instead of attempting other tools.
         ",
-        annotations(title = "ping_router/ping", read_only_hint = true)
+        annotations(title = "ping/ping", read_only_hint = true)
     )]
     pub async fn ping(&self, _params: Parameters<PingParams>) -> error::McpResult {
         let out = self

--- a/rust/crates/sift_mcp/src/tool/reports/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/reports/mod.rs
@@ -90,7 +90,7 @@ impl SiftMcpServer {
               - Use `is_archived == false` to exclude archived reports unless they're explicitly needed.
               - Order by `created_date desc` when surfacing the most recent reports to a user.
         ",
-        annotations(title = "reports_router/list_reports", read_only_hint = true)
+        annotations(title = "reports/list_reports", read_only_hint = true)
     )]
     pub async fn list_reports(&self, params: Parameters<ReportListParams>) -> error::McpResult {
         let Parameters(ReportListParams {
@@ -146,7 +146,7 @@ impl SiftMcpServer {
               - Filter by `status` (e.g. `status == \"REPORT_RULE_STATUS_FAILED\"`) to surface only failing rules.
         ",
         annotations(
-            title = "reports_router/list_report_rule_summaries",
+            title = "reports/list_report_rule_summaries",
             read_only_hint = true
         )
     )]
@@ -225,7 +225,7 @@ impl SiftMcpServer {
               - Use `list_report_rule_summaries` on the returned `report_id` to track per-rule progress.
         ",
         annotations(
-            title = "reports_router/create_report",
+            title = "reports/create_report",
             read_only_hint = false,
             destructive_hint = false,
             idempotent_hint = false,
@@ -355,7 +355,7 @@ impl SiftMcpServer {
                 read the current report via `list_reports` filtered by `report_id == \"<id>\"` and send the union.
         ",
         annotations(
-            title = "reports_router/update_report",
+            title = "reports/update_report",
             read_only_hint = false,
             destructive_hint = true,
             idempotent_hint = true,

--- a/rust/crates/sift_mcp/src/tool/reports/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/reports/mod.rs
@@ -145,10 +145,7 @@ impl SiftMcpServer {
               - Use this to drill into why a report passed or failed after locating it with `list_reports`.
               - Filter by `status` (e.g. `status == \"REPORT_RULE_STATUS_FAILED\"`) to surface only failing rules.
         ",
-        annotations(
-            title = "reports/list_report_rule_summaries",
-            read_only_hint = true
-        )
+        annotations(title = "reports/list_report_rule_summaries", read_only_hint = true)
     )]
     pub async fn list_report_rule_summaries(
         &self,

--- a/rust/crates/sift_mcp/src/tool/rules/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/rules/mod.rs
@@ -86,7 +86,7 @@ impl SiftMcpServer {
               - Use `is_archived == false` to exclude archived rules unless they're explicitly needed.
               - Use `is_live_evaluation_enabled == true` to find only rules that run against live data.
         ",
-        annotations(title = "rules_router/list_rules", read_only_hint = true)
+        annotations(title = "rules/list_rules", read_only_hint = true)
     )]
     pub async fn list_rules(&self, params: Parameters<ListParams>) -> error::McpResult {
         let Parameters(ListParams {
@@ -136,7 +136,7 @@ impl SiftMcpServer {
                 inspecting or referencing that version. Resolve the `rule_id` with `list_rules` first if you only
                 have the rule name.
         ",
-        annotations(title = "rules_router/list_rule_versions", read_only_hint = true)
+        annotations(title = "rules/list_rule_versions", read_only_hint = true)
     )]
     pub async fn list_rule_versions(
         &self,
@@ -205,7 +205,7 @@ impl SiftMcpServer {
                 with the user before calling. Do not silently default them.
         ",
         annotations(
-            title = "rules_router/create_rule",
+            title = "rules/create_rule",
             read_only_hint = false,
             destructive_hint = false,
             idempotent_hint = false,
@@ -276,7 +276,7 @@ impl SiftMcpServer {
               - Confirm the intended changes with the user before calling.
         ",
         annotations(
-            title = "rules_router/update_rule",
+            title = "rules/update_rule",
             read_only_hint = false,
             destructive_hint = true,
             idempotent_hint = true,
@@ -370,7 +370,7 @@ impl SiftMcpServer {
                 `unarchive_rule`. Confirm the target rule with the user before calling.
         ",
         annotations(
-            title = "rules_router/archive_rule",
+            title = "rules/archive_rule",
             read_only_hint = false,
             destructive_hint = true,
             idempotent_hint = true,
@@ -429,7 +429,7 @@ impl SiftMcpServer {
               - Confirm the target rule with the user before calling.
         ",
         annotations(
-            title = "rules_router/unarchive_rule",
+            title = "rules/unarchive_rule",
             read_only_hint = false,
             destructive_hint = true,
             idempotent_hint = true,

--- a/rust/crates/sift_mcp/src/tool/runs/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/runs/mod.rs
@@ -69,7 +69,7 @@ impl SiftMcpServer {
                 pulling everything and filtering client-side.
               - Order by `start_time desc` when surfacing the most recent runs to a user.
         ",
-        annotations(title = "runs_router/list_runs", read_only_hint = true)
+        annotations(title = "runs/list_runs", read_only_hint = true)
     )]
     pub async fn list_runs(&self, params: Parameters<ListParams>) -> error::McpResult {
         let Parameters(ListParams {
@@ -126,7 +126,7 @@ impl SiftMcpServer {
               - Note: `start_time` may be overwritten automatically if data is later ingested for this run.
         ",
         annotations(
-            title = "runs_router/update_run",
+            title = "runs/update_run",
             read_only_hint = false,
             destructive_hint = true,
             idempotent_hint = true,

--- a/rust/crates/sift_mcp/src/tool/test_reports/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/test_reports/mod.rs
@@ -80,7 +80,7 @@ impl SiftMcpServer {
               - To audit a single run, resolve the report first (by `name`, `run_id`, or `test_case`), then pass
                 its `test_report_id` to the step and measurement tools.
         ",
-        annotations(title = "test_reports_router/list_test_reports", read_only_hint = true)
+        annotations(title = "test_reports/list_test_reports", read_only_hint = true)
     )]
     pub async fn list_test_reports(&self, params: Parameters<ListParams>) -> error::McpResult {
         let Parameters(ListParams {
@@ -136,7 +136,7 @@ impl SiftMcpServer {
               - To find failures, filter `test_report_id == \"...\" && status == TEST_STATUS_FAILED`.
               - Order by `step_path` to reconstruct the execution tree; use `parent_step_id` to attach children.
         ",
-        annotations(title = "test_reports_router/list_test_steps", read_only_hint = true)
+        annotations(title = "test_reports/list_test_steps", read_only_hint = true)
     )]
     pub async fn list_test_steps(&self, params: Parameters<ListParams>) -> error::McpResult {
         let Parameters(ListParams {
@@ -194,7 +194,7 @@ impl SiftMcpServer {
                 `numeric_bounds`/`string_bounds`.
         ",
         annotations(
-            title = "test_reports_router/list_test_measurements",
+            title = "test_reports/list_test_measurements",
             read_only_hint = true
         )
     )]
@@ -235,7 +235,7 @@ impl SiftMcpServer {
               - `INVALID_PARAMS` if `filter` is not a valid CEL expression.
               - `INTERNAL_ERROR` for upstream gRPC failures.
         ",
-        annotations(title = "test_reports_router/count_test_steps", read_only_hint = true)
+        annotations(title = "test_reports/count_test_steps", read_only_hint = true)
     )]
     pub async fn count_test_steps(&self, params: Parameters<CountParams>) -> error::McpResult {
         let Parameters(CountParams { filter }) = params;
@@ -271,7 +271,7 @@ impl SiftMcpServer {
               - `INTERNAL_ERROR` for upstream gRPC failures.
         ",
         annotations(
-            title = "test_reports_router/count_test_measurements",
+            title = "test_reports/count_test_measurements",
             read_only_hint = true
         )
     )]
@@ -339,7 +339,7 @@ impl SiftMcpServer {
                 `test_report_id`. Verify with `list_test_steps` (filter `test_report_id == \"...\"`).
         ",
         annotations(
-            title = "test_reports_router/create_test_report",
+            title = "test_reports/create_test_report",
             read_only_hint = false,
             destructive_hint = false,
             idempotent_hint = false,
@@ -416,7 +416,7 @@ impl SiftMcpServer {
               - `INTERNAL_ERROR` for upstream gRPC failures.
         ",
         annotations(
-            title = "test_reports_router/append_test_measurements",
+            title = "test_reports/append_test_measurements",
             read_only_hint = false,
             destructive_hint = false,
             idempotent_hint = false,

--- a/rust/crates/sift_mcp/src/tool/test_reports/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/test_reports/mod.rs
@@ -193,10 +193,7 @@ impl SiftMcpServer {
               - To audit limit checks, filter `passed == false` within a report and compare each value against its
                 `numeric_bounds`/`string_bounds`.
         ",
-        annotations(
-            title = "test_reports/list_test_measurements",
-            read_only_hint = true
-        )
+        annotations(title = "test_reports/list_test_measurements", read_only_hint = true)
     )]
     pub async fn list_test_measurements(&self, params: Parameters<ListParams>) -> error::McpResult {
         let Parameters(ListParams {
@@ -270,10 +267,7 @@ impl SiftMcpServer {
               - `INVALID_PARAMS` if `filter` is not a valid CEL expression.
               - `INTERNAL_ERROR` for upstream gRPC failures.
         ",
-        annotations(
-            title = "test_reports/count_test_measurements",
-            read_only_hint = true
-        )
+        annotations(title = "test_reports/count_test_measurements", read_only_hint = true)
     )]
     pub async fn count_test_measurements(
         &self,


### PR DESCRIPTION
# Description
Removes `_router` wording on tools to make it more human readable.

Only changes the visual string, the underlying functions still read as `*_router`. 

Also now sorts tools by domain

# Verification

https://github.com/user-attachments/assets/92ed122a-c99b-46a1-a561-1ce9d2277244