### PR TITLE
rust(bulid): update rmcp to v3.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 pyo3-stub-gen = "0.10"
 rand = "0.10"
 reqwest = "0.13"
-rmcp = "1.7.0"
+rmcp = "3.0.0"
 semver = "1.0"
 serde = "^1.0"
 serde_json = "^1.0"

--- a/rust/crates/sift_mcp/src/prompt/mod.rs
+++ b/rust/crates/sift_mcp/src/prompt/mod.rs
@@ -1,6 +1,6 @@
 use rmcp::{
     handler::server::wrapper::Parameters,
-    model::{PromptMessage, PromptMessageRole},
+    model::{PromptMessage, Role},
     prompt, prompt_router,
     schemars::{self, JsonSchema},
 };
@@ -57,7 +57,7 @@ impl SiftMcpServer {
              This step is discovery only. Do not pull sample data."
         );
 
-        vec![PromptMessage::new_text(PromptMessageRole::User, body)]
+        vec![PromptMessage::new_text(Role::User, body)]
     }
 
     #[prompt(
@@ -101,7 +101,7 @@ impl SiftMcpServer {
              5. Report the findings and surface the Parquet paths so the work can be continued."
         );
 
-        vec![PromptMessage::new_text(PromptMessageRole::User, body)]
+        vec![PromptMessage::new_text(Role::User, body)]
     }
 
     #[prompt(
@@ -155,6 +155,6 @@ impl SiftMcpServer {
              `list_channels`."
         );
 
-        vec![PromptMessage::new_text(PromptMessageRole::User, body)]
+        vec![PromptMessage::new_text(Role::User, body)]
     }
 }

--- a/rust/crates/sift_mcp/src/server/mod.rs
+++ b/rust/crates/sift_mcp/src/server/mod.rs
@@ -2,10 +2,7 @@ use rmcp::{
     ErrorData, RoleServer, ServerHandler,
     handler::server::router::prompt::PromptRouter,
     handler::server::tool::ToolRouter,
-    model::{
-        GetPromptRequestParams, GetPromptResult, ListPromptsResult, ListToolsResult,
-        PaginatedRequestParams,
-    },
+    model::{ListToolsResult, PaginatedRequestParams},
     prompt_handler,
     service::RequestContext,
     tool_handler,
@@ -68,11 +65,7 @@ impl ServerHandler for SiftMcpServer {
                 .unwrap_or(b.name.as_ref());
             a_key.cmp(b_key)
         });
-        Ok(ListToolsResult {
-            tools,
-            meta: None,
-            next_cursor: None,
-        })
+        Ok(ListToolsResult::with_all_items(tools))
     }
 }
 

--- a/rust/crates/sift_mcp/src/tool/annotations/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/annotations/mod.rs
@@ -1,7 +1,7 @@
 use rmcp::{
     ErrorData,
     handler::server::wrapper::Parameters,
-    model::{CallToolResult, Content},
+    model::{CallToolResult, ContentBlock},
     schemars::{self, JsonSchema},
     tool, tool_router,
 };
@@ -273,7 +273,7 @@ impl SiftMcpServer {
             "annotation_url": annotation_url,
             "next_step": next_step,
         }));
-        result.content = vec![Content::text(next_step)];
+        result.content = vec![ContentBlock::text(next_step)];
         Ok(result)
     }
 
@@ -399,7 +399,7 @@ impl SiftMcpServer {
             "annotation_url": annotation_url,
             "next_step": next_step,
         }));
-        result.content = vec![Content::text(next_step)];
+        result.content = vec![ContentBlock::text(next_step)];
         Ok(result)
     }
 }

--- a/rust/crates/sift_mcp/src/tool/assets/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/assets/mod.rs
@@ -1,7 +1,7 @@
 use rmcp::{
     ErrorData,
     handler::server::wrapper::Parameters,
-    model::{CallToolResult, Content},
+    model::{CallToolResult, ContentBlock},
     schemars::{self, JsonSchema},
     tool, tool_router,
 };
@@ -173,7 +173,7 @@ impl SiftMcpServer {
             "asset_url": asset_url,
             "next_step": next_step,
         }));
-        result.content = vec![Content::text(next_step)];
+        result.content = vec![ContentBlock::text(next_step)];
         Ok(result)
     }
 }

--- a/rust/crates/sift_mcp/src/tool/data/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/data/mod.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use rmcp::{
     ErrorData,
     handler::server::wrapper::Parameters,
-    model::{CallToolResult, Content},
+    model::{CallToolResult, ContentBlock},
     schemars::{self, JsonSchema},
     tool, tool_router,
 };
@@ -248,7 +248,7 @@ impl SiftMcpServer {
             "output": output_str,
             "next_step": next_step,
         }));
-        result.content = vec![Content::text(next_step)];
+        result.content = vec![ContentBlock::text(next_step)];
         Ok(result)
     }
 
@@ -336,7 +336,7 @@ impl SiftMcpServer {
             "output": output_str,
             "next_step": next_step,
         }));
-        result.content = vec![Content::text(next_step)];
+        result.content = vec![ContentBlock::text(next_step)];
         Ok(result)
     }
 
@@ -446,7 +446,7 @@ impl SiftMcpServer {
             "run_id": uploaded.run_id,
             "next_step": next_step,
         }));
-        result.content = vec![Content::text(next_step)];
+        result.content = vec![ContentBlock::text(next_step)];
         Ok(result)
     }
 }

--- a/rust/crates/sift_mcp/src/tool/explore/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/explore/mod.rs
@@ -1,6 +1,6 @@
 use rmcp::{
     handler::server::wrapper::Parameters,
-    model::{CallToolResult, Content},
+    model::{CallToolResult, ContentBlock},
     schemars::{self, JsonSchema},
     tool, tool_router,
 };
@@ -94,7 +94,7 @@ impl SiftMcpServer {
             "url": url,
             "next_step": next_step,
         }));
-        result.content = vec![Content::text(next_step)];
+        result.content = vec![ContentBlock::text(next_step)];
         Ok(result)
     }
 }

--- a/rust/crates/sift_mcp/src/tool/explore/test.rs
+++ b/rust/crates/sift_mcp/src/tool/explore/test.rs
@@ -51,6 +51,6 @@ async fn handler_returns_structured_url_and_text_content() {
     assert_eq!(
         result.content.len(),
         1,
-        "expected one Content::text wrapping the next_step"
+        "expected one ContentBlock::text wrapping the next_step"
     );
 }

--- a/rust/crates/sift_mcp/src/tool/reports/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/reports/mod.rs
@@ -1,7 +1,7 @@
 use rmcp::{
     ErrorData,
     handler::server::wrapper::Parameters,
-    model::{CallToolResult, Content},
+    model::{CallToolResult, ContentBlock},
     schemars::{self, JsonSchema},
     tool, tool_router,
 };
@@ -184,7 +184,7 @@ impl SiftMcpServer {
             "report_url": report_url,
             "next_step": next_step,
         }));
-        result.content = vec![Content::text(next_step)];
+        result.content = vec![ContentBlock::text(next_step)];
         Ok(result)
     }
 
@@ -316,7 +316,7 @@ impl SiftMcpServer {
             "report_url": report_url,
             "next_step": next_step,
         }));
-        result.content = vec![Content::text(next_step)];
+        result.content = vec![ContentBlock::text(next_step)];
         Ok(result)
     }
 
@@ -398,7 +398,7 @@ impl SiftMcpServer {
             "report_url": report_url,
             "next_step": next_step,
         }));
-        result.content = vec![Content::text(next_step)];
+        result.content = vec![ContentBlock::text(next_step)];
         Ok(result)
     }
 }

--- a/rust/crates/sift_mcp/src/tool/rules/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/rules/mod.rs
@@ -1,7 +1,7 @@
 use rmcp::{
     ErrorData,
     handler::server::wrapper::Parameters,
-    model::{CallToolResult, Content},
+    model::{CallToolResult, ContentBlock},
     schemars::{self, JsonSchema},
     tool, tool_router,
 };
@@ -167,7 +167,7 @@ impl SiftMcpServer {
             "rule_url": rule_url,
             "next_step": next_step,
         }));
-        result.content = vec![Content::text(next_step)];
+        result.content = vec![ContentBlock::text(next_step)];
         Ok(result)
     }
 
@@ -235,7 +235,7 @@ impl SiftMcpServer {
             "rule_url": rule_url,
             "next_step": next_step,
         }));
-        result.content = vec![Content::text(next_step)];
+        result.content = vec![ContentBlock::text(next_step)];
         Ok(result)
     }
 
@@ -344,7 +344,7 @@ impl SiftMcpServer {
             "rule_url": rule_url,
             "next_step": next_step,
         }));
-        result.content = vec![Content::text(next_step)];
+        result.content = vec![ContentBlock::text(next_step)];
         Ok(result)
     }
 
@@ -406,7 +406,7 @@ impl SiftMcpServer {
             "rule_url": rule_url,
             "next_step": next_step,
         }));
-        result.content = vec![Content::text(next_step)];
+        result.content = vec![ContentBlock::text(next_step)];
         Ok(result)
     }
 
@@ -466,7 +466,7 @@ impl SiftMcpServer {
             "rule_url": rule_url,
             "next_step": next_step,
         }));
-        result.content = vec![Content::text(next_step)];
+        result.content = vec![ContentBlock::text(next_step)];
         Ok(result)
     }
 }

--- a/rust/crates/sift_mcp/src/tool/runs/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/runs/mod.rs
@@ -1,7 +1,7 @@
 use rmcp::{
     ErrorData,
     handler::server::wrapper::Parameters,
-    model::{CallToolResult, Content},
+    model::{CallToolResult, ContentBlock},
     schemars::{self, JsonSchema},
     tool, tool_router,
 };
@@ -201,7 +201,7 @@ impl SiftMcpServer {
             "run_url": run_url,
             "next_step": next_step,
         }));
-        result.content = vec![Content::text(next_step)];
+        result.content = vec![ContentBlock::text(next_step)];
         Ok(result)
     }
 }

--- a/rust/crates/sift_mcp/src/tool/test_reports/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/test_reports/mod.rs
@@ -1,7 +1,7 @@
 use rmcp::{
     ErrorData,
     handler::server::wrapper::Parameters,
-    model::{CallToolResult, Content},
+    model::{CallToolResult, ContentBlock},
     schemars::{self, JsonSchema},
     tool, tool_router,
 };
@@ -378,7 +378,7 @@ impl SiftMcpServer {
             "report_url": report_url,
             "next_step": next_step,
         }));
-        result.content = vec![Content::text(next_step)];
+        result.content = vec![ContentBlock::text(next_step)];
         Ok(result)
     }
 
@@ -462,7 +462,7 @@ impl SiftMcpServer {
             "report_url": report_url,
             "next_step": next_step,
         }));
-        result.content = vec![Content::text(next_step)];
+        result.content = vec![ContentBlock::text(next_step)];
         Ok(result)
     }
 }


### PR DESCRIPTION
## Changes

Updates the `rmcp` crate and relevant code to v3.0.0 which is compliant with [MCP 2028-07-26](https://blog.modelcontextprotocol.io/posts/2026-07-28/). There were breaking changes but very minimal for the API surface that we leverage.

## Verification

- Test suite