### PR TITLE
Python(fix): tolerate multi-value metadata keys in metadata_proto_to_dict

### DIFF
--- a/python/lib/sift_client/_tests/util/test_metadata.py
+++ b/python/lib/sift_client/_tests/util/test_metadata.py
@@ -1,0 +1,54 @@
+from sift.metadata.v1.metadata_pb2 import (
+    MetadataKey,
+    MetadataKeyType,
+    MetadataValue,
+)
+
+from sift_client.util.metadata import metadata_dict_to_proto, metadata_proto_to_dict
+
+
+def _string_value(name: str, value: str) -> MetadataValue:
+    return MetadataValue(
+        key=MetadataKey(name=name, type=MetadataKeyType.METADATA_KEY_TYPE_STRING),
+        string_value=value,
+    )
+
+
+class TestMetadataProtoToDict:
+    def test_unwraps_each_value_type(self):
+        metadata = [
+            _string_value("env", "prod"),
+            MetadataValue(
+                key=MetadataKey(name="build", type=MetadataKeyType.METADATA_KEY_TYPE_NUMBER),
+                number_value=1.5,
+            ),
+            MetadataValue(
+                key=MetadataKey(name="armed", type=MetadataKeyType.METADATA_KEY_TYPE_BOOLEAN),
+                boolean_value=True,
+            ),
+        ]
+        assert metadata_proto_to_dict(metadata) == {
+            "env": "prod",
+            "build": 1.5,
+            "armed": True,
+        }
+
+    def test_multi_value_key_keeps_first_value(self):
+        # A key can hold multiple values (multi-value metadata). The API
+        # returns values in canonical order; the dict view keeps the first.
+        metadata = [
+            _string_value("associated_parts", "ABC"),
+            _string_value("associated_parts", "XYZ"),
+            _string_value("env", "prod"),
+        ]
+        assert metadata_proto_to_dict(metadata) == {
+            "associated_parts": "ABC",
+            "env": "prod",
+        }
+
+    def test_empty_metadata(self):
+        assert metadata_proto_to_dict([]) == {}
+
+    def test_round_trip_from_dict(self):
+        original = {"env": "prod", "build": 1.5, "armed": True}
+        assert metadata_proto_to_dict(metadata_dict_to_proto(original)) == original

--- a/python/lib/sift_client/util/metadata.py
+++ b/python/lib/sift_client/util/metadata.py
@@ -54,16 +54,21 @@ def metadata_dict_to_proto(_metadata: dict[str, str | float | bool]) -> list[Met
 def metadata_proto_to_dict(metadata: list[MetadataProto]) -> dict[str, str | float | bool]:
     """Converts a list of MetadataValue objects into a dictionary.
 
+    A key may appear multiple times when it holds multiple values
+    (multi-value metadata). The dictionary keeps the first value of each
+    key -- the API returns values in canonical order, so this matches the
+    value every other single-value context (e.g. backend flattening) uses.
+
     Args:
         metadata: List of MetadataValue objects.
 
     Returns:
-        Dictionary of metadata key-value pairs.
+        Dictionary of metadata key-value pairs (first value per key).
     """
     unwrapped_metadata: dict[str, str | float | bool] = {}
     for md in metadata:
         if md.key.name in unwrapped_metadata:
-            raise ValueError(f"Key already exists: {md.key.name}")
+            continue
         if md.key.type == MetadataKeyType.METADATA_KEY_TYPE_STRING:
             unwrapped_metadata[md.key.name] = md.string_value
         elif md.key.type == MetadataKeyType.METADATA_KEY_TYPE_BOOLEAN:


### PR DESCRIPTION
## What

`metadata_proto_to_dict` raises `ValueError("Key already exists")` when the repeated `MetadataValue` list contains the same key twice. Once the backend's org-scoped `multi-value-metadata` feature ships (azimuth ENG-9885), a metadata key can legitimately hold multiple values — and because `Run._from_proto` / `Asset._from_proto` call this helper, `client.runs.get()` / `list_()` crash outright for any entity carrying multi-value metadata. This also breaks azimuth's isolated rule runner and canvas parameter hydration, which fetch entities through this client.

This PR makes the helper keep the **first** value per key instead of raising. The API returns values in canonical order (the backend assigns `order_index` deterministically on write), so "first" is stable and matches the value every backend single-value context uses (e.g. azimuth's `MetadataToFlatMap`).

## Why first-value rather than lists

Returning lists would change the type of `.metadata` values and break every existing caller. First-value keeps the dict view exactly as it is today for single-valued keys and degrades gracefully for multi-valued ones. Full list access (a dict-compatible `Metadata` mapping with `getall(key)`, plus list writes) is scoped separately in Linear ENG-13281 — this PR is deliberately the minimal forward-compatibility fix.

## Rollout note

This must be released **before** the `multi-value-metadata` flag is enabled for any org: every published sift-py version crashes on fetch the moment an org writes its first multi-value key. Tracked with an org-enablement checklist in ENG-13281.

## Testing

New `_tests/util/test_metadata.py` (first test module for this util): value-type unwrapping, multi-value first-value behavior, empty input, and a dict→proto→dict round trip. `ruff check` and `ruff format --check` pass on the changed files.

Linear: ENG-13281 (client multi-value support), ENG-13104 (rule payload counterpart), ENG-9885 (feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)