### PR TITLE
rust(feat): add sift-cli agent lifecycle for Claude and Codex

### DIFF
--- a/rust/crates/sift_cli/AGENTS.md
+++ b/rust/crates/sift_cli/AGENTS.md
@@ -6,6 +6,35 @@
 
 Do not add per-client copies of the skill. The pair of near-identical files this
 replaced drifted apart, which is the failure this layout exists to prevent.
+Claude installs the canonical file to `~/.claude/skills/sift/SKILL.md`; Codex
+uses `~/.agents/skills/sift/SKILL.md`.
+
+The skill is embedded at compile time, so rebuild `sift-cli` after changing it.
+
+## CLI lifecycle
+
+`src/cmd/agent/` implements four stateless, user-scoped commands:
+
+- `sift-cli agent install`
+- `sift-cli agent update`
+- `sift-cli agent doctor`
+- `sift-cli agent uninstall`
+
+Install and update operate on every detected supported client. They preflight
+all targets before writing and refuse to overwrite an unmanaged same-name skill
+or MCP entry. Doctor derives status from the installed files and client configs.
+Uninstall removes only content identifiable as Sift-managed. Do not add a state
+file or per-client version tracking.
+
+Install defaults every MCP registration to read-only. Install accepts
+`--allow-destructive` as an explicit opt-in. An ordinary update preserves the
+single access mode discovered from the managed client configs. Update accepts
+`--allow-destructive` or `--read-only` to switch access, and the change applies
+to every detected client. Doctor reports the setting. Mixed modes are errors
+rather than values the CLI silently resolves.
+
+The `agent` command and `mcp` sidecar remain behind the `mcp` Cargo feature until
+the open-beta release explicitly changes that policy.
 
 ## Updating the skill
 
@@ -15,6 +44,24 @@ Keep the skill accurate to the CLI and `sift_mcp` tool surfaces. In particular:
 - The `sift-cli` subcommand list must mirror `src/cli/mod.rs`.
 - Keep the preference order MCP → CLI → REST/cURL → Python.
 - Keep `sift_client` as the recommended Python module; `sift_py` is deprecated.
+- Teach agents to use `agent doctor`, `install`, and `update` instead of editing
+  one client. They must obtain explicit user approval before running
+  `agent update --allow-destructive` and tell the user to reload the client.
 
 Write in direct voice and keep it concise. The skill is loaded under context
 pressure, so every line should change what the agent does.
+
+## Local development
+
+From the repository root:
+
+```sh
+cargo build -p sift_cli --features mcp
+cargo test -p sift_cli --features mcp cmd::agent
+./target/debug/sift-cli agent doctor
+```
+
+`agent install` changes real user-level client configuration and points it at
+the exact `sift-cli` executable running the command. Use `doctor` for read-only
+validation, and only run install/update/uninstall when those user-level changes
+are intended.

--- a/rust/crates/sift_cli/CHANGELOG.md
+++ b/rust/crates/sift_cli/CHANGELOG.md
@@ -7,6 +7,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### What's New
 
+- Added `sift-cli agent install`, `update`, `doctor`, and `uninstall` for
+  stateless, lockstep management of the release-matched Sift skill and MCP
+  sidecar across detected Claude Code and Codex clients.
+- Added safe-by-default, lockstep MCP access controls: install defaults to
+  read-only, update preserves the existing mode, explicit flags enable or
+  disable destructive tools for all detected clients, and doctor reports mixed
+  modes.
 - Consolidated the duplicated agent instructions into one canonical skill at
   `assets/skills/sift/SKILL.md`.
 - Removed the project-scoped `install agent-skills` workflow. Existing Sift

--- a/rust/crates/sift_cli/Cargo.toml
+++ b/rust/crates/sift_cli/Cargo.toml
@@ -53,3 +53,4 @@ include_dir.workspace = true
 [dev-dependencies]
 indoc = { workspace = true }
 bytes = { workspace = true }
+tempdir = { workspace = true }

--- a/rust/crates/sift_cli/assets/skills/sift/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/sift/SKILL.md
@@ -4,8 +4,9 @@ description: >-
   Use when working with Sift: ingesting or importing time-series data,
   querying assets/runs/channels/users, exporting data, decimating or running SQL
   over data, opening a view in the Sift Explore web app, writing code
-  that integrates with Sift, or looking up how Sift works in its product and
-  API documentation. Covers the Sift MCP server (started by
+  that integrates with Sift, installing, updating, or diagnosing the Sift
+  agent integration, or looking up how Sift works in its product and API
+  documentation. Covers the Sift MCP server (started by
   `sift-cli mcp`), the `sift-cli` itself, the Sift REST API over cURL, the
   Sift Python library (`sift_client`), and the Sift Rust streaming library
   (`sift_stream`). Triggers include phrases like "import this file into
@@ -17,7 +18,8 @@ description: >-
 ---
 
 <!--
-  Managed by sift-cli. Do not edit an installed copy.
+  Managed by sift-cli. Do not edit an installed copy; reinstall it with
+  `sift-cli agent install` or `sift-cli agent update`.
 -->
 
 # Sift toolbox
@@ -65,9 +67,13 @@ to combine them when working with Sift.
      collections use replace semantics, so confirm the change first).
    - `create_report`, `update_report`: manage reports (writes — confirm first).
    - Destructive tools (`update_*`, `archive_*`, `unarchive_*`) are gated on
-     `--allow-destructive`. If one errors with a message about the flag, tell
-     the user to relaunch the server with `sift-cli mcp --allow-destructive`
-     (and update their MCP client config) before retrying.
+     `--allow-destructive`. If one is blocked, explain that this access is
+     disabled by default and ask the user for explicit approval to enable it
+     across every detected client. Only after approval, run
+     `sift-cli agent update --allow-destructive`, ask the user to reload or
+     restart the MCP client, and wait for confirmation before retrying. Never
+     enable it silently. Restore safe mode with
+     `sift-cli agent update --read-only`.
    - `explore_url`: build a Sift Explore deep-link for an asset/run/channel
      selection, with an optional panel/chart pre-defined. Surface the URL to
      the user as plain text, in full, so the user can open the view. Do not
@@ -82,7 +88,7 @@ to combine them when working with Sift.
    - `mcp`: start the MCP server.
    - `ping`: verify credentials and connectivity.
    - `config`: manage profiles and credentials.
-   - `install`: install completions and these agent skills.
+   - `agent`: install, update, diagnose, or uninstall Sift's agent integration.
 3. **REST API over cURL** — the full API surface. Docs:
    https://docs.siftstack.com/api/rest
 4. **Sift Python library** — module `sift_client`. Reference:
@@ -106,6 +112,26 @@ and stop at the first that does the job:
 4. **Python library (`sift_client`).** Use when the task needs a script:
    custom streaming, data transformation, or programmatic logic the above
    cannot express. Prefer `sift_client` over the deprecated `sift_py`.
+
+## Managing the agent integration
+
+Use the CLI lifecycle instead of editing one client's MCP configuration or
+skill:
+
+- Run `sift-cli agent doctor` to diagnose setup, including the access mode,
+  without changing it.
+- For first-time setup, explain that `sift-cli agent install` installs the
+  release-matched skill and read-only MCP registration for every detected
+  client. Run the command when the user asks you to install or approves the
+  change.
+- Run `sift-cli agent update` to refresh every detected client together. It
+  preserves the existing read-only or destructive access mode.
+- If the CLI is outdated, relay the exact curl or PowerShell installer printed
+  by `agent doctor` or `agent update`. After the user updates `sift-cli`, rerun
+  `sift-cli agent update`.
+- Never repair or update only one detected client. If doctor reports mixed
+  access modes, ask the user to choose `sift-cli agent update --read-only` or
+  `sift-cli agent update --allow-destructive`.
 
 ## Running `sift-cli` from your shell
 

--- a/rust/crates/sift_cli/src/cli/mod.rs
+++ b/rust/crates/sift_cli/src/cli/mod.rs
@@ -62,6 +62,11 @@ pub enum Cmd {
     #[command(subcommand)]
     Install(InstallCmd),
 
+    /// Manage the Sift integration for detected AI coding clients
+    #[cfg(feature = "mcp")]
+    #[command(subcommand)]
+    Agent(AgentCmd),
+
     /// Start the Sift MCP server
     #[cfg(feature = "mcp")]
     #[command(hide = true)]
@@ -92,6 +97,43 @@ pub enum InstallCmd {
     /// Install or print shell completions for sift-cli
     #[command(subcommand)]
     Completions(CompletionsCmd),
+}
+
+/// Manage Sift's release-matched skill and MCP sidecar as one bundle.
+#[cfg(feature = "mcp")]
+#[derive(Subcommand)]
+pub enum AgentCmd {
+    /// Install every detected client in safe mode
+    Install(AgentInstallArgs),
+
+    /// Refresh every detected client while preserving its access mode
+    Update(AgentUpdateArgs),
+
+    /// Check the CLI version, skill files, and access modes
+    Doctor,
+
+    /// Remove Sift-owned agent files and registrations
+    Uninstall,
+}
+
+#[cfg(feature = "mcp")]
+#[derive(clap::Args)]
+pub struct AgentInstallArgs {
+    /// Enable tools that modify or archive resources for every detected MCP client
+    #[arg(long)]
+    pub allow_destructive: bool,
+}
+
+#[cfg(feature = "mcp")]
+#[derive(clap::Args)]
+pub struct AgentUpdateArgs {
+    /// Enable tools that modify or archive resources for every detected MCP client
+    #[arg(long, conflicts_with = "read_only")]
+    pub allow_destructive: bool,
+
+    /// Disable destructive tools for every detected MCP client
+    #[arg(long, conflicts_with = "allow_destructive")]
+    pub read_only: bool,
 }
 
 #[derive(Subcommand)]

--- a/rust/crates/sift_cli/src/cmd/agent/config.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/config.rs
@@ -1,0 +1,770 @@
+use std::{
+    ffi::{OsStr, OsString},
+    io,
+    path::Path,
+    process::Command,
+};
+
+use anyhow::{Context, Result, anyhow};
+use serde_json::Value;
+
+use super::{AccessMode, Environment, Harness};
+
+#[derive(Debug)]
+struct CommandOutput {
+    success: bool,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+}
+
+trait Runner {
+    fn output(&self, program: &str, args: &[OsString]) -> io::Result<CommandOutput>;
+}
+
+struct SystemRunner;
+
+impl Runner for SystemRunner {
+    fn output(&self, program: &str, args: &[OsString]) -> io::Result<CommandOutput> {
+        Command::new(program)
+            .args(args)
+            .output()
+            .map(|output| CommandOutput {
+                success: output.status.success(),
+                stdout: output.stdout,
+                stderr: output.stderr,
+            })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct NativeEntry {
+    command: String,
+    args: Vec<String>,
+}
+
+#[derive(Debug)]
+struct NativeInspection {
+    state: State,
+    entry: Option<NativeEntry>,
+}
+
+#[derive(Debug)]
+pub(super) struct Snapshot {
+    harness: Harness,
+    previous: Option<NativeEntry>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(super) enum State {
+    Missing,
+    Current(AccessMode),
+    ManagedDrift(AccessMode),
+    Conflict(String),
+    Unavailable(String),
+}
+
+pub(super) fn inspect(harness: Harness, environment: &Environment) -> Result<State> {
+    inspect_with(harness, environment, &SystemRunner)
+}
+
+pub(super) fn snapshot(harness: Harness, environment: &Environment) -> Result<Snapshot> {
+    let inspection = inspect_native(harness, environment, &SystemRunner)?;
+    let previous = match inspection.state {
+        State::Missing => None,
+        State::Current(_) | State::ManagedDrift(_) => inspection.entry,
+        State::Conflict(detail) | State::Unavailable(detail) => {
+            return Err(anyhow!(
+                "{} MCP registration cannot be snapshotted: {detail}",
+                harness.label()
+            ));
+        }
+    };
+    Ok(Snapshot { harness, previous })
+}
+
+pub(super) fn restore(snapshot: &Snapshot, environment: &Environment) -> Result<()> {
+    restore_native(
+        snapshot.harness,
+        snapshot.previous.as_ref(),
+        environment,
+        &SystemRunner,
+    )
+}
+
+fn inspect_with(harness: Harness, environment: &Environment, runner: &dyn Runner) -> Result<State> {
+    Ok(inspect_native(harness, environment, runner)?.state)
+}
+
+pub(super) fn install(
+    harness: Harness,
+    environment: &Environment,
+    access: AccessMode,
+) -> Result<()> {
+    install_with(harness, environment, access, &SystemRunner)
+}
+
+fn install_with(
+    harness: Harness,
+    environment: &Environment,
+    access: AccessMode,
+    runner: &dyn Runner,
+) -> Result<()> {
+    install_native(harness, environment, access, runner)
+}
+
+pub(super) fn uninstall(harness: Harness, environment: &Environment) -> Result<bool> {
+    uninstall_with(harness, environment, &SystemRunner)
+}
+
+fn uninstall_with(
+    harness: Harness,
+    environment: &Environment,
+    runner: &dyn Runner,
+) -> Result<bool> {
+    match inspect_with(harness, environment, runner)? {
+        State::Missing => Ok(false),
+        State::Conflict(_) | State::Unavailable(_) => Ok(false),
+        State::Current(_) | State::ManagedDrift(_) => {
+            remove_native(harness, runner)?;
+            Ok(true)
+        }
+    }
+}
+
+fn inspect_native(
+    harness: Harness,
+    environment: &Environment,
+    runner: &dyn Runner,
+) -> Result<NativeInspection> {
+    match harness {
+        Harness::Claude => inspect_claude(environment, runner),
+        Harness::Codex => inspect_codex(environment, runner),
+    }
+}
+
+fn inspect_claude(environment: &Environment, runner: &dyn Runner) -> Result<NativeInspection> {
+    if !environment.command_available("claude") {
+        return Ok(NativeInspection {
+            state: State::Unavailable("`claude` is not available on PATH".to_string()),
+            entry: None,
+        });
+    }
+
+    let output = runner
+        .output("claude", &os_args(["mcp", "get", "sift"]))
+        .context("failed to inspect Claude Code MCP configuration")?;
+    if !output.success {
+        return Ok(NativeInspection {
+            state: missing_or_unavailable(output),
+            entry: None,
+        });
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let scope = field(&stdout, "Scope:");
+    if scope
+        .as_deref()
+        .is_some_and(|scope| !scope.to_ascii_lowercase().starts_with("user"))
+    {
+        return Ok(NativeInspection {
+            state: State::Conflict(format!(
+                "a non-user `sift` MCP entry ({}) shadows the user integration",
+                scope.unwrap_or_default()
+            )),
+            entry: None,
+        });
+    }
+
+    if environment_block_has_values(&stdout) {
+        return Ok(NativeInspection {
+            state: State::Conflict(
+                "the existing `sift` MCP entry has custom environment variables".to_string(),
+            ),
+            entry: None,
+        });
+    }
+
+    let Some(command) = field(&stdout, "Command:") else {
+        return Ok(NativeInspection {
+            state: State::Conflict(
+                "could not read the command for the existing `sift` MCP entry".to_string(),
+            ),
+            entry: None,
+        });
+    };
+    let args = field(&stdout, "Args:")
+        .map(|args| {
+            args.split_whitespace()
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    Ok(NativeInspection {
+        state: classify_command(&command, &args, environment),
+        entry: Some(NativeEntry { command, args }),
+    })
+}
+
+fn inspect_codex(environment: &Environment, runner: &dyn Runner) -> Result<NativeInspection> {
+    if !environment.command_available("codex") {
+        return Ok(NativeInspection {
+            state: State::Unavailable("`codex` is not available on PATH".to_string()),
+            entry: None,
+        });
+    }
+
+    let output = runner
+        .output("codex", &os_args(["mcp", "get", "sift", "--json"]))
+        .context("failed to inspect Codex MCP configuration")?;
+    if !output.success {
+        return Ok(NativeInspection {
+            state: missing_or_unavailable(output),
+            entry: None,
+        });
+    }
+
+    let payload: Value = serde_json::from_slice(&output.stdout)
+        .context("Codex returned an invalid JSON MCP configuration")?;
+    let transport = payload.get("transport").unwrap_or(&payload);
+    let Some(command) = transport.get("command").and_then(Value::as_str) else {
+        return Ok(NativeInspection {
+            state: State::Conflict(
+                "could not read the command for the existing `sift` MCP entry".to_string(),
+            ),
+            entry: None,
+        });
+    };
+    let Some(args) = string_array(transport.get("args")) else {
+        return Ok(NativeInspection {
+            state: State::Conflict(
+                "the existing `sift` MCP entry has invalid arguments".to_string(),
+            ),
+            entry: None,
+        });
+    };
+    if !codex_metadata_is_managed(&payload, transport) {
+        return Ok(NativeInspection {
+            state: State::Conflict(
+                "the existing `sift` MCP entry contains custom settings".to_string(),
+            ),
+            entry: None,
+        });
+    }
+    Ok(NativeInspection {
+        state: classify_command(command, &args, environment),
+        entry: Some(NativeEntry {
+            command: command.to_string(),
+            args,
+        }),
+    })
+}
+
+fn install_native(
+    harness: Harness,
+    environment: &Environment,
+    access: AccessMode,
+    runner: &dyn Runner,
+) -> Result<()> {
+    let inspection = inspect_native(harness, environment, runner)?;
+    let previous = match inspection.state {
+        State::Missing => None,
+        State::Current(_) | State::ManagedDrift(_) => inspection.entry,
+        State::Conflict(detail) | State::Unavailable(detail) => {
+            return Err(anyhow!(
+                "{} MCP registration cannot be replaced: {detail}",
+                harness.label()
+            ));
+        }
+    };
+    let desired = NativeEntry {
+        command: environment.current_exe.to_string_lossy().to_string(),
+        args: mcp_args(access),
+    };
+
+    if previous.is_some() {
+        remove_native(harness, runner)?;
+    }
+    if let Err(error) = add_native(harness, &desired, runner) {
+        let Some(previous) = previous else {
+            return Err(error);
+        };
+        return match add_native(harness, &previous, runner) {
+            Ok(()) => Err(error.context("the previous MCP registration was restored")),
+            Err(rollback_error) => Err(anyhow!(
+                "{error:#}; restoring the previous MCP registration also failed: {rollback_error:#}"
+            )),
+        };
+    }
+    Ok(())
+}
+
+fn restore_native(
+    harness: Harness,
+    previous: Option<&NativeEntry>,
+    environment: &Environment,
+    runner: &dyn Runner,
+) -> Result<()> {
+    let inspection = inspect_native(harness, environment, runner)?;
+    let current = match inspection.state {
+        State::Missing => None,
+        State::Current(_) | State::ManagedDrift(_) => inspection.entry,
+        State::Conflict(detail) | State::Unavailable(detail) => {
+            return Err(anyhow!(
+                "{} MCP registration cannot be restored: {detail}",
+                harness.label()
+            ));
+        }
+    };
+
+    if current.is_some() {
+        remove_native(harness, runner)?;
+    }
+    let Some(previous) = previous else {
+        return Ok(());
+    };
+    if let Err(error) = add_native(harness, previous, runner) {
+        let Some(current) = current else {
+            return Err(error);
+        };
+        return match add_native(harness, &current, runner) {
+            Ok(()) => Err(error.context("the newer MCP registration was restored")),
+            Err(rollback_error) => Err(anyhow!(
+                "{error:#}; restoring the newer MCP registration also failed: {rollback_error:#}"
+            )),
+        };
+    }
+    Ok(())
+}
+
+fn mcp_args(access: AccessMode) -> Vec<String> {
+    let mut args = vec!["mcp".to_string()];
+    if access == AccessMode::Destructive {
+        args.push("--allow-destructive".to_string());
+    }
+    args
+}
+
+fn classify_command(command: &str, args: &[String], environment: &Environment) -> State {
+    let current = environment.current_exe.to_string_lossy();
+    let current_command = command == "sift-cli" || command == current;
+    let Some(access) = access_from_args(args) else {
+        return State::Conflict(format!(
+            "the existing `sift` MCP entry runs a custom command: `{command} {}`",
+            args.join(" ")
+        ));
+    };
+    if current_command {
+        return State::Current(access);
+    }
+    if is_sift_cli(command) {
+        return State::ManagedDrift(access);
+    }
+    State::Conflict(format!(
+        "the existing `sift` MCP entry runs a custom command: `{command} {}`",
+        args.join(" ")
+    ))
+}
+
+fn access_from_args(args: &[String]) -> Option<AccessMode> {
+    match args {
+        [mcp] if mcp == "mcp" => Some(AccessMode::ReadOnly),
+        [mcp, destructive] if mcp == "mcp" && destructive == "--allow-destructive" => {
+            Some(AccessMode::Destructive)
+        }
+        _ => None,
+    }
+}
+
+fn is_sift_cli(command: &str) -> bool {
+    Path::new(command)
+        .file_name()
+        .and_then(OsStr::to_str)
+        .is_some_and(|name| {
+            matches!(
+                name.to_ascii_lowercase().as_str(),
+                "sift-cli" | "sift-cli.exe"
+            )
+        })
+}
+
+fn string_array(value: Option<&Value>) -> Option<Vec<String>> {
+    let Some(value) = value else {
+        return Some(Vec::new());
+    };
+    value
+        .as_array()?
+        .iter()
+        .map(|value| value.as_str().map(str::to_string))
+        .collect()
+}
+
+fn codex_metadata_is_managed(payload: &Value, transport: &Value) -> bool {
+    let Some(transport) = transport.as_object() else {
+        return false;
+    };
+    let allowed_transport = ["type", "command", "args", "env", "env_vars", "cwd"];
+    if !transport
+        .keys()
+        .all(|key| allowed_transport.contains(&key.as_str()))
+        || transport
+            .get("type")
+            .is_some_and(|value| value.as_str() != Some("stdio"))
+        || nonempty_object(transport.get("env"))
+        || nonempty_array(transport.get("env_vars"))
+        || transport.get("cwd").is_some_and(|value| !value.is_null())
+    {
+        return false;
+    }
+
+    if payload.get("transport").is_none() {
+        return true;
+    }
+    let Some(payload) = payload.as_object() else {
+        return false;
+    };
+    let allowed_payload = [
+        "name",
+        "enabled",
+        "disabled_reason",
+        "transport",
+        "enabled_tools",
+        "disabled_tools",
+        "startup_timeout_sec",
+        "tool_timeout_sec",
+    ];
+    payload
+        .keys()
+        .all(|key| allowed_payload.contains(&key.as_str()))
+        && payload.get("name").and_then(Value::as_str) == Some("sift")
+        && true_or_missing(payload.get("enabled"))
+        && null_or_missing(payload.get("disabled_reason"))
+        && empty_or_missing(payload.get("enabled_tools"))
+        && empty_or_missing(payload.get("disabled_tools"))
+        && null_or_missing(payload.get("startup_timeout_sec"))
+        && null_or_missing(payload.get("tool_timeout_sec"))
+}
+
+fn nonempty_object(value: Option<&Value>) -> bool {
+    value.is_some_and(|value| {
+        !value.is_null() && value.as_object().is_none_or(|map| !map.is_empty())
+    })
+}
+
+fn nonempty_array(value: Option<&Value>) -> bool {
+    value.is_some_and(|value| {
+        !value.is_null() && value.as_array().is_none_or(|items| !items.is_empty())
+    })
+}
+
+fn empty_or_missing(value: Option<&Value>) -> bool {
+    value.is_none_or(|value| value.is_null() || value.as_array().is_some_and(Vec::is_empty))
+}
+
+fn null_or_missing(value: Option<&Value>) -> bool {
+    value.is_none_or(Value::is_null)
+}
+
+fn true_or_missing(value: Option<&Value>) -> bool {
+    value.is_none_or(|value| value.as_bool() == Some(true))
+}
+
+fn field(contents: &str, prefix: &str) -> Option<String> {
+    contents
+        .lines()
+        .find_map(|line| line.trim().strip_prefix(prefix))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn environment_block_has_values(contents: &str) -> bool {
+    let mut environment = false;
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed == "Environment:" {
+            environment = true;
+            continue;
+        }
+        if environment {
+            if trimmed.is_empty() || trimmed.starts_with("To remove this server") {
+                return false;
+            }
+            return true;
+        }
+    }
+    false
+}
+
+fn missing_or_unavailable(output: CommandOutput) -> State {
+    let text = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    if text.to_ascii_lowercase().contains("no mcp server")
+        || text.to_ascii_lowercase().contains("not found")
+    {
+        State::Missing
+    } else {
+        State::Unavailable(one_line(&text))
+    }
+}
+
+fn add_native(harness: Harness, entry: &NativeEntry, runner: &dyn Runner) -> Result<()> {
+    let (program, mut args, action) = match harness {
+        Harness::Claude => (
+            "claude",
+            os_args(["mcp", "add", "--scope", "user", "sift", "--"]),
+            "register the Sift MCP server with Claude Code",
+        ),
+        Harness::Codex => (
+            "codex",
+            os_args(["mcp", "add", "sift", "--"]),
+            "register the Sift MCP server with Codex",
+        ),
+    };
+    args.push(OsString::from(&entry.command));
+    args.extend(entry.args.iter().map(OsString::from));
+    run_checked(runner, program, &args, action)
+}
+
+fn remove_native(harness: Harness, runner: &dyn Runner) -> Result<()> {
+    let (program, args, action) = match harness {
+        Harness::Claude => (
+            "claude",
+            os_args(["mcp", "remove", "sift", "--scope", "user"]),
+            "remove the Claude Code MCP registration",
+        ),
+        Harness::Codex => (
+            "codex",
+            os_args(["mcp", "remove", "sift"]),
+            "remove the Codex MCP registration",
+        ),
+    };
+    run_checked(runner, program, &args, action)
+}
+
+fn run_checked(runner: &dyn Runner, program: &str, args: &[OsString], action: &str) -> Result<()> {
+    let output = runner
+        .output(program, args)
+        .with_context(|| format!("failed to {action}"))?;
+    if output.success {
+        return Ok(());
+    }
+    let detail = one_line(&format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    ));
+    Err(anyhow!("failed to {action}: {detail}"))
+}
+
+fn os_args<const N: usize>(values: [&str; N]) -> Vec<OsString> {
+    values.into_iter().map(OsString::from).collect()
+}
+
+fn one_line(value: &str) -> String {
+    value
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("command failed without an error message")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, collections::VecDeque, fs};
+
+    use serde_json::json;
+    use tempdir::TempDir;
+
+    use super::*;
+
+    struct FakeRunner {
+        outputs: RefCell<VecDeque<CommandOutput>>,
+        calls: RefCell<Vec<(String, Vec<String>)>>,
+    }
+
+    impl FakeRunner {
+        fn new(outputs: impl IntoIterator<Item = CommandOutput>) -> Self {
+            Self {
+                outputs: RefCell::new(outputs.into_iter().collect()),
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl Runner for FakeRunner {
+        fn output(&self, program: &str, args: &[OsString]) -> io::Result<CommandOutput> {
+            self.calls.borrow_mut().push((
+                program.to_string(),
+                args.iter()
+                    .map(|arg| arg.to_string_lossy().to_string())
+                    .collect(),
+            ));
+            self.outputs
+                .borrow_mut()
+                .pop_front()
+                .ok_or_else(|| io::Error::other("fake runner has no queued output"))
+        }
+    }
+
+    fn output(
+        success: bool,
+        stdout: impl Into<Vec<u8>>,
+        stderr: impl Into<Vec<u8>>,
+    ) -> CommandOutput {
+        CommandOutput {
+            success,
+            stdout: stdout.into(),
+            stderr: stderr.into(),
+        }
+    }
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn only_exact_sift_mcp_argument_shapes_are_managed() {
+        assert_eq!(
+            access_from_args(&args(&["mcp"])),
+            Some(AccessMode::ReadOnly)
+        );
+        assert_eq!(
+            access_from_args(&args(&["mcp", "--allow-destructive"])),
+            Some(AccessMode::Destructive)
+        );
+
+        for custom in [
+            args(&["mcp", "--custom"]),
+            args(&["mcp", "--allow-destructive", "--extra"]),
+            args(&["--allow-destructive"]),
+            args(&["mcp", "mcp"]),
+            args(&[]),
+        ] {
+            assert_eq!(access_from_args(&custom), None);
+        }
+    }
+
+    #[test]
+    fn codex_default_metadata_is_managed_but_custom_settings_are_not() {
+        let payload = json!({
+            "name": "sift",
+            "enabled": true,
+            "disabled_reason": null,
+            "transport": {
+                "type": "stdio",
+                "command": "sift-cli",
+                "args": ["mcp"],
+                "env": null,
+                "env_vars": [],
+                "cwd": null
+            },
+            "enabled_tools": null,
+            "disabled_tools": null,
+            "startup_timeout_sec": null,
+            "tool_timeout_sec": null
+        });
+        assert!(codex_metadata_is_managed(&payload, &payload["transport"]));
+
+        for custom in [
+            ("enabled", json!(false)),
+            ("enabled", json!("true")),
+            ("enabled_tools", json!(["query"])),
+            ("disabled_tools", json!(["delete"])),
+            ("startup_timeout_sec", json!(30)),
+            ("tool_timeout_sec", json!(60)),
+        ] {
+            let mut changed = payload.clone();
+            changed[custom.0] = custom.1;
+            assert!(!codex_metadata_is_managed(&changed, &changed["transport"]));
+        }
+
+        for custom in [
+            ("env", json!({"SIFT_API_KEY": "custom"})),
+            ("env_vars", json!(["SIFT_API_KEY"])),
+            ("cwd", json!("/tmp/custom")),
+        ] {
+            let mut changed = payload.clone();
+            changed["transport"][custom.0] = custom.1;
+            assert!(!codex_metadata_is_managed(&changed, &changed["transport"]));
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn failed_native_replacement_restores_the_previous_registration() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = TempDir::new("sift-cli-agent-native-rollback").unwrap();
+        let bin = directory.path().join("bin");
+        fs::create_dir_all(&bin).unwrap();
+        let codex = bin.join("codex");
+        fs::write(&codex, "").unwrap();
+        fs::set_permissions(&codex, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let current_exe = directory.path().join("current/sift-cli");
+        let mut environment = Environment::for_test(
+            directory.path().to_path_buf(),
+            current_exe.clone(),
+            vec![Harness::Codex],
+        );
+        environment.path = bin.into_os_string();
+        let existing = json!({
+            "name": "sift",
+            "enabled": true,
+            "disabled_reason": null,
+            "transport": {
+                "type": "stdio",
+                "command": "/old/sift-cli",
+                "args": ["mcp"],
+                "env": null,
+                "env_vars": [],
+                "cwd": null
+            },
+            "enabled_tools": null,
+            "disabled_tools": null,
+            "startup_timeout_sec": null,
+            "tool_timeout_sec": null
+        });
+        let runner = FakeRunner::new([
+            output(true, serde_json::to_vec(&existing).unwrap(), Vec::new()),
+            output(true, Vec::new(), Vec::new()),
+            output(false, Vec::new(), b"desired add failed".to_vec()),
+            output(true, Vec::new(), Vec::new()),
+        ]);
+
+        let error =
+            install_with(Harness::Codex, &environment, AccessMode::ReadOnly, &runner).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("the previous MCP registration was restored")
+        );
+        assert_eq!(
+            runner.calls.into_inner(),
+            vec![
+                ("codex".to_string(), args(&["mcp", "get", "sift", "--json"])),
+                ("codex".to_string(), args(&["mcp", "remove", "sift"])),
+                (
+                    "codex".to_string(),
+                    vec![
+                        "mcp".to_string(),
+                        "add".to_string(),
+                        "sift".to_string(),
+                        "--".to_string(),
+                        current_exe.to_string_lossy().to_string(),
+                        "mcp".to_string(),
+                    ]
+                ),
+                (
+                    "codex".to_string(),
+                    args(&["mcp", "add", "sift", "--", "/old/sift-cli", "mcp"])
+                ),
+            ]
+        );
+    }
+}

--- a/rust/crates/sift_cli/src/cmd/agent/files.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/files.rs
@@ -1,0 +1,7 @@
+use std::{fs, path::Path};
+
+pub(super) fn remove_empty_parent(path: &Path) {
+    if let Some(parent) = path.parent() {
+        let _ = fs::remove_dir(parent);
+    }
+}

--- a/rust/crates/sift_cli/src/cmd/agent/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/mod.rs
@@ -1,0 +1,575 @@
+mod config;
+mod files;
+mod skill;
+
+#[cfg(test)]
+mod tests;
+
+use std::{
+    env,
+    ffi::OsString,
+    path::{Path, PathBuf},
+    process::ExitCode,
+};
+
+use anyhow::{Context, Result, anyhow};
+use semver::Version;
+
+use crate::{
+    cli::{AgentInstallArgs, AgentUpdateArgs},
+    cmd::version,
+};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(super) enum AccessMode {
+    ReadOnly,
+    Destructive,
+}
+
+impl AccessMode {
+    fn label(self) -> &'static str {
+        match self {
+            Self::ReadOnly => "read-only",
+            Self::Destructive => "destructive tools enabled",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(super) enum Harness {
+    Claude,
+    Codex,
+}
+
+impl Harness {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Claude => "Claude Code",
+            Self::Codex => "Codex",
+        }
+    }
+}
+
+pub(super) struct Environment {
+    home: PathBuf,
+    current_exe: PathBuf,
+    path: OsString,
+    harnesses: Vec<Harness>,
+}
+
+impl Environment {
+    fn discover() -> Result<Self> {
+        let home = dirs::home_dir().context("failed to locate the user home directory")?;
+        let current_exe =
+            env::current_exe().context("failed to locate the running sift-cli executable")?;
+        let path = env::var_os("PATH").unwrap_or_default();
+        let mut environment = Self {
+            home,
+            current_exe,
+            path,
+            harnesses: Vec::new(),
+        };
+        environment.harnesses = environment.detect_harnesses();
+        Ok(environment)
+    }
+
+    fn detect_harnesses(&self) -> Vec<Harness> {
+        let candidates = [
+            (Harness::Claude, &["claude"][..]),
+            (Harness::Codex, &["codex"][..]),
+        ];
+
+        candidates
+            .into_iter()
+            .filter_map(|(harness, commands)| {
+                commands
+                    .iter()
+                    .any(|command| self.command_available(command))
+                    .then_some(harness)
+            })
+            .collect()
+    }
+
+    fn command_available(&self, command: &str) -> bool {
+        env::split_paths(&self.path).any(|directory| {
+            let direct = directory.join(command);
+            if is_executable(&direct) {
+                return true;
+            }
+            cfg!(windows)
+                && ["exe", "cmd", "bat"].iter().any(|extension| {
+                    is_executable(&directory.join(format!("{command}.{extension}")))
+                })
+        })
+    }
+
+    #[cfg(test)]
+    fn for_test(home: PathBuf, current_exe: PathBuf, harnesses: Vec<Harness>) -> Self {
+        Self {
+            home,
+            current_exe,
+            path: OsString::new(),
+            harnesses,
+        }
+    }
+}
+
+pub fn install(args: AgentInstallArgs) -> Result<ExitCode> {
+    let access = if args.allow_destructive {
+        AccessMode::Destructive
+    } else {
+        AccessMode::ReadOnly
+    };
+    install_environment(&Environment::discover()?, "Installed", access)
+}
+
+pub async fn update(args: AgentUpdateArgs) -> Result<ExitCode> {
+    let current = Version::parse(env!("CARGO_PKG_VERSION"))?;
+    match version::fetch_latest().await {
+        Ok(Some(latest)) if latest > current => {
+            println!("sift-cli {current} is outdated; the current agent bundle was not installed.");
+            println!("Update the CLI and its embedded bundle with:");
+            println!("\n  {}\n", version::install_command(&latest));
+            println!("Then run `sift-cli agent update` again.");
+            return Ok(ExitCode::FAILURE);
+        }
+        Ok(_) => {}
+        Err(error) => {
+            eprintln!(
+                "warning: unable to check GitHub for a newer sift-cli release ({error}); \
+                 refreshing the bundle embedded in this CLI"
+            );
+        }
+    }
+
+    let environment = Environment::discover()?;
+    let inferred = infer_access(&environment)?;
+    let requested = if args.allow_destructive {
+        Some(AccessMode::Destructive)
+    } else if args.read_only {
+        Some(AccessMode::ReadOnly)
+    } else {
+        None
+    };
+
+    if requested.is_none() && matches!(inferred, AccessInference::Mixed) {
+        println!("No changes were made because detected MCP clients are not configured uniformly.");
+        println!("- Access modes are mixed. Choose `--allow-destructive` or `--read-only`.");
+        return Ok(ExitCode::FAILURE);
+    }
+
+    let access = requested.unwrap_or_else(|| match inferred {
+        AccessInference::Resolved(access) => access,
+        AccessInference::Mixed => unreachable!("mixed access was handled above"),
+    });
+
+    install_environment(&environment, "Updated", access)
+}
+
+pub async fn doctor() -> Result<ExitCode> {
+    let environment = Environment::discover()?;
+    println!("Sift agent bundle {}", env!("CARGO_PKG_VERSION"));
+
+    let mut unhealthy = check_release().await;
+    let mut blocked = false;
+    if environment.harnesses.is_empty() {
+        println!("[error] No supported AI coding clients were detected.");
+        return Ok(ExitCode::FAILURE);
+    }
+
+    println!(
+        "Detected: {}",
+        environment
+            .harnesses
+            .iter()
+            .map(|harness| harness.label())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    for target in skill::targets(&environment) {
+        let clients = harness_labels(&target.harnesses);
+        match skill::inspect(&target.path)? {
+            skill::State::Current => {
+                println!("[ok] {clients} skill: {}", target.path.display());
+            }
+            skill::State::Missing => {
+                println!(
+                    "[error] {clients} skill is missing: {}",
+                    target.path.display()
+                );
+                unhealthy = true;
+            }
+            skill::State::ManagedOutdated => {
+                println!(
+                    "[error] {clients} skill is from a different sift-cli release: {}",
+                    target.path.display()
+                );
+                unhealthy = true;
+            }
+            skill::State::Conflict => {
+                println!(
+                    "[error] {clients} has an unmanaged skill at {}",
+                    target.path.display()
+                );
+                unhealthy = true;
+                blocked = true;
+            }
+        }
+    }
+
+    let mut access_modes = Vec::new();
+    for harness in &environment.harnesses {
+        match config::inspect(*harness, &environment)? {
+            config::State::Current(access) => {
+                println!(
+                    "[ok] {} MCP registration ({})",
+                    harness.label(),
+                    access.label()
+                );
+                access_modes.push(access);
+            }
+            config::State::Missing => {
+                println!("[error] {} MCP registration is missing", harness.label());
+                unhealthy = true;
+            }
+            config::State::ManagedDrift(access) => {
+                println!(
+                    "[error] {} MCP registration differs from the current bundle ({})",
+                    harness.label(),
+                    access.label()
+                );
+                access_modes.push(access);
+                unhealthy = true;
+            }
+            config::State::Conflict(detail) => {
+                println!("[error] {} MCP registration: {detail}", harness.label());
+                unhealthy = true;
+                blocked = true;
+            }
+            config::State::Unavailable(detail) => {
+                println!("[error] {} MCP registration: {detail}", harness.label());
+                unhealthy = true;
+                blocked = true;
+            }
+        }
+    }
+    let mixed_access = has_mixed_access_modes(&access_modes);
+    if mixed_access {
+        println!("[error] Detected MCP clients use mixed access modes.");
+        unhealthy = true;
+    }
+
+    if unhealthy {
+        if blocked {
+            println!(
+                "Resolve the reported conflicts before repairing all detected integrations \
+                 together."
+            );
+        }
+        if mixed_access {
+            println!(
+                "Choose one explicitly with `sift-cli agent update --allow-destructive` or \
+                 `sift-cli agent update --read-only`."
+            );
+        }
+        if blocked && !mixed_access {
+            println!(
+                "Then run `sift-cli agent update` to repair all detected integrations together."
+            );
+        }
+        if !blocked && !mixed_access {
+            println!("Run `sift-cli agent update` to repair the detected integrations.");
+        }
+        Ok(ExitCode::FAILURE)
+    } else {
+        println!("All detected Sift agent integrations are healthy.");
+        Ok(ExitCode::SUCCESS)
+    }
+}
+
+pub fn uninstall() -> Result<ExitCode> {
+    uninstall_environment(&Environment::discover()?)
+}
+
+fn uninstall_environment(environment: &Environment) -> Result<ExitCode> {
+    if environment.harnesses.is_empty() {
+        println!("No supported AI coding clients were detected; nothing to uninstall.");
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    let targets = skill::targets(environment);
+    let mut blockers = Vec::new();
+    for target in &targets {
+        if skill::inspect(&target.path)? == skill::State::Conflict {
+            blockers.push(format!(
+                "{} has an unmanaged skill at {}",
+                harness_labels(&target.harnesses),
+                target.path.display()
+            ));
+        }
+    }
+    for harness in &environment.harnesses {
+        match config::inspect(*harness, environment)? {
+            config::State::Conflict(detail) | config::State::Unavailable(detail) => {
+                blockers.push(format!("{} MCP registration: {detail}", harness.label()));
+            }
+            _ => {}
+        }
+    }
+    if !blockers.is_empty() {
+        println!("No changes were made because the existing setup needs attention:");
+        for blocker in blockers {
+            println!("  - {blocker}");
+        }
+        return Ok(ExitCode::FAILURE);
+    }
+
+    for target in targets {
+        let clients = harness_labels(&target.harnesses);
+        match skill::inspect(&target.path)? {
+            skill::State::Missing => println!("[skip] {clients} skill was not installed"),
+            skill::State::Current | skill::State::ManagedOutdated => {
+                skill::uninstall(&target.path)?;
+                println!("[removed] {clients} skill: {}", target.path.display());
+            }
+            skill::State::Conflict => {
+                unreachable!("unmanaged skills are rejected during preflight");
+            }
+        }
+    }
+
+    for harness in &environment.harnesses {
+        let state = config::inspect(*harness, environment)?;
+        match &state {
+            config::State::Missing => {
+                println!(
+                    "[skip] {} MCP registration was not installed",
+                    harness.label()
+                );
+            }
+            config::State::Conflict(detail) | config::State::Unavailable(detail) => {
+                unreachable!(
+                    "{} config changed after preflight: {detail}",
+                    harness.label()
+                );
+            }
+            config::State::Current(_) | config::State::ManagedDrift(_) => {
+                config::uninstall(*harness, environment)?;
+                println!("[removed] {} MCP registration", harness.label());
+            }
+        }
+    }
+
+    println!("Removed the Sift agent bundle from every detected client.");
+    Ok(ExitCode::SUCCESS)
+}
+
+fn install_environment(
+    environment: &Environment,
+    verb: &str,
+    access: AccessMode,
+) -> Result<ExitCode> {
+    if environment.harnesses.is_empty() {
+        println!(
+            "No supported AI coding clients were detected. Supported clients: \
+             Claude Code and Codex."
+        );
+        return Ok(ExitCode::FAILURE);
+    }
+
+    let targets = skill::targets(environment);
+    let mut blockers = Vec::new();
+    for target in &targets {
+        if skill::inspect(&target.path)? == skill::State::Conflict {
+            blockers.push(format!(
+                "{} has an unmanaged skill at {}",
+                harness_labels(&target.harnesses),
+                target.path.display()
+            ));
+        }
+    }
+    for harness in &environment.harnesses {
+        let state = config::inspect(*harness, environment)?;
+        match state {
+            config::State::Conflict(detail) | config::State::Unavailable(detail) => {
+                blockers.push(format!("{} MCP registration: {detail}", harness.label()));
+            }
+            _ => {}
+        }
+    }
+
+    if !blockers.is_empty() {
+        println!("No changes were made because the existing setup needs attention:");
+        for blocker in blockers {
+            println!("  - {blocker}");
+        }
+        return Ok(ExitCode::FAILURE);
+    }
+
+    let config_snapshots = environment
+        .harnesses
+        .iter()
+        .map(|harness| config::snapshot(*harness, environment))
+        .collect::<Result<Vec<_>>>()?;
+    let mut replacements = Vec::new();
+    let mut installed_configs = 0;
+    let apply_result = (|| -> Result<()> {
+        for target in &targets {
+            replacements.push(skill::begin_install(&target.path)?);
+        }
+        for harness in &environment.harnesses {
+            config::install(*harness, environment, access)?;
+            installed_configs += 1;
+        }
+        Ok(())
+    })();
+    if let Err(error) = apply_result {
+        let mut rollback_errors = Vec::new();
+        for snapshot in config_snapshots[..installed_configs].iter().rev() {
+            if let Err(rollback_error) = config::restore(snapshot, environment) {
+                rollback_errors.push(rollback_error.to_string());
+            }
+        }
+        for replacement in replacements.into_iter().rev() {
+            if let Err(rollback_error) = replacement.rollback() {
+                rollback_errors.push(rollback_error.to_string());
+            }
+        }
+        if rollback_errors.is_empty() {
+            return Err(error.context("all earlier agent integration changes were rolled back"));
+        }
+        return Err(anyhow!(
+            "{error:#}; rollback also failed: {}",
+            rollback_errors.join("; ")
+        ));
+    }
+
+    let mut cleanup_errors = Vec::new();
+    for replacement in replacements {
+        if let Err(error) = replacement.commit() {
+            cleanup_errors.push(error.to_string());
+        }
+    }
+    if !cleanup_errors.is_empty() {
+        return Err(anyhow!(
+            "installed the agent bundle but failed to remove temporary backups: {}",
+            cleanup_errors.join("; ")
+        ));
+    }
+
+    for target in &targets {
+        println!(
+            "[ok] {verb} {} skill: {}",
+            harness_labels(&target.harnesses),
+            target.path.display()
+        );
+    }
+    for harness in &environment.harnesses {
+        println!(
+            "[ok] {verb} {} MCP registration ({})",
+            harness.label(),
+            access.label()
+        );
+    }
+
+    println!(
+        "{verb} the Sift agent bundle for: {} ({}).",
+        harness_labels(&environment.harnesses),
+        access.label()
+    );
+    Ok(ExitCode::SUCCESS)
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum AccessInference {
+    Resolved(AccessMode),
+    Mixed,
+}
+
+fn infer_access(environment: &Environment) -> Result<AccessInference> {
+    let mut access_modes = Vec::new();
+    for harness in &environment.harnesses {
+        match config::inspect(*harness, environment)? {
+            config::State::Current(access) | config::State::ManagedDrift(access) => {
+                access_modes.push(access);
+            }
+            _ => {}
+        }
+    }
+    Ok(infer_access_modes(&access_modes))
+}
+
+fn infer_access_modes(access_modes: &[AccessMode]) -> AccessInference {
+    if has_mixed_access_modes(access_modes) {
+        AccessInference::Mixed
+    } else {
+        AccessInference::Resolved(
+            access_modes
+                .first()
+                .copied()
+                .unwrap_or(AccessMode::ReadOnly),
+        )
+    }
+}
+
+fn has_mixed_access_modes(access_modes: &[AccessMode]) -> bool {
+    access_modes
+        .first()
+        .is_some_and(|first| access_modes.iter().any(|access| access != first))
+}
+
+async fn check_release() -> bool {
+    let current = match Version::parse(env!("CARGO_PKG_VERSION")) {
+        Ok(current) => current,
+        Err(error) => {
+            println!("[warning] Could not parse the installed CLI version: {error}");
+            return false;
+        }
+    };
+    match version::fetch_latest().await {
+        Ok(Some(latest)) if latest > current => {
+            println!("[error] sift-cli {current} is outdated; latest is {latest}");
+            println!("Update with:\n\n  {}\n", version::install_command(&latest));
+            true
+        }
+        Ok(Some(_)) => {
+            println!("[ok] sift-cli {current} is current");
+            false
+        }
+        Ok(None) => {
+            println!("[warning] No stable sift-cli releases were found on GitHub");
+            false
+        }
+        Err(error) => {
+            println!("[warning] Could not check for a newer sift-cli release: {error}");
+            false
+        }
+    }
+}
+
+fn harness_labels(harnesses: &[Harness]) -> String {
+    harnesses
+        .iter()
+        .map(|harness| harness.label())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn is_executable(path: &Path) -> bool {
+    let Ok(metadata) = path.metadata() else {
+        return false;
+    };
+    if !metadata.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        metadata.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}

--- a/rust/crates/sift_cli/src/cmd/agent/skill.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/skill.rs
@@ -1,0 +1,290 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ffi::OsString,
+    fs,
+    io::ErrorKind,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, anyhow};
+use include_dir::{Dir, include_dir};
+
+use super::{Environment, Harness, files};
+
+#[cfg(test)]
+pub(super) const CONTENT: &str = include_str!("../../../assets/skills/sift/SKILL.md");
+static BUNDLE: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/assets/skills/sift");
+const MANAGED_MARKER: &str = "Managed by sift-cli.";
+const LEGACY_MARKER: &str = "LOCKSTEP:";
+const SIFT_HEADING: &str = "# Sift toolbox";
+/// Backup names carry the PID, so a live run only collides with its own targets.
+/// Extra indices are orphans a killed run never got to delete, so bound the probe
+/// and fail loudly instead of scanning a littered directory forever.
+const MAX_BACKUP_CANDIDATES: u32 = 100;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(super) enum State {
+    Missing,
+    Current,
+    ManagedOutdated,
+    Conflict,
+}
+
+#[derive(Debug)]
+pub(super) struct Target {
+    pub path: PathBuf,
+    pub harnesses: Vec<Harness>,
+}
+
+#[derive(Debug)]
+pub(super) struct Replacement {
+    path: PathBuf,
+    backup: Option<PathBuf>,
+}
+
+impl Replacement {
+    pub(super) fn commit(self) -> Result<()> {
+        if let Some(backup) = self.backup {
+            fs::remove_dir_all(&backup)
+                .with_context(|| format!("failed to remove {}", backup.display()))?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn rollback(self) -> Result<()> {
+        remove_path(&self.path)?;
+        if let Some(backup) = self.backup {
+            fs::rename(&backup, &self.path).with_context(|| {
+                format!(
+                    "failed to restore {} from {}",
+                    self.path.display(),
+                    backup.display()
+                )
+            })?;
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn targets(environment: &Environment) -> Vec<Target> {
+    let mut by_path = BTreeMap::<PathBuf, Vec<Harness>>::new();
+
+    for harness in &environment.harnesses {
+        let path = match harness {
+            Harness::Claude => environment.home.join(".claude").join("skills").join("sift"),
+            Harness::Codex => environment.home.join(".agents").join("skills").join("sift"),
+        };
+        by_path.entry(path).or_default().push(*harness);
+    }
+
+    by_path
+        .into_iter()
+        .map(|(path, harnesses)| Target { path, harnesses })
+        .collect()
+}
+
+pub(super) fn inspect(path: &Path) -> Result<State> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => return Ok(State::Conflict),
+        Ok(metadata) if !metadata.is_dir() => return Ok(State::Conflict),
+        Ok(_) => {}
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(State::Missing),
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to inspect {}", path.display()));
+        }
+    }
+
+    if directory_matches(&BUNDLE, path)? {
+        return Ok(State::Current);
+    }
+
+    let skill_path = path.join("SKILL.md");
+    let installed = match fs::read_to_string(&skill_path) {
+        Ok(installed) => installed,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(State::Conflict),
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to read {}", skill_path.display()));
+        }
+    };
+
+    if is_managed(&installed) {
+        Ok(State::ManagedOutdated)
+    } else {
+        Ok(State::Conflict)
+    }
+}
+
+#[cfg(test)]
+pub(super) fn install(path: &Path) -> Result<()> {
+    begin_install(path)?.commit()
+}
+
+pub(super) fn begin_install(path: &Path) -> Result<Replacement> {
+    let backup = match inspect(path)? {
+        State::Conflict => {
+            return Err(anyhow!(
+                "{} is not a managed skill directory",
+                path.display()
+            ));
+        }
+        State::Missing => None,
+        State::Current | State::ManagedOutdated => {
+            let backup = unused_backup_path(path)?;
+            fs::rename(path, &backup).with_context(|| {
+                format!("failed to move {} to {}", path.display(), backup.display())
+            })?;
+            Some(backup)
+        }
+    };
+
+    if let Err(error) = copy_bundle(&BUNDLE, path) {
+        let replacement = Replacement {
+            path: path.to_path_buf(),
+            backup,
+        };
+        return match replacement.rollback() {
+            Ok(()) => Err(error.context("the previous skill directory was restored")),
+            Err(rollback_error) => Err(anyhow!(
+                "{error:#}; restoring the previous skill directory also failed: {rollback_error:#}"
+            )),
+        };
+    }
+    Ok(Replacement {
+        path: path.to_path_buf(),
+        backup,
+    })
+}
+
+pub(super) fn uninstall(path: &Path) -> Result<bool> {
+    match inspect(path)? {
+        State::Missing => Ok(false),
+        State::Current | State::ManagedOutdated => {
+            fs::remove_dir_all(path)
+                .with_context(|| format!("failed to remove {}", path.display()))?;
+            files::remove_empty_parent(path);
+            Ok(true)
+        }
+        State::Conflict => Ok(false),
+    }
+}
+
+fn is_managed(contents: &str) -> bool {
+    contents.contains(SIFT_HEADING)
+        && (contents.contains(MANAGED_MARKER) || contents.contains(LEGACY_MARKER))
+}
+
+fn directory_matches(bundle: &Dir<'_>, installed: &Path) -> Result<bool> {
+    let actual_entries = fs::read_dir(installed)
+        .with_context(|| format!("failed to read {}", installed.display()))?
+        .map(|entry| entry.map(|entry| entry.file_name()))
+        .collect::<std::io::Result<BTreeSet<OsString>>>()
+        .with_context(|| format!("failed to read {}", installed.display()))?;
+    let expected_entries = bundle
+        .files()
+        .filter_map(|file| file.path().file_name().map(OsString::from))
+        .chain(
+            bundle
+                .dirs()
+                .filter_map(|directory| directory.path().file_name().map(OsString::from)),
+        )
+        .collect::<BTreeSet<_>>();
+    if actual_entries != expected_entries {
+        return Ok(false);
+    }
+
+    for file in bundle.files() {
+        let name = file
+            .path()
+            .file_name()
+            .ok_or_else(|| anyhow!("embedded skill file has no name"))?;
+        let target = installed.join(name);
+        let metadata = fs::symlink_metadata(&target)
+            .with_context(|| format!("failed to inspect {}", target.display()))?;
+        if metadata.file_type().is_symlink()
+            || !metadata.is_file()
+            || fs::read(&target).with_context(|| format!("failed to read {}", target.display()))?
+                != file.contents()
+        {
+            return Ok(false);
+        }
+    }
+
+    for directory in bundle.dirs() {
+        let name = directory
+            .path()
+            .file_name()
+            .ok_or_else(|| anyhow!("embedded skill directory has no name"))?;
+        let target = installed.join(name);
+        let metadata = fs::symlink_metadata(&target)
+            .with_context(|| format!("failed to inspect {}", target.display()))?;
+        if metadata.file_type().is_symlink()
+            || !metadata.is_dir()
+            || !directory_matches(directory, &target)?
+        {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+fn copy_bundle(bundle: &Dir<'_>, destination: &Path) -> Result<()> {
+    fs::create_dir_all(destination)
+        .with_context(|| format!("failed to create {}", destination.display()))?;
+
+    for directory in bundle.dirs() {
+        let name = directory
+            .path()
+            .file_name()
+            .ok_or_else(|| anyhow!("embedded skill directory has no name"))?;
+        copy_bundle(directory, &destination.join(name))?;
+    }
+    for file in bundle.files() {
+        let name = file
+            .path()
+            .file_name()
+            .ok_or_else(|| anyhow!("embedded skill file has no name"))?;
+        let target = destination.join(name);
+        fs::write(&target, file.contents())
+            .with_context(|| format!("failed to write {}", target.display()))?;
+    }
+
+    Ok(())
+}
+
+fn unused_backup_path(path: &Path) -> Result<PathBuf> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .ok_or_else(|| anyhow!("{} has no parent directory", path.display()))?;
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("sift");
+    for index in 0..MAX_BACKUP_CANDIDATES {
+        let candidate = parent.join(format!(
+            ".{name}.sift-cli-backup-{}-{index}",
+            std::process::id()
+        ));
+        if !candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+    Err(anyhow!(
+        "failed to find an unused backup path beside {}",
+        path.display()
+    ))
+}
+
+fn remove_path(path: &Path) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {
+            fs::remove_dir_all(path).with_context(|| format!("failed to remove {}", path.display()))
+        }
+        Ok(_) => {
+            fs::remove_file(path).with_context(|| format!("failed to remove {}", path.display()))
+        }
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).with_context(|| format!("failed to inspect {}", path.display())),
+    }
+}

--- a/rust/crates/sift_cli/src/cmd/agent/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/tests.rs
@@ -1,0 +1,172 @@
+use std::{fs, path::PathBuf};
+
+use clap::Parser;
+use tempdir::TempDir;
+
+use super::{AccessInference, AccessMode, Environment, Harness, skill};
+
+fn environment(harnesses: Vec<Harness>) -> (TempDir, Environment) {
+    let directory = TempDir::new("sift-cli-agent-tests").unwrap();
+    let current_exe = directory.path().join("bin").join("sift-cli");
+    (
+        directory,
+        Environment::for_test(PathBuf::new(), current_exe, harnesses),
+    )
+}
+
+#[test]
+fn stale_native_config_directories_are_not_detected_as_installed_clients() {
+    let directory = TempDir::new("sift-cli-agent-detection").unwrap();
+    fs::create_dir_all(directory.path().join(".claude")).unwrap();
+    fs::create_dir_all(directory.path().join(".codex")).unwrap();
+    let environment = Environment::for_test(
+        directory.path().to_path_buf(),
+        directory.path().join("bin/sift-cli"),
+        Vec::new(),
+    );
+
+    assert!(environment.detect_harnesses().is_empty());
+}
+
+#[test]
+fn claude_and_codex_install_the_skill_to_their_own_conventions() {
+    let (directory, mut environment) = environment(vec![Harness::Claude, Harness::Codex]);
+    environment.home = directory.path().to_path_buf();
+
+    let targets = skill::targets(&environment);
+
+    assert_eq!(targets.len(), 2);
+    let paths = targets
+        .iter()
+        .map(|target| target.path.clone())
+        .collect::<Vec<_>>();
+    assert!(paths.contains(&directory.path().join(".claude/skills/sift")));
+    assert!(paths.contains(&directory.path().join(".agents/skills/sift")));
+}
+
+#[test]
+fn skill_install_is_fresh_and_stateless() {
+    let directory = TempDir::new("sift-cli-agent-skill").unwrap();
+    let path = directory.path().join(".agents/skills/sift");
+
+    assert_eq!(skill::inspect(&path).unwrap(), skill::State::Missing);
+    skill::install(&path).unwrap();
+    assert_eq!(skill::inspect(&path).unwrap(), skill::State::Current);
+
+    fs::write(
+        path.join("SKILL.md"),
+        skill::CONTENT.replace("# Sift toolbox", "# Sift toolbox\n\nOld release."),
+    )
+    .unwrap();
+    assert_eq!(
+        skill::inspect(&path).unwrap(),
+        skill::State::ManagedOutdated
+    );
+    skill::install(&path).unwrap();
+    assert_eq!(skill::inspect(&path).unwrap(), skill::State::Current);
+}
+
+#[test]
+fn skill_install_removes_every_stale_managed_file() {
+    let directory = TempDir::new("sift-cli-agent-skill-mirror").unwrap();
+    let path = directory.path().join(".agents/skills/sift");
+    skill::install(&path).unwrap();
+    fs::write(path.join("removed.md"), "stale top-level content").unwrap();
+    fs::create_dir_all(path.join("old/nested")).unwrap();
+    fs::write(path.join("old/nested/removed.md"), "stale nested content").unwrap();
+
+    assert_eq!(
+        skill::inspect(&path).unwrap(),
+        skill::State::ManagedOutdated
+    );
+    skill::install(&path).unwrap();
+
+    assert_eq!(skill::inspect(&path).unwrap(), skill::State::Current);
+    assert!(!path.join("removed.md").exists());
+    assert!(!path.join("old").exists());
+    assert_eq!(
+        fs::read_to_string(path.join("SKILL.md")).unwrap(),
+        skill::CONTENT
+    );
+}
+
+#[test]
+fn successful_reinstall_leaves_no_backup_behind() {
+    let directory = TempDir::new("sift-cli-agent-skill-backup").unwrap();
+    let path = directory.path().join(".agents/skills/sift");
+
+    skill::install(&path).unwrap();
+    skill::install(&path).unwrap();
+
+    let leftovers = fs::read_dir(path.parent().unwrap())
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name().to_string_lossy().to_string())
+        .filter(|name| name.contains("sift-cli-backup"))
+        .collect::<Vec<_>>();
+
+    assert!(leftovers.is_empty(), "backups left behind: {leftovers:?}");
+}
+
+#[test]
+fn unmanaged_skill_is_never_removed() {
+    let directory = TempDir::new("sift-cli-agent-skill-conflict").unwrap();
+    let path = directory.path().join(".agents/skills/sift");
+    fs::create_dir_all(&path).unwrap();
+    fs::write(
+        path.join("SKILL.md"),
+        "---\nname: sift\n---\nCustom instructions.\n",
+    )
+    .unwrap();
+
+    assert_eq!(skill::inspect(&path).unwrap(), skill::State::Conflict);
+    assert!(!skill::uninstall(&path).unwrap());
+    assert!(path.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinked_skill_is_never_replaced() {
+    use std::os::unix::fs::symlink;
+
+    let directory = TempDir::new("sift-cli-agent-symlink").unwrap();
+    let source = directory.path().join("source");
+    let path = directory.path().join(".agents/skills/sift");
+    fs::create_dir_all(&source).unwrap();
+    fs::write(source.join("SKILL.md"), skill::CONTENT).unwrap();
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    symlink(&source, &path).unwrap();
+
+    assert_eq!(skill::inspect(&path).unwrap(), skill::State::Conflict);
+    assert!(!skill::uninstall(&path).unwrap());
+    assert!(path.is_symlink());
+}
+
+#[test]
+fn update_access_inference_preserves_one_mode_and_rejects_mixed_modes() {
+    assert_eq!(
+        super::infer_access_modes(&[]),
+        AccessInference::Resolved(AccessMode::ReadOnly)
+    );
+    assert_eq!(
+        super::infer_access_modes(&[AccessMode::Destructive, AccessMode::Destructive]),
+        AccessInference::Resolved(AccessMode::Destructive)
+    );
+    assert_eq!(
+        super::infer_access_modes(&[AccessMode::ReadOnly, AccessMode::Destructive]),
+        AccessInference::Mixed
+    );
+}
+
+#[test]
+fn update_access_flags_are_mutually_exclusive() {
+    assert!(
+        crate::cli::Args::try_parse_from([
+            "sift-cli",
+            "agent",
+            "update",
+            "--allow-destructive",
+            "--read-only",
+        ])
+        .is_err()
+    );
+}

--- a/rust/crates/sift_cli/src/cmd/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/mod.rs
@@ -4,6 +4,8 @@ use crossterm::style::Stylize;
 use std::{fs::read_to_string, io::ErrorKind};
 use toml::{Table, Value};
 
+#[cfg(feature = "mcp")]
+pub mod agent;
 pub mod config;
 pub mod doc;
 pub mod export;

--- a/rust/crates/sift_cli/src/cmd/version.rs
+++ b/rust/crates/sift_cli/src/cmd/version.rs
@@ -15,6 +15,10 @@ const USER_AGENT: &str = concat!("sift-cli/", env!("CARGO_PKG_VERSION"));
 #[derive(Deserialize)]
 struct GithubRelease {
     tag_name: String,
+    #[serde(default)]
+    draft: bool,
+    #[serde(default)]
+    prerelease: bool,
 }
 
 pub async fn run() -> Result<ExitCode> {
@@ -60,13 +64,13 @@ pub async fn run() -> Result<ExitCode> {
     Ok(ExitCode::SUCCESS)
 }
 
-async fn fetch_latest() -> Result<Option<Version>> {
+pub(crate) async fn fetch_latest() -> Result<Option<Version>> {
     let client = ClientBuilder::new()
         .user_agent(USER_AGENT)
         .timeout(Duration::from_secs(5))
         .build()?;
 
-    let mut releases: Vec<GithubRelease> = client
+    let releases: Vec<GithubRelease> = client
         .get(RELEASES_URL)
         .send()
         .await?
@@ -74,23 +78,20 @@ async fn fetch_latest() -> Result<Option<Version>> {
         .json()
         .await?;
 
-    let mut i = 0;
-    while i < releases.len() {
-        if releases[i].tag_name.contains("alpha") {
-            releases.remove(i);
-        } else {
-            i += 1;
-        }
-    }
-
-    Ok(releases
-        .into_iter()
-        .filter_map(|r| r.tag_name.strip_prefix(TAG_PREFIX).map(str::to_string))
-        .filter_map(|v| Version::parse(&v).ok())
-        .max())
+    Ok(latest_stable(releases))
 }
 
-fn install_command(latest: &Version) -> String {
+fn latest_stable(releases: Vec<GithubRelease>) -> Option<Version> {
+    releases
+        .into_iter()
+        .filter(|release| !release.draft && !release.prerelease)
+        .filter_map(|r| r.tag_name.strip_prefix(TAG_PREFIX).map(str::to_string))
+        .filter_map(|v| Version::parse(&v).ok())
+        .filter(|version| version.pre.is_empty())
+        .max()
+}
+
+pub(crate) fn install_command(latest: &Version) -> String {
     let (asset, cmd_tmpl) = if cfg!(windows) {
         (
             "sift_cli-installer.ps1",
@@ -107,4 +108,36 @@ fn install_command(latest: &Version) -> String {
         "https://github.com/sift-stack/sift/releases/download/{TAG_PREFIX}{latest}/{asset}"
     );
     cmd_tmpl.replace("{url}", &url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GithubRelease, latest_stable};
+    use semver::Version;
+
+    #[test]
+    fn latest_release_excludes_drafts_and_prereleases() {
+        let releases = vec![
+            GithubRelease {
+                tag_name: "sift_cli-v0.4.0-alpha.1".to_string(),
+                draft: false,
+                prerelease: true,
+            },
+            GithubRelease {
+                tag_name: "sift_cli-v0.3.1".to_string(),
+                draft: true,
+                prerelease: false,
+            },
+            GithubRelease {
+                tag_name: "sift_cli-v0.3.0".to_string(),
+                draft: false,
+                prerelease: false,
+            },
+        ];
+
+        assert_eq!(
+            latest_stable(releases),
+            Some(Version::parse("0.3.0").unwrap())
+        );
+    }
 }

--- a/rust/crates/sift_cli/src/main.rs
+++ b/rust/crates/sift_cli/src/main.rs
@@ -14,6 +14,8 @@ use util::tty::Output;
 
 use clap::{CommandFactory, Parser};
 
+#[cfg(feature = "mcp")]
+use crate::cli::AgentCmd;
 use crate::cli::InstallCmd;
 
 const BIN_NAME: &str = "sift-cli";
@@ -79,6 +81,13 @@ fn run(clargs: cli::Args) -> Result<ExitCode> {
                 cli::CompletionsCmd::Print(args) => return cmd::install::completions::print(args),
                 cli::CompletionsCmd::Update => return cmd::install::completions::update(),
             },
+        },
+        #[cfg(feature = "mcp")]
+        Cmd::Agent(cmd) => match cmd {
+            AgentCmd::Install(args) => return cmd::agent::install(args),
+            AgentCmd::Update(args) => return run_future(cmd::agent::update(args)),
+            AgentCmd::Doctor => return run_future(cmd::agent::doctor()),
+            AgentCmd::Uninstall => return cmd::agent::uninstall(),
         },
         _ => (),
     }

--- a/rust/crates/sift_mcp/src/server/mod.rs
+++ b/rust/crates/sift_mcp/src/server/mod.rs
@@ -43,7 +43,12 @@ pub struct SiftMcpServer {
     router = self.tool_router,
     name = "SiftMcp",
     version = "0.1.0",
-    instructions = "Sift MCP Server",
+    instructions = "Use Sift tools for telemetry discovery, analysis, and \
+    ingestion. Run `sift-cli agent doctor` for read-only integration \
+    diagnosis, `sift-cli agent install` for first setup, and \
+    `sift-cli agent update` to refresh every detected client together. If the \
+    CLI is outdated, relay the exact curl or PowerShell installer it prints. \
+    Never enable destructive tools without explicit user approval.",
 )]
 #[prompt_handler(router = self.prompt_router)]
 impl ServerHandler for SiftMcpServer {
@@ -133,14 +138,17 @@ impl SiftMcpServer {
             return Ok(());
         }
         Err(ErrorData::invalid_request(
-            "This tool is destructive and is disabled. Ask the user to relaunch \
-             the Sift MCP server with the `--allow-destructive` flag (e.g. \
-             `sift-cli mcp --allow-destructive`) and update their MCP client \
-             config accordingly. Do not retry until they confirm the server has \
-             been restarted.",
+            "This tool is destructive and is disabled. Ask the user for explicit \
+             approval to enable destructive Sift tools. If they approve, run \
+             `sift-cli agent update --allow-destructive` to update every detected \
+             client together, then ask the user to reload or restart their MCP \
+             client. Do not retry until they confirm the client has restarted.",
             Some(serde_json::json!({
                 "status": "stopped",
                 "reason": "DestructiveToolsDisabled",
+                "requires_user_approval": true,
+                "remediation_command": "sift-cli agent update --allow-destructive",
+                "restart_required": true,
             })),
         ))
     }

--- a/rust/crates/sift_mcp/src/tool/assets/test.rs
+++ b/rust/crates/sift_mcp/src/tool/assets/test.rs
@@ -1,5 +1,4 @@
-use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::ErrorCode;
+use rmcp::{ServerHandler, handler::server::wrapper::Parameters, model::ErrorCode};
 use sift_rs::assets::v1::{Asset, ListAssetsResponse, asset_service_server::AssetServiceServer};
 use sift_test_util::{grpc::memory_sift_channel, mock::assets::v1::MockAssetServiceImpl};
 use tokio::task::JoinHandle;
@@ -41,6 +40,19 @@ async fn server_with_mock_and_flag(
         ),
         handle,
     )
+}
+
+#[tokio::test]
+async fn server_instructions_explain_agent_lifecycle() {
+    let (server, _h) = server_with_mock(MockAssetServiceImpl::new()).await;
+    let instructions = ServerHandler::get_info(&server)
+        .instructions
+        .expect("server should advertise lifecycle instructions");
+
+    assert!(instructions.contains("sift-cli agent"));
+    assert!(instructions.contains("doctor"));
+    assert!(instructions.contains("install"));
+    assert!(instructions.contains("update"));
 }
 
 #[tokio::test]
@@ -239,6 +251,20 @@ async fn update_asset_blocked_without_allow_destructive() {
 
     assert_eq!(err.code, ErrorCode::INVALID_REQUEST);
     assert!(err.message.contains("--allow-destructive"));
+    assert!(
+        err.message
+            .contains("sift-cli agent update --allow-destructive")
+    );
+    assert!(err.message.contains("explicit approval"));
+    let data = err
+        .data
+        .expect("destructive gate should return remediation data");
+    assert_eq!(data["requires_user_approval"], true);
+    assert_eq!(
+        data["remediation_command"],
+        "sift-cli agent update --allow-destructive"
+    );
+    assert_eq!(data["restart_required"], true);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Changes

Adds `sift-cli agent install|update|doctor|uninstall`, replacing the removed project-scoped skill writer with four stateless, user-scoped commands. State is derived from the installed files and each client's own MCP config, so there is no state file to drift.

Registers through each client's native CLI (`claude mcp`, `codex mcp`) rather than editing their config files. A Codex registration counts as Sift-managed only when both the transport and the surrounding metadata match what this CLI writes, so a hand-tuned entry is reported as a conflict instead of being silently replaced. Native replacement is remove-then-add, and a failed add restores the previous entry.

Install and update preflight every target and refuse to touch an unmanaged same-name skill or MCP entry. Skill install mirrors the embedded bundle exactly, so files a previous release left behind are removed. Registrations default to read-only; update preserves whatever mode is installed and rejects a mixed fleet rather than choosing for the user.

Points the MCP server's instructions and destructive-tool refusal at these commands, and makes `agent update` refuse to run on an outdated CLI, printing the installer for the newer release. Release lookup now skips drafts and prereleases.

## Verification

- `cargo fmt --check --all`, `cargo clippy --all-features`, `cargo test --all-features`
- 11 new `cmd::agent` tests plus the `cmd::version` release-filter test

## Note for reviewers

Rollback of a partial multi-client install is covered here by the native replacement test. The cross-client transaction tests arrive with the JSON-backed clients in the next PR, which can be driven directly without a fake process runner.
