### PR TITLE
rust(feat): mcp gate destructive flag

### DIFF
--- a/rust/crates/sift_cli/assets/docs/src/agents/mcp.md
+++ b/rust/crates/sift_cli/assets/docs/src/agents/mcp.md
@@ -28,6 +28,22 @@ sift-cli --profile mission mcp
 The server communicates over stdio and is meant to be launched by an MCP client,
 not run interactively.
 
+## Destructive tools
+
+Tools that modify existing state (`update_asset`, `update_run`, `update_report`,
+`update_annotation`, `update_rule`, `archive_rule`, `unarchive_rule`) are
+disabled by default. Calling one returns an error telling the agent that the
+server must be relaunched with `--allow-destructive`:
+
+```sh
+sift-cli mcp --allow-destructive
+```
+
+Additive writes (`create_annotation`, `create_report`, `create_rule`,
+`create_test_report`, `append_test_measurements`, `upload_dataset`) remain
+available without the flag. Update your MCP client config to include the flag
+if you want the agent to be able to modify or archive existing resources.
+
 ## Available tools
 
 | Tool             | Purpose                                                                       |

--- a/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
+++ b/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
@@ -41,6 +41,10 @@ to combine them when working with Sift.
    - `create_annotation`, `update_annotation`: manage annotations (writes —
      collections use replace semantics, so confirm the change first).
    - `create_report`, `update_report`: manage reports (writes — confirm first).
+   - Destructive tools (`update_*`, `archive_*`, `unarchive_*`) are gated on
+     `--allow-destructive`. If one errors with a message about the flag, tell
+     the user to relaunch the server with `sift-cli mcp --allow-destructive`
+     (and update their MCP client config) before retrying.
    - `explore_url`: build a Sift Explore deep-link for an asset/run/channel
      selection, with an optional panel/chart pre-defined. Surface the URL to
      the user as plain text, in full, so the user can open the view. Do not

--- a/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
@@ -57,6 +57,10 @@ to combine them when working with Sift.
    - `create_annotation`, `update_annotation`: manage annotations (writes —
      collections use replace semantics, so confirm the change first).
    - `create_report`, `update_report`: manage reports (writes — confirm first).
+   - Destructive tools (`update_*`, `archive_*`, `unarchive_*`) are gated on
+     `--allow-destructive`. If one errors with a message about the flag, tell
+     the user to relaunch the server with `sift-cli mcp --allow-destructive`
+     (and update their MCP client config) before retrying.
    - `explore_url`: build a Sift Explore deep-link for an asset/run/channel
      selection, with an optional panel/chart pre-defined. Surface the URL to
      the user as plain text, in full, so the user can open the view. Do not

--- a/rust/crates/sift_cli/src/cli/mod.rs
+++ b/rust/crates/sift_cli/src/cli/mod.rs
@@ -66,7 +66,17 @@ pub enum Cmd {
     /// Start the Sift MCP server
     #[cfg(feature = "mcp")]
     #[command(hide = true)]
-    Mcp,
+    Mcp(McpArgs),
+}
+
+#[cfg(feature = "mcp")]
+#[derive(clap::Args)]
+pub struct McpArgs {
+    /// Expose destructive tools (updates, archives, restores). When omitted,
+    /// destructive tool calls return an error instructing the caller to
+    /// relaunch the server with this flag.
+    #[arg(long)]
+    pub allow_destructive: bool,
 }
 
 /// Serve the bundled Sift CLI user documentation over HTTP.

--- a/rust/crates/sift_cli/src/cmd/mcp.rs
+++ b/rust/crates/sift_cli/src/cmd/mcp.rs
@@ -3,14 +3,22 @@ use std::process::ExitCode;
 use anyhow::Result;
 use sift_rs::Credentials;
 
+use crate::cli::McpArgs;
 use crate::cmd::Context;
 
-pub async fn run(ctx: Context) -> Result<ExitCode> {
+pub async fn run(ctx: Context, args: McpArgs) -> Result<ExitCode> {
     let credentials = Credentials::Config {
         uri: ctx.grpc_uri,
         apikey: ctx.api_key,
     };
-    match sift_mcp::run(credentials, !ctx.disable_tls, ctx.rest_uri).await {
+    match sift_mcp::run(
+        credentials,
+        !ctx.disable_tls,
+        ctx.rest_uri,
+        args.allow_destructive,
+    )
+    .await
+    {
         Ok(_) => Ok(ExitCode::SUCCESS),
         Err(err) => Err(err),
     }

--- a/rust/crates/sift_cli/src/main.rs
+++ b/rust/crates/sift_cli/src/main.rs
@@ -88,8 +88,8 @@ fn run(clargs: cli::Args) -> Result<ExitCode> {
 
     // Mcp Server
     #[cfg(feature = "mcp")]
-    if let Cmd::Mcp = cmd {
-        return run_future_mt(cmd::mcp::run(ctx));
+    if let Cmd::Mcp(args) = cmd {
+        return run_future_mt(cmd::mcp::run(ctx, args));
     }
 
     let profile = clargs

--- a/rust/crates/sift_mcp/CLAUDE.md
+++ b/rust/crates/sift_mcp/CLAUDE.md
@@ -48,7 +48,11 @@ Non-negotiables. These hold regardless of context pressure:
    tools must also set `destructive_hint` and `idempotent_hint` — see Step 4 for the mapping
    (additive vs. update vs. state-flip). These fields follow the MCP tool annotations spec:
    <https://modelcontextprotocol.io/specification/2025-11-25/server/tools>.
-5. Do not mirror the API one-to-one. Run Step 0 before writing anything.
+5. Every tool with `destructive_hint = true` MUST call `self.require_destructive()?` as the
+   first line of its handler. The server is launched without destructive tools by default; the
+   gate returns an `INVALID_REQUEST` telling the caller to relaunch with `--allow-destructive`.
+   Skipping this call ships a destructive tool that is always on and bypasses the flag.
+6. Do not mirror the API one-to-one. Run Step 0 before writing anything.
 
 ---
 
@@ -247,6 +251,11 @@ pub async fn list_webhooks(&self, params: Parameters<ListParams>) -> error::McpR
 
 - Validate before calling the service. Return `ErrorData::invalid_params(...)` or
   `ErrorData::resource_not_found(...)` for bad input. `get_data` shows multi-field validation.
+- **Gate destructive handlers.** If the tool sets `destructive_hint = true`, call
+  `self.require_destructive()?` as the FIRST line of the handler — before parameter
+  destructuring, validation, or any service call. The gate returns an `INVALID_REQUEST` when
+  the server was launched without `--allow-destructive`, so no gRPC traffic and no partial
+  work occurs when the flag is off. `tool/assets/mod.rs::update_asset` is the reference.
 - Always return `CallToolResult::structured(json!({ ... }))`.
 - Annotate: `annotations(title = "<domain>/<tool>", read_only_hint = <bool>, destructive_hint = <bool>, idempotent_hint = <bool>)`.
   Read tools set `read_only_hint = true` and may omit the other two. Write tools set
@@ -612,6 +621,10 @@ Run through this before declaring the tool done:
       match the current proto comments.
 - [ ] `read_only_hint` is correct, and write tools set `destructive_hint` / `idempotent_hint`
       per the Step 4 mapping. Write tools confirm the destination via `next_step`.
+- [ ] Every handler with `destructive_hint = true` calls `self.require_destructive()?` as its
+      first line, and has a test that asserts the gate returns `INVALID_REQUEST` when the
+      server is constructed with `allow_destructive = false`. See
+      `tool/assets/test.rs::update_asset_blocked_without_allow_destructive`.
 - [ ] Service registered in `server/mod.rs` and the router merged.
 - [ ] Service tests added, covering single page, pagination, `limit`, and an error path. A mock
       was added to `sift_test_util` if one did not exist.

--- a/rust/crates/sift_mcp/src/lib.rs
+++ b/rust/crates/sift_mcp/src/lib.rs
@@ -12,14 +12,19 @@ mod prompt;
 mod service;
 mod tool;
 
-pub async fn run(credentials: Credentials, use_tls: bool, rest_uri: String) -> Result<()> {
+pub async fn run(
+    credentials: Credentials,
+    use_tls: bool,
+    rest_uri: String,
+    allow_destructive: bool,
+) -> Result<()> {
     let channel = SiftChannelBuilder::new(credentials)
         .use_tls(use_tls)
         .user_agent(format!("{}/{}", crate_name!(), crate_version!()))
         .build()
         .context("failed to build gRPC channel to connect to Sift")?;
 
-    let service = SiftMcpServer::new(channel, rest_uri)
+    let service = SiftMcpServer::new(channel, rest_uri, allow_destructive)
         .serve(stdio())
         .await
         .context("failed to start MCP server")?;

--- a/rust/crates/sift_mcp/src/server/mod.rs
+++ b/rust/crates/sift_mcp/src/server/mod.rs
@@ -37,6 +37,8 @@ pub struct SiftMcpServer {
     pub rule_service: RuleService,
     pub test_report_service: TestReportService,
     pub docs_service: DocsService,
+
+    pub allow_destructive: bool,
 }
 
 #[tool_handler(
@@ -75,7 +77,7 @@ impl ServerHandler for SiftMcpServer {
 }
 
 impl SiftMcpServer {
-    pub fn new(channel: SiftChannel, rest_uri: String) -> Self {
+    pub fn new(channel: SiftChannel, rest_uri: String, allow_destructive: bool) -> Self {
         // Add more routers here as new tool groups are introduced, e.g.
         //   tool_router.merge(Self::ingestion_router())
         let mut tool_router = Self::assets_router();
@@ -122,6 +124,27 @@ impl SiftMcpServer {
             docs_service,
             tool_router,
             prompt_router,
+            allow_destructive,
         }
+    }
+
+    /// Gate for destructive tool handlers. Returns an error the calling agent
+    /// can relay to the user when the server was launched without
+    /// `--allow-destructive`.
+    pub(crate) fn require_destructive(&self) -> Result<(), ErrorData> {
+        if self.allow_destructive {
+            return Ok(());
+        }
+        Err(ErrorData::invalid_request(
+            "This tool is destructive and is disabled. Ask the user to relaunch \
+             the Sift MCP server with the `--allow-destructive` flag (e.g. \
+             `sift-cli mcp --allow-destructive`) and update their MCP client \
+             config accordingly. Do not retry until they confirm the server has \
+             been restarted.",
+            Some(serde_json::json!({
+                "status": "stopped",
+                "reason": "DestructiveToolsDisabled",
+            })),
+        ))
     }
 }

--- a/rust/crates/sift_mcp/src/tool/annotations/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/annotations/mod.rs
@@ -324,6 +324,8 @@ impl SiftMcpServer {
         &self,
         params: Parameters<UpdateAnnotationParams>,
     ) -> error::McpResult {
+        self.require_destructive()?;
+
         let Parameters(UpdateAnnotationParams {
             annotation_id,
             name,

--- a/rust/crates/sift_mcp/src/tool/annotations/test.rs
+++ b/rust/crates/sift_mcp/src/tool/annotations/test.rs
@@ -23,7 +23,7 @@ async fn server_with_mock(mock: MockAnnotationServiceImpl) -> (SiftMcpServer, Jo
     });
 
     (
-        SiftMcpServer::new(channel, String::from("https://api.test.local")),
+        SiftMcpServer::new(channel, String::from("https://api.test.local"), true),
         handle,
     )
 }

--- a/rust/crates/sift_mcp/src/tool/assets/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/assets/mod.rs
@@ -128,6 +128,8 @@ impl SiftMcpServer {
         )
     )]
     pub async fn update_asset(&self, params: Parameters<UpdateAssetParams>) -> error::McpResult {
+        self.require_destructive()?;
+
         let Parameters(UpdateAssetParams {
             asset_id,
             tags,

--- a/rust/crates/sift_mcp/src/tool/assets/test.rs
+++ b/rust/crates/sift_mcp/src/tool/assets/test.rs
@@ -1,3 +1,4 @@
+use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::ErrorCode;
 use sift_rs::assets::v1::{Asset, ListAssetsResponse, asset_service_server::AssetServiceServer};
 use sift_test_util::{grpc::memory_sift_channel, mock::assets::v1::MockAssetServiceImpl};
@@ -7,10 +8,20 @@ use tonic::{Response, Status, transport::Server};
 use crate::{
     server::SiftMcpServer,
     service::common::PAGE_SIZE,
-    tool::common::test_support::{list_params, structured_field},
+    tool::{
+        assets::UpdateAssetParams,
+        common::test_support::{list_params, structured_field},
+    },
 };
 
 async fn server_with_mock(mock: MockAssetServiceImpl) -> (SiftMcpServer, JoinHandle<()>) {
+    server_with_mock_and_flag(mock, true).await
+}
+
+async fn server_with_mock_and_flag(
+    mock: MockAssetServiceImpl,
+    allow_destructive: bool,
+) -> (SiftMcpServer, JoinHandle<()>) {
     let (client, server) = tokio::io::duplex(1024);
     let channel = memory_sift_channel(client).await;
 
@@ -23,7 +34,11 @@ async fn server_with_mock(mock: MockAssetServiceImpl) -> (SiftMcpServer, JoinHan
     });
 
     (
-        SiftMcpServer::new(channel, String::from("https://api.test.local")),
+        SiftMcpServer::new(
+            channel,
+            String::from("https://api.test.local"),
+            allow_destructive,
+        ),
         handle,
     )
 }
@@ -174,6 +189,25 @@ async fn list_assets_breaks_on_empty_page() {
             .unwrap()
             .is_empty()
     );
+}
+
+#[tokio::test]
+async fn update_asset_blocked_without_allow_destructive() {
+    // No expectations on the mock: the gate must fire before any RPC.
+    let mock = MockAssetServiceImpl::new();
+    let (server, _h) = server_with_mock_and_flag(mock, false).await;
+
+    let err = server
+        .update_asset(Parameters(UpdateAssetParams {
+            asset_id: "a1".into(),
+            tags: Some(vec!["engine".into()]),
+            metadata: None,
+        }))
+        .await
+        .expect_err("expected destructive gate to reject the call");
+
+    assert_eq!(err.code, ErrorCode::INVALID_REQUEST);
+    assert!(err.message.contains("--allow-destructive"));
 }
 
 #[tokio::test]

--- a/rust/crates/sift_mcp/src/tool/channels/test.rs
+++ b/rust/crates/sift_mcp/src/tool/channels/test.rs
@@ -25,7 +25,7 @@ async fn server_with_mock(mock: MockChannelServiceImpl) -> (SiftMcpServer, JoinH
     });
 
     (
-        SiftMcpServer::new(channel, String::from("https://api.test.local")),
+        SiftMcpServer::new(channel, String::from("https://api.test.local"), true),
         handle,
     )
 }

--- a/rust/crates/sift_mcp/src/tool/docs/test.rs
+++ b/rust/crates/sift_mcp/src/tool/docs/test.rs
@@ -24,7 +24,7 @@ async fn server_with_mock(mock: MockDocsServiceImpl) -> (SiftMcpServer, JoinHand
             .unwrap();
     });
 
-    let server = SiftMcpServer::new(channel, "https://api.test.local".into());
+    let server = SiftMcpServer::new(channel, "https://api.test.local".into(), true);
     (server, handle)
 }
 

--- a/rust/crates/sift_mcp/src/tool/explore/test.rs
+++ b/rust/crates/sift_mcp/src/tool/explore/test.rs
@@ -10,7 +10,7 @@ const REST_URI: &str = "https://api.siftstack.com";
 async fn server_for_explore(rest_uri: &str) -> SiftMcpServer {
     let (client, _server) = tokio::io::duplex(1024);
     let channel = memory_sift_channel(client).await;
-    SiftMcpServer::new(channel, rest_uri.to_string())
+    SiftMcpServer::new(channel, rest_uri.to_string(), true)
 }
 
 fn structured_field(result: rmcp::model::CallToolResult, key: &str) -> Value {

--- a/rust/crates/sift_mcp/src/tool/reports/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/reports/mod.rs
@@ -359,6 +359,8 @@ impl SiftMcpServer {
         )
     )]
     pub async fn update_report(&self, params: Parameters<UpdateReportParams>) -> error::McpResult {
+        self.require_destructive()?;
+
         let Parameters(UpdateReportParams {
             report_id,
             metadata,

--- a/rust/crates/sift_mcp/src/tool/reports/test.rs
+++ b/rust/crates/sift_mcp/src/tool/reports/test.rs
@@ -40,7 +40,7 @@ async fn server_with_mock(mock: MockReportServiceImpl) -> (SiftMcpServer, JoinHa
     });
 
     (
-        SiftMcpServer::new(channel, String::from("https://api.test.local")),
+        SiftMcpServer::new(channel, String::from("https://api.test.local"), true),
         handle,
     )
 }

--- a/rust/crates/sift_mcp/src/tool/rules/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/rules/mod.rs
@@ -283,6 +283,8 @@ impl SiftMcpServer {
         )
     )]
     pub async fn update_rule(&self, params: Parameters<UpdateRuleParams>) -> error::McpResult {
+        self.require_destructive()?;
+
         let Parameters(UpdateRuleParams {
             rule_id,
             name,
@@ -377,6 +379,8 @@ impl SiftMcpServer {
         )
     )]
     pub async fn archive_rule(&self, params: Parameters<RuleArchiveParams>) -> error::McpResult {
+        self.require_destructive()?;
+
         let Parameters(RuleArchiveParams {
             rule_id,
             client_key,
@@ -436,6 +440,8 @@ impl SiftMcpServer {
         )
     )]
     pub async fn unarchive_rule(&self, params: Parameters<RuleArchiveParams>) -> error::McpResult {
+        self.require_destructive()?;
+
         let Parameters(RuleArchiveParams {
             rule_id,
             client_key,

--- a/rust/crates/sift_mcp/src/tool/runs/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/runs/mod.rs
@@ -133,6 +133,8 @@ impl SiftMcpServer {
         )
     )]
     pub async fn update_run(&self, params: Parameters<UpdateRunParams>) -> error::McpResult {
+        self.require_destructive()?;
+
         let Parameters(UpdateRunParams {
             run_id,
             name,

--- a/rust/crates/sift_mcp/src/tool/runs/test.rs
+++ b/rust/crates/sift_mcp/src/tool/runs/test.rs
@@ -39,7 +39,7 @@ async fn server_with_mock(mock: MockRunServiceImpl) -> (SiftMcpServer, JoinHandl
     });
 
     (
-        SiftMcpServer::new(channel, String::from("https://api.test.local")),
+        SiftMcpServer::new(channel, String::from("https://api.test.local"), true),
         handle,
     )
 }

--- a/rust/crates/sift_mcp/src/tool/test_reports/test.rs
+++ b/rust/crates/sift_mcp/src/tool/test_reports/test.rs
@@ -25,7 +25,7 @@ async fn server_with_mock(mock: MockTestReportServiceImpl) -> (SiftMcpServer, Jo
     });
 
     (
-        SiftMcpServer::new(channel, String::from("https://api.test.local")),
+        SiftMcpServer::new(channel, String::from("https://api.test.local"), true),
         handle,
     )
 }


### PR DESCRIPTION
# Description
Require a `--allow-destructive` flag on mcp launch to enable all destructive actions. Adds a method that checks if the flag is turned on, otherwise it gives a useful Error. Also updates developer agent files to ensure when new tools are built the agents have the context to use this method.

Full command is `sift-cli mcp --allow-destructive`

# Verification

Updating Tags w/o flag enabled
<img width="754" height="260" alt="Screenshot 2026-07-15 at 11 32 35 PM" src="https://github.com/user-attachments/assets/2d2272f1-a85d-4f46-bbbb-f16587e79778" />

Updating Tags with flag enabled
<img width="1432" height="356" alt="image" src="https://github.com/user-attachments/assets/2eb7d9ac-5b4c-4dd6-a9f3-dc14ce209a1f" />


