### PR TITLE
rust(feat): lower MCP list defaults to 50

### DIFF
--- a/rust/crates/sift_cli/CHANGELOG.md
+++ b/rust/crates/sift_cli/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### What's New
 
+- Reduced MCP list defaults from 200 records to 50 and the maximum from 1000 to
+  200 to protect agent context windows.
 - Removed the MCP server, built-in prompt, and agent skill pages from the
   bundled `sift-cli` documentation. The agent-facing tool surface is documented
   in the installed skill instead.

--- a/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
+++ b/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
@@ -18,8 +18,8 @@ to combine them when working with Sift.
    agents. Exposes structured, authenticated tools:
    - `list_assets`, `list_runs`, `list_channels`, `list_reports`, `list_rules`,
      `list_rule_versions`, `list_annotations`: discover what exists. Pass `limit`
-     (start at 200, max 1000). Omitting it defaults to 200 and values above 1000
-     clamp to 1000, so raise `limit` when a result comes back capped.
+     (start at 50, max 200). Omitting it defaults to 50 and values above 200
+     clamp to 200, so raise `limit` when a result comes back capped.
    - `list_report_rule_summaries`: per-rule pass/fail/open breakdown for a report.
    - `list_users`: resolve a person to a `user_id` by name, email, or id, then
      filter another list on `created_by_user_id` — that is how you answer "runs

--- a/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
@@ -35,8 +35,8 @@ to combine them when working with Sift.
    agents. Exposes structured, authenticated tools:
    - `list_assets`, `list_runs`, `list_channels`, `list_reports`, `list_rules`,
      `list_rule_versions`, `list_annotations`: discover what exists. Pass `limit`
-     (start at 200, max 1000). Omitting it defaults to 200 and values above 1000
-     clamp to 1000, so raise `limit` when a result comes back capped.
+     (start at 50, max 200). Omitting it defaults to 50 and values above 200
+     clamp to 200, so raise `limit` when a result comes back capped.
    - `list_report_rule_summaries`: per-rule pass/fail/open breakdown for a report.
    - `list_users`: resolve a person to a `user_id` by name, email, or id, then
      filter another list on `created_by_user_id` — that is how you answer "runs

--- a/rust/crates/sift_mcp/CLAUDE.md
+++ b/rust/crates/sift_mcp/CLAUDE.md
@@ -489,8 +489,8 @@ When you add or update a list tool:
    - Order-by: list every orderable field, the default sort when the field is empty (assets and
      runs default to `created_date desc`; channels defaults to `created_date` ascending — these
      differ, do not assume), and the `\"FIELD_NAME[ desc],...\"` format.
-   - Limit: describe the clamp in `service::common::paging`. Any value is bounded to `1..=1000`,
-     and omitting `limit` falls back to `DEFAULT_LIMIT` (200), so no call is ever unbounded. This
+   - Limit: describe the clamp in `service::common::paging`. Any value is bounded to `1..=200`,
+     and omitting `limit` falls back to `DEFAULT_LIMIT` (50), so no call is ever unbounded. This
      differs from the proto's raw `page_size` (it caps higher for some services).
 4. **Re-read the proto whenever the resource changes.** If a filterable or orderable field is
    added to the proto, update the tool description in the same change. A stale description is

--- a/rust/crates/sift_mcp/src/service/common/mod.rs
+++ b/rust/crates/sift_mcp/src/service/common/mod.rs
@@ -5,12 +5,12 @@ use anyhow::{Context, bail};
 #[cfg(test)]
 mod test;
 
-/// Default and max page size for list calls.
-pub const PAGE_SIZE: u32 = 1000;
+/// Maximum page size and record limit for list calls.
+pub const PAGE_SIZE: u32 = 200;
 /// Record limit applied when a caller omits `limit`. Matches the starting limit
 /// the `list_*` tool descriptions advise, so a caller that ignores that advice
 /// cannot trigger an unbounded query.
-pub const DEFAULT_LIMIT: u32 = 200;
+pub const DEFAULT_LIMIT: u32 = 50;
 pub const BIT_FIELD_METADATA_KEY: &str = "bit_field_elements";
 pub const ENUM_METADATA_KEY: &str = "enum_config";
 pub const TS_COLUMN_NAME: &str = "timestamp_unix_nanos";

--- a/rust/crates/sift_mcp/src/service/common/test.rs
+++ b/rust/crates/sift_mcp/src/service/common/test.rs
@@ -2,16 +2,19 @@ use super::{ColumnName, DEFAULT_LIMIT, PAGE_SIZE, paging};
 
 #[test]
 fn paging_uses_default_limit_when_unset() {
-    assert_eq!(paging(None), (DEFAULT_LIMIT, DEFAULT_LIMIT as usize));
+    assert_eq!(DEFAULT_LIMIT, 50);
+    assert_eq!(paging(None), (50, 50));
 }
 
 #[test]
 fn paging_passes_through_in_range_limit() {
-    assert_eq!(paging(Some(200)), (200, 200));
+    assert_eq!(paging(Some(125)), (125, 125));
 }
 
 #[test]
 fn paging_clamps_limit_above_page_size() {
+    assert_eq!(PAGE_SIZE, 200);
+    assert_eq!(paging(Some(201)), (200, 200));
     assert_eq!(paging(Some(50_000)), (PAGE_SIZE, PAGE_SIZE as usize));
     assert_eq!(paging(Some(u32::MAX)), (PAGE_SIZE, PAGE_SIZE as usize));
 }

--- a/rust/crates/sift_mcp/src/tool/annotations/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/annotations/mod.rs
@@ -107,8 +107,8 @@ impl SiftMcpServer {
               - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `created_date`,
                 `modified_date`, `start_time`, `end_time`, `name`, `description`. Default sort is `created_date desc`
                 (newest first). Example: `\"start_time desc,name\"`.
-              - `limit`: max items to return. Start at 200 and only raise it if the result is capped
-                and you still need more. Values are clamped to `1..=1000`; omitting it defaults to 200.
+              - `limit`: max items to return. Start at 50 and only raise it if the result is capped
+                and you still need more. Values are clamped to `1..=200`; omitting it defaults to 50.
               - `organization_id`: optional. Required only when the caller belongs to multiple organizations.
 
             Errors:

--- a/rust/crates/sift_mcp/src/tool/assets/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/assets/mod.rs
@@ -45,8 +45,8 @@ impl SiftMcpServer {
               - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `name`,
                 `created_date`, `modified_date`, `archived_date`. Default sort is `created_date desc` (newest first).
                 Example: `\"created_date desc,modified_date\"`.
-              - `limit`: max items to return. Start at 200 and only raise it if the result is capped
-                and you still need more. Values are clamped to `1..=1000`; omitting it defaults to 200.
+              - `limit`: max items to return. Start at 50 and only raise it if the result is capped
+                and you still need more. Values are clamped to `1..=200`; omitting it defaults to 50.
 
             Errors:
               - `INVALID_PARAMS` if `filter` is not a valid CEL expression or `order_by` references an unknown field.

--- a/rust/crates/sift_mcp/src/tool/assets/test.rs
+++ b/rust/crates/sift_mcp/src/tool/assets/test.rs
@@ -44,6 +44,37 @@ async fn server_with_mock_and_flag(
 }
 
 #[tokio::test]
+async fn list_tool_descriptions_advertise_bounded_limits() {
+    let (server, _h) = server_with_mock(MockAssetServiceImpl::new()).await;
+    let list_tools: Vec<_> = server
+        .tool_router
+        .list_all()
+        .into_iter()
+        .filter(|tool| tool.name.starts_with("list_"))
+        .collect();
+
+    assert!(!list_tools.is_empty());
+    for tool in list_tools {
+        let description = tool.description.as_deref().unwrap_or_default();
+        assert!(
+            description.contains("Start at 50"),
+            "{} does not advertise the starting limit",
+            tool.name
+        );
+        assert!(
+            description.contains("1..=200"),
+            "{} does not advertise the maximum limit",
+            tool.name
+        );
+        assert!(
+            description.contains("defaults to 50"),
+            "{} does not advertise the default limit",
+            tool.name
+        );
+    }
+}
+
+#[tokio::test]
 async fn list_assets_returns_single_page() {
     let mut asset_mock = MockAssetServiceImpl::new();
     asset_mock

--- a/rust/crates/sift_mcp/src/tool/channels/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/channels/mod.rs
@@ -28,8 +28,8 @@ impl SiftMcpServer {
               - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `name`,
                 `created_date`, `modified_date`, `active`. Default sort is `created_date` ascending (oldest first) —
                 note this differs from `list_assets` and `list_runs`. Example: `\"name,created_date desc\"`.
-              - `limit`: max items to return. Start at 200 and only raise it if the result is capped
-                and you still need more. Values are clamped to `1..=1000`; omitting it defaults to 200.
+              - `limit`: max items to return. Start at 50 and only raise it if the result is capped
+                and you still need more. Values are clamped to `1..=200`; omitting it defaults to 50.
 
             Errors:
               - `INVALID_PARAMS` if `filter` is not a valid CEL expression or `order_by` references an unknown field.

--- a/rust/crates/sift_mcp/src/tool/reports/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/reports/mod.rs
@@ -76,8 +76,8 @@ impl SiftMcpServer {
               - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `name`,
                 `created_date`, `modified_date`. Default sort is `created_date desc` (newest first).
                 Example: `\"created_date desc,modified_date\"`.
-              - `limit`: max items to return. Start at 200 and only raise it if the result is capped
-                and you still need more. Values are clamped to `1..=1000`; omitting it defaults to 200.
+              - `limit`: max items to return. Start at 50 and only raise it if the result is capped
+                and you still need more. Values are clamped to `1..=200`; omitting it defaults to 50.
               - `organization_id`: optional. Required only when the caller belongs to multiple organizations; it
                 scopes the listing to that org. Omit it for single-organization users.
 
@@ -133,8 +133,8 @@ impl SiftMcpServer {
                 `rule_id`, `rule_version_id`, `asset_id`, and `status`.
               - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `display_order`,
                 `created_date`, `modified_date`. Default sort is `display_order` ascending.
-              - `limit`: max items to return. Start at 200 and only raise it if the result is capped
-                and you still need more. Values are clamped to `1..=1000`; omitting it defaults to 200.
+              - `limit`: max items to return. Start at 50 and only raise it if the result is capped
+                and you still need more. Values are clamped to `1..=200`; omitting it defaults to 50.
 
             Errors:
               - `INVALID_PARAMS` if `report_id` is empty or `filter`/`order_by` is invalid.

--- a/rust/crates/sift_mcp/src/tool/rules/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/rules/mod.rs
@@ -73,8 +73,8 @@ impl SiftMcpServer {
               - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields:
                 `created_date`, `modified_date`. Default sort is `created_date desc` (newest first).
                 Example: `\"created_date desc,modified_date\"`.
-              - `limit`: max items to return. Start at 200 and only raise it if the result is capped
-                and you still need more. Values are clamped to `1..=1000`; omitting it defaults to 200.
+              - `limit`: max items to return. Start at 50 and only raise it if the result is capped
+                and you still need more. Values are clamped to `1..=200`; omitting it defaults to 50.
 
             Errors:
               - `INVALID_PARAMS` if `filter` is not a valid CEL expression or `order_by` references an unknown field.
@@ -124,8 +124,8 @@ impl SiftMcpServer {
               - `rule_id`: required. The rule whose versions to list.
               - `filter`: optional CEL expression. Filterable fields: `rule_version_id`, `user_notes`, and
                 `change_message`. Omit or pass an empty string to list all versions.
-              - `limit`: max items to return. Start at 200 and only raise it if the result is capped
-                and you still need more. Values are clamped to `1..=1000`; omitting it defaults to 200.
+              - `limit`: max items to return. Start at 50 and only raise it if the result is capped
+                and you still need more. Values are clamped to `1..=200`; omitting it defaults to 50.
 
             Errors:
               - `INVALID_PARAMS` if `filter` is not a valid CEL expression.

--- a/rust/crates/sift_mcp/src/tool/runs/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/runs/mod.rs
@@ -55,8 +55,8 @@ impl SiftMcpServer {
               - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `name`,
                 `description`, `created_date`, `modified_date`, `start_time`, `stop_time`. Default sort is
                 `created_date desc` (newest first). Example: `\"created_date desc,modified_date\"`.
-              - `limit`: max items to return. Start at 200 and only raise it if the result is capped
-                and you still need more. Values are clamped to `1..=1000`; omitting it defaults to 200.
+              - `limit`: max items to return. Start at 50 and only raise it if the result is capped
+                and you still need more. Values are clamped to `1..=200`; omitting it defaults to 50.
 
             Errors:
               - `INVALID_PARAMS` if `filter` is not a valid CEL expression or `order_by` references an unknown field.

--- a/rust/crates/sift_mcp/src/tool/test_reports/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/test_reports/mod.rs
@@ -69,8 +69,8 @@ impl SiftMcpServer {
               - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `test_report_id`,
                 `name`, `test_system_name`, `test_case`, `start_time`, `end_time`, `created_date`, `modified_date`.
                 Default sort is `start_time desc` (newest first). Example: `\"start_time desc,name\"`.
-              - `limit`: max items to return. Start at 200 and only raise it if the result is capped
-                and you still need more. Values are clamped to `1..=1000`; omitting it defaults to 200.
+              - `limit`: max items to return. Start at 50 and only raise it if the result is capped
+                and you still need more. Values are clamped to `1..=200`; omitting it defaults to 50.
 
             Errors:
               - `INVALID_PARAMS` if `filter` is not a valid CEL expression or `order_by` references an unknown field.
@@ -124,8 +124,8 @@ impl SiftMcpServer {
                 `name`, `step_type`, `step_path`, `status`, `start_time`, `end_time`, `created_date`,
                 `modified_date`. Default sort is `step_path` ascending (tree order). Example:
                 `\"step_path asc,start_time desc\"`.
-              - `limit`: max items to return. Start at 200 and only raise it if the result is capped
-                and you still need more. Values are clamped to `1..=1000`; omitting it defaults to 200. Use
+              - `limit`: max items to return. Start at 50 and only raise it if the result is capped
+                and you still need more. Values are clamped to `1..=200`; omitting it defaults to 50. Use
                 `count_test_steps` to learn the true total before relying on a capped page.
 
             Errors:
@@ -181,8 +181,8 @@ impl SiftMcpServer {
                 `name`, `measurement_type`, `test_step_id`, `test_report_id`, `passed`, `timestamp`,
                 `created_date`, `modified_date`. Default sort is `timestamp` ascending. Example:
                 `\"timestamp asc,name\"`.
-              - `limit`: max items to return. Start at 200 and only raise it if the result is capped
-                and you still need more. Values are clamped to `1..=1000`; omitting it defaults to 200. Use
+              - `limit`: max items to return. Start at 50 and only raise it if the result is capped
+                and you still need more. Values are clamped to `1..=200`; omitting it defaults to 50. Use
                 `count_test_measurements` to learn the true total before relying on a capped page.
 
             Errors:
@@ -216,7 +216,7 @@ impl SiftMcpServer {
         name = "count_test_steps",
         description = "
             Count test steps matching a CEL filter, without fetching them. Use this to learn the true total when a
-            report may hold more steps than the 1000-item list cap, or to reconcile expected vs actual counts in an
+            report may hold more steps than the 200-item list cap, or to reconcile expected vs actual counts in an
             audit (e.g. \"how many steps failed in this report\").
 
             Output:
@@ -251,7 +251,7 @@ impl SiftMcpServer {
         name = "count_test_measurements",
         description = "
             Count test measurements matching a CEL filter, without fetching them. Use this to learn the true total
-            when a report may hold more measurements than the 1000-item list cap, or to reconcile expected vs actual
+            when a report may hold more measurements than the 200-item list cap, or to reconcile expected vs actual
             counts in an audit (e.g. \"how many measurements failed their limits\").
 
             Output:

--- a/rust/crates/sift_mcp/src/tool/users/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/users/mod.rs
@@ -52,8 +52,8 @@ impl SiftMcpServer {
               - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `name`,
                 `created_date`, `modified_date`; with `include_inactive` set, only `created_date` and
                 `modified_date`. Default sort is `name` ascending (A-Z). Example: `\"created_date desc,name\"`.
-              - `limit`: max items to return. Start at 200 and only raise it if the result is capped and you still
-                need more. Values are clamped to `1..=1000`; omitting it defaults to 200.
+              - `limit`: max items to return. Start at 50 and only raise it if the result is capped and you still
+                need more. Values are clamped to `1..=200`; omitting it defaults to 50.
               - `include_inactive`: optional; defaults to false, listing only users active in the organization. Set
                 true to also return deactivated accounts — needed when attributing older records to someone who has
                 since left.


### PR DESCRIPTION
## Changes

Tightens the MCP list bounds that ENG-13258 (#694) introduced. `DEFAULT_LIMIT` drops from 200 to 50 and `PAGE_SIZE` from 1000 to 200, so a single `list_*` call cannot flood an agent's context window.

Updates every `list_*` tool description, the `sift_mcp` playbook, and both shipped skill assets to state the new bounds.

Adds a test asserting every registered `list_*` description advertises the starting, maximum, and default limits, so a future bound change cannot silently drift from the documentation agents read.

## Verification

- `cargo fmt --check --all`, `cargo clippy --all-features`, `cargo test --all-features`
- Red/green checked the new test: reverting `tool/runs/mod.rs` to `main` fails it with `list_runs does not advertise the starting limit`
