### PR TITLE
rust(feat): add Cursor and OpenCode agent support

### DIFF
--- a/rust/crates/sift_cli/AGENTS.md
+++ b/rust/crates/sift_cli/AGENTS.md
@@ -6,8 +6,8 @@
 
 Do not add per-client copies of the skill. The pair of near-identical files this
 replaced drifted apart, which is the failure this layout exists to prevent.
-Claude installs the canonical file to `~/.claude/skills/sift/SKILL.md`; Codex
-uses `~/.agents/skills/sift/SKILL.md`.
+Claude installs the canonical file to `~/.claude/skills/sift/SKILL.md`; Codex,
+Cursor, and OpenCode share `~/.agents/skills/sift/SKILL.md`.
 
 The skill is embedded at compile time, so rebuild `sift-cli` after changing it.
 

--- a/rust/crates/sift_cli/CHANGELOG.md
+++ b/rust/crates/sift_cli/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added `sift-cli agent install`, `update`, `doctor`, and `uninstall` for
   stateless, lockstep management of the release-matched Sift skill and MCP
-  sidecar across detected Claude Code and Codex clients.
+  sidecar across detected Claude Code, Codex, Cursor, and OpenCode clients.
 - Added safe-by-default, lockstep MCP access controls: install defaults to
   read-only, update preserves the existing mode, explicit flags enable or
   disable destructive tools for all detected clients, and doctor reports mixed

--- a/rust/crates/sift_cli/src/cmd/agent/config.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/config.rs
@@ -1,14 +1,15 @@
 use std::{
     ffi::{OsStr, OsString},
-    io,
-    path::Path,
+    fs,
+    io::{self, ErrorKind},
+    path::{Path, PathBuf},
     process::Command,
 };
 
 use anyhow::{Context, Result, anyhow};
-use serde_json::Value;
+use serde_json::{Map, Value, json};
 
-use super::{AccessMode, Environment, Harness};
+use super::{AccessMode, Environment, Harness, files};
 
 #[derive(Debug)]
 struct CommandOutput {
@@ -51,7 +52,16 @@ struct NativeInspection {
 #[derive(Debug)]
 pub(super) struct Snapshot {
     harness: Harness,
-    previous: Option<NativeEntry>,
+    contents: SnapshotContents,
+}
+
+#[derive(Debug)]
+enum SnapshotContents {
+    Native(Option<NativeEntry>),
+    Json {
+        path: PathBuf,
+        contents: Option<Vec<u8>>,
+    },
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -68,31 +78,83 @@ pub(super) fn inspect(harness: Harness, environment: &Environment) -> Result<Sta
 }
 
 pub(super) fn snapshot(harness: Harness, environment: &Environment) -> Result<Snapshot> {
-    let inspection = inspect_native(harness, environment, &SystemRunner)?;
-    let previous = match inspection.state {
-        State::Missing => None,
-        State::Current(_) | State::ManagedDrift(_) => inspection.entry,
-        State::Conflict(detail) | State::Unavailable(detail) => {
-            return Err(anyhow!(
-                "{} MCP registration cannot be snapshotted: {detail}",
-                harness.label()
-            ));
+    let contents = match harness {
+        Harness::Claude | Harness::Codex => {
+            let inspection = inspect_native(harness, environment, &SystemRunner)?;
+            match inspection.state {
+                State::Missing => SnapshotContents::Native(None),
+                State::Current(_) | State::ManagedDrift(_) => {
+                    SnapshotContents::Native(inspection.entry)
+                }
+                State::Conflict(detail) | State::Unavailable(detail) => {
+                    return Err(anyhow!(
+                        "{} MCP registration cannot be snapshotted: {detail}",
+                        harness.label()
+                    ));
+                }
+            }
+        }
+        Harness::Cursor | Harness::OpenCode => {
+            let path = json_path(harness, environment);
+            let contents = match fs::symlink_metadata(&path) {
+                Ok(metadata) if metadata.file_type().is_symlink() => {
+                    return Err(anyhow!(
+                        "{} is a symbolic link; refusing to snapshot it",
+                        path.display()
+                    ));
+                }
+                Ok(_) => Some(
+                    fs::read(&path)
+                        .with_context(|| format!("failed to read {}", path.display()))?,
+                ),
+                Err(error) if error.kind() == ErrorKind::NotFound => None,
+                Err(error) => {
+                    return Err(error)
+                        .with_context(|| format!("failed to inspect {}", path.display()));
+                }
+            };
+            SnapshotContents::Json { path, contents }
         }
     };
-    Ok(Snapshot { harness, previous })
+    Ok(Snapshot { harness, contents })
 }
 
 pub(super) fn restore(snapshot: &Snapshot, environment: &Environment) -> Result<()> {
-    restore_native(
-        snapshot.harness,
-        snapshot.previous.as_ref(),
-        environment,
-        &SystemRunner,
-    )
+    match &snapshot.contents {
+        SnapshotContents::Native(previous) => restore_native(
+            snapshot.harness,
+            previous.as_ref(),
+            environment,
+            &SystemRunner,
+        ),
+        SnapshotContents::Json { path, contents } => match contents {
+            Some(contents) => files::write_atomic(path, contents),
+            None => match fs::symlink_metadata(path) {
+                Ok(metadata) if metadata.file_type().is_symlink() => Err(anyhow!(
+                    "{} became a symbolic link; refusing to remove it",
+                    path.display()
+                )),
+                Ok(_) => {
+                    fs::remove_file(path)
+                        .with_context(|| format!("failed to remove {}", path.display()))?;
+                    files::remove_empty_parent(path);
+                    Ok(())
+                }
+                Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+                Err(error) => {
+                    Err(error).with_context(|| format!("failed to inspect {}", path.display()))
+                }
+            },
+        },
+    }
 }
 
 fn inspect_with(harness: Harness, environment: &Environment, runner: &dyn Runner) -> Result<State> {
-    Ok(inspect_native(harness, environment, runner)?.state)
+    match harness {
+        Harness::Claude | Harness::Codex => Ok(inspect_native(harness, environment, runner)?.state),
+        Harness::Cursor => inspect_json(harness, environment),
+        Harness::OpenCode => inspect_json(harness, environment),
+    }
 }
 
 pub(super) fn install(
@@ -109,7 +171,10 @@ fn install_with(
     access: AccessMode,
     runner: &dyn Runner,
 ) -> Result<()> {
-    install_native(harness, environment, access, runner)
+    match harness {
+        Harness::Claude | Harness::Codex => install_native(harness, environment, access, runner),
+        Harness::Cursor | Harness::OpenCode => install_json(harness, environment, access),
+    }
 }
 
 pub(super) fn uninstall(harness: Harness, environment: &Environment) -> Result<bool> {
@@ -124,10 +189,16 @@ fn uninstall_with(
     match inspect_with(harness, environment, runner)? {
         State::Missing => Ok(false),
         State::Conflict(_) | State::Unavailable(_) => Ok(false),
-        State::Current(_) | State::ManagedDrift(_) => {
-            remove_native(harness, runner)?;
-            Ok(true)
-        }
+        State::Current(_) | State::ManagedDrift(_) => match harness {
+            Harness::Claude | Harness::Codex => {
+                remove_native(harness, runner)?;
+                Ok(true)
+            }
+            Harness::Cursor | Harness::OpenCode => {
+                remove_json(harness, environment)?;
+                Ok(true)
+            }
+        },
     }
 }
 
@@ -139,6 +210,9 @@ fn inspect_native(
     match harness {
         Harness::Claude => inspect_claude(environment, runner),
         Harness::Codex => inspect_codex(environment, runner),
+        Harness::Cursor | Harness::OpenCode => {
+            unreachable!("JSON-backed harnesses do not have native registrations")
+        }
     }
 }
 
@@ -344,6 +418,136 @@ fn mcp_args(access: AccessMode) -> Vec<String> {
     args
 }
 
+fn inspect_json(harness: Harness, environment: &Environment) -> Result<State> {
+    let path = json_path(harness, environment);
+    if harness == Harness::OpenCode && !path.exists() {
+        let jsonc = path.with_extension("jsonc");
+        if jsonc.exists() {
+            return Ok(State::Unavailable(format!(
+                "{} uses JSON with comments; add Sift to it manually or rename it to opencode.json",
+                jsonc.display()
+            )));
+        }
+    }
+
+    let root = match load_json(&path) {
+        Ok(Some(root)) => root,
+        Ok(None) => return Ok(State::Missing),
+        Err(error) => return Ok(State::Unavailable(error.to_string())),
+    };
+    let container_key = container_key(harness);
+    let Some(servers) = root.get(container_key) else {
+        return Ok(State::Missing);
+    };
+    let Some(servers) = servers.as_object() else {
+        return Ok(State::Conflict(format!(
+            "`{container_key}` in {} is not a JSON object",
+            path.display()
+        )));
+    };
+    let Some(entry) = servers.get("sift") else {
+        return Ok(State::Missing);
+    };
+    Ok(classify_json_entry(harness, entry, environment))
+}
+
+fn install_json(harness: Harness, environment: &Environment, access: AccessMode) -> Result<()> {
+    let path = json_path(harness, environment);
+    let mut root = load_json(&path)?.unwrap_or_default();
+    let container_key = container_key(harness);
+    let servers = object_entry(&mut root, container_key)?;
+    let args = mcp_args(access);
+    servers.insert(
+        "sift".to_string(),
+        match harness {
+            Harness::Cursor => json!({
+                "command": environment.current_exe,
+                "args": args
+            }),
+            Harness::OpenCode => json!({
+                "type": "local",
+                "command": std::iter::once(environment.current_exe.to_string_lossy().to_string())
+                    .chain(args.iter().cloned())
+                    .collect::<Vec<_>>(),
+                "enabled": true
+            }),
+            _ => unreachable!("only JSON-backed harnesses reach install_json"),
+        },
+    );
+    write_json(&path, &root)
+}
+
+fn remove_json(harness: Harness, environment: &Environment) -> Result<()> {
+    let path = json_path(harness, environment);
+    let Some(mut root) = load_json(&path)? else {
+        return Ok(());
+    };
+    if let Some(servers) = root
+        .get_mut(container_key(harness))
+        .and_then(Value::as_object_mut)
+    {
+        servers.remove("sift");
+    }
+    write_json(&path, &root)
+}
+
+fn classify_json_entry(harness: Harness, entry: &Value, environment: &Environment) -> State {
+    let Some(entry) = entry.as_object() else {
+        return State::Conflict("the existing `sift` MCP entry is not an object".to_string());
+    };
+
+    let (command, args, metadata_is_managed) = match harness {
+        Harness::Cursor => {
+            let allowed = ["command", "args"];
+            let managed = entry.keys().all(|key| allowed.contains(&key.as_str()));
+            let Some(args) = string_array(entry.get("args")) else {
+                return State::Conflict(
+                    "the existing `sift` MCP entry has invalid arguments".to_string(),
+                );
+            };
+            (
+                entry
+                    .get("command")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                args,
+                managed,
+            )
+        }
+        Harness::OpenCode => {
+            let allowed = ["type", "command", "enabled"];
+            let managed = entry.keys().all(|key| allowed.contains(&key.as_str()))
+                && entry.get("type").and_then(Value::as_str) == Some("local");
+            let Some(command_parts) = string_array(entry.get("command")) else {
+                return State::Conflict(
+                    "the existing `sift` MCP entry has an invalid command".to_string(),
+                );
+            };
+            let command = command_parts.first().cloned();
+            let args = command_parts.iter().skip(1).cloned().collect();
+            let enabled = true_or_missing(entry.get("enabled"));
+            (command, args, managed && enabled)
+        }
+        _ => unreachable!("only JSON-backed harnesses reach classify_json_entry"),
+    };
+
+    let Some(command) = command else {
+        return State::Conflict(
+            "could not read the command for the existing `sift` MCP entry".to_string(),
+        );
+    };
+    let classified = classify_command(&command, &args, environment);
+    if !metadata_is_managed {
+        return match classified {
+            State::Current(_) | State::ManagedDrift(_) => State::Conflict(
+                "the existing `sift` MCP entry contains custom settings".to_string(),
+            ),
+            other => other,
+        };
+    }
+    classified
+}
+
 fn classify_command(command: &str, args: &[String], environment: &Environment) -> State {
     let current = environment.current_exe.to_string_lossy();
     let current_command = command == "sift-cli" || command == current;
@@ -385,6 +589,74 @@ fn is_sift_cli(command: &str) -> bool {
                 "sift-cli" | "sift-cli.exe"
             )
         })
+}
+
+fn json_path(harness: Harness, environment: &Environment) -> PathBuf {
+    match harness {
+        Harness::Cursor => environment.home.join(".cursor").join("mcp.json"),
+        Harness::OpenCode => environment
+            .home
+            .join(".config")
+            .join("opencode")
+            .join("opencode.json"),
+        _ => unreachable!("only JSON-backed harnesses have JSON paths"),
+    }
+}
+
+fn container_key(harness: Harness) -> &'static str {
+    match harness {
+        Harness::Cursor => "mcpServers",
+        Harness::OpenCode => "mcp",
+        _ => unreachable!("only JSON-backed harnesses have container keys"),
+    }
+}
+
+fn load_json(path: &Path) -> Result<Option<Map<String, Value>>> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err(anyhow!(
+                "{} is a symbolic link; refusing to replace it",
+                path.display()
+            ));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to inspect {}", path.display()));
+        }
+    }
+
+    let contents = match fs::read(path) {
+        Ok(contents) => contents,
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to read {}", path.display()));
+        }
+    };
+    let value: Value = serde_json::from_slice(&contents)
+        .with_context(|| format!("{} is not valid JSON", path.display()))?;
+    value
+        .as_object()
+        .cloned()
+        .map(Some)
+        .ok_or_else(|| anyhow!("{} must contain a JSON object", path.display()))
+}
+
+fn write_json(path: &Path, root: &Map<String, Value>) -> Result<()> {
+    let mut contents = serde_json::to_vec_pretty(root)?;
+    contents.push(b'\n');
+    files::write_atomic(path, &contents)
+}
+
+fn object_entry<'a>(
+    root: &'a mut Map<String, Value>,
+    key: &str,
+) -> Result<&'a mut Map<String, Value>> {
+    let value = root
+        .entry(key.to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    value
+        .as_object_mut()
+        .ok_or_else(|| anyhow!("`{key}` must be a JSON object"))
 }
 
 fn string_array(value: Option<&Value>) -> Option<Vec<String>> {
@@ -522,6 +794,9 @@ fn add_native(harness: Harness, entry: &NativeEntry, runner: &dyn Runner) -> Res
             os_args(["mcp", "add", "sift", "--"]),
             "register the Sift MCP server with Codex",
         ),
+        Harness::Cursor | Harness::OpenCode => {
+            unreachable!("JSON-backed harnesses do not use native registration commands")
+        }
     };
     args.push(OsString::from(&entry.command));
     args.extend(entry.args.iter().map(OsString::from));
@@ -540,6 +815,9 @@ fn remove_native(harness: Harness, runner: &dyn Runner) -> Result<()> {
             os_args(["mcp", "remove", "sift"]),
             "remove the Codex MCP registration",
         ),
+        Harness::Cursor | Harness::OpenCode => {
+            unreachable!("JSON-backed harnesses do not use native registration commands")
+        }
     };
     run_checked(runner, program, &args, action)
 }

--- a/rust/crates/sift_cli/src/cmd/agent/files.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/files.rs
@@ -1,4 +1,55 @@
-use std::{fs, path::Path};
+use std::{
+    fs::{self, OpenOptions},
+    io::Write,
+    path::Path,
+};
+
+use anyhow::{Context, Result};
+
+pub(super) fn write_atomic(path: &Path, contents: &[u8]) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .ok_or_else(|| anyhow::anyhow!("{} has no parent directory", path.display()))?;
+    fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
+
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("sift-agent-config");
+    let temporary = parent.join(format!(".{file_name}.sift-cli-{}.tmp", std::process::id()));
+
+    let mut file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&temporary)
+        .with_context(|| format!("failed to create {}", temporary.display()))?;
+    if let Ok(metadata) = fs::metadata(path)
+        && let Err(error) = fs::set_permissions(&temporary, metadata.permissions())
+    {
+        let _ = fs::remove_file(&temporary);
+        return Err(error)
+            .with_context(|| format!("failed to preserve permissions for {}", path.display()));
+    }
+    if let Err(error) = file.write_all(contents).and_then(|()| file.sync_all()) {
+        let _ = fs::remove_file(&temporary);
+        return Err(error)
+            .with_context(|| format!("failed to write temporary file {}", temporary.display()));
+    }
+
+    if let Err(error) = fs::rename(&temporary, path) {
+        let _ = fs::remove_file(&temporary);
+        return Err(error).with_context(|| {
+            format!(
+                "failed to move {} into place at {}",
+                temporary.display(),
+                path.display()
+            )
+        });
+    }
+
+    Ok(())
+}
 
 pub(super) fn remove_empty_parent(path: &Path) {
     if let Some(parent) = path.parent() {

--- a/rust/crates/sift_cli/src/cmd/agent/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/mod.rs
@@ -39,6 +39,8 @@ impl AccessMode {
 pub(super) enum Harness {
     Claude,
     Codex,
+    Cursor,
+    OpenCode,
 }
 
 impl Harness {
@@ -46,6 +48,8 @@ impl Harness {
         match self {
             Self::Claude => "Claude Code",
             Self::Codex => "Codex",
+            Self::Cursor => "Cursor",
+            Self::OpenCode => "OpenCode",
         }
     }
 }
@@ -75,17 +79,31 @@ impl Environment {
 
     fn detect_harnesses(&self) -> Vec<Harness> {
         let candidates = [
-            (Harness::Claude, &["claude"][..]),
-            (Harness::Codex, &["codex"][..]),
+            (Harness::Claude, &["claude"][..], self.home.join(".claude")),
+            (Harness::Codex, &["codex"][..], self.home.join(".codex")),
+            (
+                Harness::Cursor,
+                &["cursor", "cursor-agent"][..],
+                self.home.join(".cursor"),
+            ),
+            (
+                Harness::OpenCode,
+                &["opencode"][..],
+                self.home.join(".config").join("opencode"),
+            ),
         ];
 
         candidates
             .into_iter()
-            .filter_map(|(harness, commands)| {
-                commands
+            .filter_map(|(harness, commands, config_dir)| {
+                let command_exists = commands
                     .iter()
-                    .any(|command| self.command_available(command))
-                    .then_some(harness)
+                    .any(|command| self.command_available(command));
+                let detected = match harness {
+                    Harness::Claude | Harness::Codex => command_exists,
+                    Harness::Cursor | Harness::OpenCode => command_exists || config_dir.exists(),
+                };
+                detected.then_some(harness)
             })
             .collect()
     }
@@ -373,7 +391,7 @@ fn install_environment(
     if environment.harnesses.is_empty() {
         println!(
             "No supported AI coding clients were detected. Supported clients: \
-             Claude Code and Codex."
+             Claude Code, Codex, Cursor, and OpenCode."
         );
         return Ok(ExitCode::FAILURE);
     }

--- a/rust/crates/sift_cli/src/cmd/agent/skill.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/skill.rs
@@ -72,7 +72,9 @@ pub(super) fn targets(environment: &Environment) -> Vec<Target> {
     for harness in &environment.harnesses {
         let path = match harness {
             Harness::Claude => environment.home.join(".claude").join("skills").join("sift"),
-            Harness::Codex => environment.home.join(".agents").join("skills").join("sift"),
+            Harness::Codex | Harness::Cursor | Harness::OpenCode => {
+                environment.home.join(".agents").join("skills").join("sift")
+            }
         };
         by_path.entry(path).or_default().push(*harness);
     }

--- a/rust/crates/sift_cli/src/cmd/agent/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/tests.rs
@@ -1,9 +1,10 @@
 use std::{fs, path::PathBuf};
 
 use clap::Parser;
+use serde_json::Value;
 use tempdir::TempDir;
 
-use super::{AccessInference, AccessMode, Environment, Harness, skill};
+use super::{AccessInference, AccessMode, Environment, Harness, config, skill};
 
 fn environment(harnesses: Vec<Harness>) -> (TempDir, Environment) {
     let directory = TempDir::new("sift-cli-agent-tests").unwrap();
@@ -29,19 +30,19 @@ fn stale_native_config_directories_are_not_detected_as_installed_clients() {
 }
 
 #[test]
-fn claude_and_codex_install_the_skill_to_their_own_conventions() {
-    let (directory, mut environment) = environment(vec![Harness::Claude, Harness::Codex]);
+fn one_shared_skill_covers_agent_skills_clients() {
+    let (directory, mut environment) =
+        environment(vec![Harness::Codex, Harness::Cursor, Harness::OpenCode]);
     environment.home = directory.path().to_path_buf();
 
     let targets = skill::targets(&environment);
 
-    assert_eq!(targets.len(), 2);
-    let paths = targets
-        .iter()
-        .map(|target| target.path.clone())
-        .collect::<Vec<_>>();
-    assert!(paths.contains(&directory.path().join(".claude/skills/sift")));
-    assert!(paths.contains(&directory.path().join(".agents/skills/sift")));
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0].harnesses.len(), 3);
+    assert_eq!(
+        targets[0].path,
+        directory.path().join(".agents/skills/sift")
+    );
 }
 
 #[test]
@@ -123,6 +124,104 @@ fn unmanaged_skill_is_never_removed() {
     assert!(path.exists());
 }
 
+#[test]
+fn cursor_config_merge_preserves_other_servers() {
+    let directory = TempDir::new("sift-cli-agent-cursor").unwrap();
+    let current_exe = directory.path().join("bin/sift-cli");
+    let environment = Environment::for_test(
+        directory.path().to_path_buf(),
+        current_exe.clone(),
+        vec![Harness::Cursor],
+    );
+    let path = directory.path().join(".cursor/mcp.json");
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(
+        &path,
+        r#"{"mcpServers":{"other":{"command":"other-server"}},"setting":true}"#,
+    )
+    .unwrap();
+
+    config::install(Harness::Cursor, &environment, AccessMode::ReadOnly).unwrap();
+
+    let value: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+    assert_eq!(value["setting"], true);
+    assert_eq!(value["mcpServers"]["other"]["command"], "other-server");
+    assert_eq!(
+        value["mcpServers"]["sift"]["command"],
+        current_exe.to_string_lossy().as_ref()
+    );
+    assert_eq!(
+        config::inspect(Harness::Cursor, &environment).unwrap(),
+        config::State::Current(AccessMode::ReadOnly)
+    );
+}
+
+#[test]
+fn opencode_config_uses_local_command_array() {
+    let directory = TempDir::new("sift-cli-agent-opencode").unwrap();
+    let current_exe = directory.path().join("bin/sift-cli");
+    let environment = Environment::for_test(
+        directory.path().to_path_buf(),
+        current_exe.clone(),
+        vec![Harness::OpenCode],
+    );
+
+    config::install(Harness::OpenCode, &environment, AccessMode::ReadOnly).unwrap();
+
+    let path = directory.path().join(".config/opencode/opencode.json");
+    let value: Value = serde_json::from_slice(&fs::read(path).unwrap()).unwrap();
+    assert_eq!(value["mcp"]["sift"]["type"], "local");
+    assert_eq!(value["mcp"]["sift"]["enabled"], true);
+    assert_eq!(
+        value["mcp"]["sift"]["command"][0],
+        current_exe.to_string_lossy().as_ref()
+    );
+    assert_eq!(value["mcp"]["sift"]["command"][1], "mcp");
+}
+
+#[test]
+fn custom_same_name_server_is_a_conflict() {
+    let directory = TempDir::new("sift-cli-agent-conflict").unwrap();
+    let environment = Environment::for_test(
+        directory.path().to_path_buf(),
+        directory.path().join("bin/sift-cli"),
+        vec![Harness::Cursor],
+    );
+    let path = directory.path().join(".cursor/mcp.json");
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(
+        path,
+        r#"{"mcpServers":{"sift":{"command":"my-wrapper","args":["mcp"]}}}"#,
+    )
+    .unwrap();
+
+    assert!(matches!(
+        config::inspect(Harness::Cursor, &environment).unwrap(),
+        config::State::Conflict(_)
+    ));
+}
+
+#[test]
+fn malformed_config_container_is_caught_during_preflight() {
+    let directory = TempDir::new("sift-cli-agent-malformed-config").unwrap();
+    let environment = Environment::for_test(
+        directory.path().to_path_buf(),
+        directory.path().join("bin/sift-cli"),
+        vec![Harness::Cursor],
+    );
+    let config_path = directory.path().join(".cursor/mcp.json");
+    fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    fs::write(&config_path, r#"{"mcpServers":[]}"#).unwrap();
+
+    super::install_environment(&environment, "Installed", AccessMode::ReadOnly).unwrap();
+
+    assert!(!directory.path().join(".agents/skills/sift").exists());
+    assert_eq!(
+        fs::read_to_string(config_path).unwrap(),
+        r#"{"mcpServers":[]}"#
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn symlinked_skill_is_never_replaced() {
@@ -139,6 +238,51 @@ fn symlinked_skill_is_never_replaced() {
     assert_eq!(skill::inspect(&path).unwrap(), skill::State::Conflict);
     assert!(!skill::uninstall(&path).unwrap());
     assert!(path.is_symlink());
+}
+
+#[test]
+fn destructive_access_is_a_current_managed_registration() {
+    let directory = TempDir::new("sift-cli-agent-destructive-access").unwrap();
+    let environment = Environment::for_test(
+        directory.path().to_path_buf(),
+        directory.path().join("bin/sift-cli"),
+        vec![Harness::Cursor],
+    );
+    let path = directory.path().join(".cursor/mcp.json");
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(
+        path,
+        r#"{"mcpServers":{"sift":{"command":"sift-cli","args":["mcp","--allow-destructive"]}}}"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        config::inspect(Harness::Cursor, &environment).unwrap(),
+        config::State::Current(AccessMode::Destructive)
+    );
+}
+
+#[test]
+fn destructive_install_updates_every_json_backed_client() {
+    let directory = TempDir::new("sift-cli-agent-destructive-install").unwrap();
+    let current_exe = directory.path().join("bin/sift-cli");
+    let environment = Environment::for_test(
+        directory.path().to_path_buf(),
+        current_exe,
+        vec![Harness::Cursor, Harness::OpenCode],
+    );
+
+    config::install(Harness::Cursor, &environment, AccessMode::Destructive).unwrap();
+    config::install(Harness::OpenCode, &environment, AccessMode::Destructive).unwrap();
+
+    assert_eq!(
+        config::inspect(Harness::Cursor, &environment).unwrap(),
+        config::State::Current(AccessMode::Destructive)
+    );
+    assert_eq!(
+        config::inspect(Harness::OpenCode, &environment).unwrap(),
+        config::State::Current(AccessMode::Destructive)
+    );
 }
 
 #[test]
@@ -169,4 +313,104 @@ fn update_access_flags_are_mutually_exclusive() {
         ])
         .is_err()
     );
+}
+
+#[test]
+fn uninstall_removes_only_sift_json_entry() {
+    let directory = TempDir::new("sift-cli-agent-uninstall").unwrap();
+    let environment = Environment::for_test(
+        directory.path().to_path_buf(),
+        directory.path().join("bin/sift-cli"),
+        vec![Harness::Cursor],
+    );
+    let path = directory.path().join(".cursor/mcp.json");
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(
+        &path,
+        r#"{"mcpServers":{"sift":{"command":"sift-cli","args":["mcp"]},"other":{"command":"other"}}}"#,
+    )
+    .unwrap();
+
+    assert!(config::uninstall(Harness::Cursor, &environment).unwrap());
+
+    let value: Value = serde_json::from_slice(&fs::read(path).unwrap()).unwrap();
+    assert!(value["mcpServers"].get("sift").is_none());
+    assert_eq!(value["mcpServers"]["other"]["command"], "other");
+}
+
+#[test]
+fn install_preflight_keeps_every_target_unchanged_on_conflict() {
+    let directory = TempDir::new("sift-cli-agent-install-preflight").unwrap();
+    let environment = Environment::for_test(
+        directory.path().to_path_buf(),
+        directory.path().join("bin/sift-cli"),
+        vec![Harness::Cursor],
+    );
+    let config_path = directory.path().join(".cursor/mcp.json");
+    fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    fs::write(
+        config_path,
+        r#"{"mcpServers":{"sift":{"command":"custom-sift","args":["mcp"]}}}"#,
+    )
+    .unwrap();
+
+    super::install_environment(&environment, "Installed", AccessMode::ReadOnly).unwrap();
+
+    assert!(!directory.path().join(".agents/skills/sift").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn failed_later_client_install_rolls_back_earlier_clients_and_skills() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let directory = TempDir::new("sift-cli-agent-install-rollback").unwrap();
+    let environment = Environment::for_test(
+        directory.path().to_path_buf(),
+        directory.path().join("bin/sift-cli"),
+        vec![Harness::Cursor, Harness::OpenCode],
+    );
+    let cursor_path = directory.path().join(".cursor/mcp.json");
+    fs::create_dir_all(cursor_path.parent().unwrap()).unwrap();
+    let original_cursor = br#"{"mcpServers":{"other":{"command":"other"}}}"#;
+    fs::write(&cursor_path, original_cursor).unwrap();
+
+    let opencode_dir = directory.path().join(".config/opencode");
+    fs::create_dir_all(&opencode_dir).unwrap();
+    fs::set_permissions(&opencode_dir, fs::Permissions::from_mode(0o555)).unwrap();
+
+    let result = super::install_environment(&environment, "Installed", AccessMode::ReadOnly);
+
+    fs::set_permissions(&opencode_dir, fs::Permissions::from_mode(0o755)).unwrap();
+    let error = result.unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("all earlier agent integration changes were rolled back")
+    );
+    assert_eq!(fs::read(&cursor_path).unwrap(), original_cursor);
+    assert!(!directory.path().join(".agents/skills/sift").exists());
+}
+
+#[test]
+fn uninstall_preflight_keeps_every_target_unchanged_on_conflict() {
+    let directory = TempDir::new("sift-cli-agent-uninstall-preflight").unwrap();
+    let environment = Environment::for_test(
+        directory.path().to_path_buf(),
+        directory.path().join("bin/sift-cli"),
+        vec![Harness::Cursor],
+    );
+    let skill_path = directory.path().join(".agents/skills/sift");
+    skill::install(&skill_path).unwrap();
+    let config_path = directory.path().join(".cursor/mcp.json");
+    fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    fs::write(
+        config_path,
+        r#"{"mcpServers":{"sift":{"command":"custom-sift","args":["mcp"]}}}"#,
+    )
+    .unwrap();
+
+    super::uninstall_environment(&environment).unwrap();
+
+    assert!(skill_path.exists());
 }


### PR DESCRIPTION
## Changes

Extends the agent lifecycle to the two clients that keep MCP registrations in their own JSON config rather than behind a CLI. Cursor uses `~/.cursor/mcp.json` under `mcpServers`; OpenCode uses `~/.config/opencode/opencode.json` under `mcp` with a local command array. Both join Codex on the shared `~/.agents/skills/sift` directory.

Merges into the existing config instead of rewriting it, so unrelated servers and top-level settings survive. Writes go through a temp file and rename with permissions carried over, so an interrupted write cannot truncate a user's config. Refuses to follow a symlinked config or skill directory. An entry carrying keys this CLI does not write is a conflict rather than something to overwrite, and an OpenCode `opencode.jsonc` is reported as unavailable because comments would not survive a rewrite.

Detects these two clients by config directory as well as `PATH`, since both are commonly installed as editors with no CLI on `PATH`.

Snapshots every client's prior config before the first write, so a failure partway through a multi-client install restores all of them plus the skill directories.

## Verification

- `cargo fmt --check --all`, `cargo clippy --all-features`, `cargo test --all-features`
- 21 `cmd::agent` tests, including the cross-client rollback and preflight cases this PR makes testable
