### PR TITLE
rust(chore): remove linux arm64

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -12,7 +12,7 @@ tag-namespace = "sift_cli-v"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program


### PR DESCRIPTION
# Description

Seeing how the current release process breaks with linux arm64 as a target, removing temporarily.