### PR TITLE
python(fix): build offline archives with all extra

### DIFF
--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -123,15 +123,12 @@ jobs:
         working-directory: python
         shell: bash
         run: |
-          # Generate requirements file with all extras
+          # Generate requirements file with all extras. The "all" extra is
+          # auto-generated from [tool.sift.extras] and is a superset of every
+          # runtime extra, so new extras are picked up without editing this list.
           pip-compile pyproject.toml \
+          --extra all \
           --extra build \
-          --extra data_review \
-          --extra tdms \
-          --extra hdf5 \
-          --extra sift-stream \
-          --extra rosbags \
-          --extra openssl \
           -o requirements-all.txt
 
       - name: Build dependency wheels


### PR DESCRIPTION
## Summary

The offline archive workflow hardcodes the extras to download and was missing `ulog` from #663, while the install test discovers extras from wheel metadata and asked for `pyulog`. 

Adds `--extra all --extra build` instead, so future extras are picked up automatically.

## Test plan

- `pip-compile pyproject.toml --extra all --extra build -o requirements-all.txt` resolves and includes `pyulog` plus everything the previous list covered
- Ran the Offline Installation Archive workflow on this branch, all legs pass