### PR TITLE
rust(feat): add profile-aware agent installation

### DIFF
--- a/rust/crates/sift_cli/AGENTS.md
+++ b/rust/crates/sift_cli/AGENTS.md
@@ -27,11 +27,14 @@ Uninstall removes only content identifiable as Sift-managed. Do not add a state
 file or per-client version tracking.
 
 Install defaults every MCP registration to read-only. Install accepts
-`--allow-destructive` as an explicit opt-in. An ordinary update preserves the
-single access mode discovered from the managed client configs. Update accepts
-`--allow-destructive` or `--read-only` to switch access, and the change applies
-to every detected client. Doctor reports the setting. Mixed modes are errors
-rather than values the CLI silently resolves.
+`--allow-destructive` as an explicit opt-in. Install uses the default Sift
+profile unless `--profile <name>` selects a named profile. An ordinary update
+preserves the single access mode and profile discovered from the managed client
+configs. Update accepts `--allow-destructive` or `--read-only` to switch access,
+`--profile <name>` to switch to a named profile, and `--default-profile` to
+switch back to the default; each change applies to every detected client.
+Doctor reports both settings. Mixed modes or profiles are errors rather than
+values the CLI silently resolves.
 
 The `agent` command and `mcp` sidecar remain behind the `mcp` Cargo feature until
 the open-beta release explicitly changes that policy.

--- a/rust/crates/sift_cli/assets/skills/sift/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/sift/SKILL.md
@@ -118,20 +118,26 @@ and stop at the first that does the job:
 Use the CLI lifecycle instead of editing one client's MCP configuration or
 skill:
 
-- Run `sift-cli agent doctor` to diagnose setup, including the access mode,
-  without changing it.
+- Run `sift-cli agent doctor` to diagnose setup, including the installed
+  profile and access mode, without changing it.
 - For first-time setup, explain that `sift-cli agent install` installs the
   release-matched skill and read-only MCP registration for every detected
-  client. Run the command when the user asks you to install or approves the
-  change.
+  client using the default Sift profile. If the user selected a named profile,
+  pass it as `sift-cli agent install --profile <name>`. Run the command when the
+  user asks you to install or approves the change.
 - Run `sift-cli agent update` to refresh every detected client together. It
-  preserves the existing read-only or destructive access mode.
+  preserves the existing profile and read-only or destructive access mode.
+  Switch every client to another named profile with
+  `sift-cli agent update --profile <name>`, or return them to the default with
+  `sift-cli agent update --default-profile`.
 - If the CLI is outdated, relay the exact curl or PowerShell installer printed
   by `agent doctor` or `agent update`. After the user updates `sift-cli`, rerun
   `sift-cli agent update`.
 - Never repair or update only one detected client. If doctor reports mixed
   access modes, ask the user to choose `sift-cli agent update --read-only` or
-  `sift-cli agent update --allow-destructive`.
+  `sift-cli agent update --allow-destructive`. If it reports mixed profiles,
+  ask for the intended profile and use `sift-cli agent update --profile <name>`
+  or `sift-cli agent update --default-profile`.
 
 ## Running `sift-cli` from your shell
 

--- a/rust/crates/sift_cli/src/cli/mod.rs
+++ b/rust/crates/sift_cli/src/cli/mod.rs
@@ -33,7 +33,8 @@ pub struct Args {
     #[arg(short = 'V', long)]
     pub version: bool,
 
-    #[arg(long, global = true, hide = true)]
+    /// Use a named profile from the config file
+    #[arg(long, global = true)]
     pub profile: Option<String>,
 
     #[arg(long, global = true, hide = true)]
@@ -103,13 +104,13 @@ pub enum InstallCmd {
 #[cfg(feature = "mcp")]
 #[derive(Subcommand)]
 pub enum AgentCmd {
-    /// Install every detected client in safe mode
+    /// Install every detected client in safe mode using the default profile unless selected
     Install(AgentInstallArgs),
 
-    /// Refresh every detected client while preserving its access mode
+    /// Refresh every detected client while preserving its profile and access mode
     Update(AgentUpdateArgs),
 
-    /// Check the CLI version, skill files, and access modes
+    /// Check the CLI version, skill files, MCP profiles, and access modes
     Doctor,
 
     /// Remove Sift-owned agent files and registrations
@@ -134,6 +135,10 @@ pub struct AgentUpdateArgs {
     /// Disable destructive tools for every detected MCP client
     #[arg(long, conflicts_with = "allow_destructive")]
     pub read_only: bool,
+
+    /// Switch every detected MCP client back to the default profile
+    #[arg(long, conflicts_with = "profile")]
+    pub default_profile: bool,
 }
 
 #[derive(Subcommand)]

--- a/rust/crates/sift_cli/src/cmd/agent/config.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/config.rs
@@ -9,7 +9,7 @@ use std::{
 use anyhow::{Context, Result, anyhow};
 use serde_json::{Map, Value, json};
 
-use super::{AccessMode, Environment, Harness, files};
+use super::{AccessMode, Environment, Harness, Profile, Registration, files};
 
 #[derive(Debug)]
 struct CommandOutput {
@@ -67,8 +67,8 @@ enum SnapshotContents {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(super) enum State {
     Missing,
-    Current(AccessMode),
-    ManagedDrift(AccessMode),
+    Current(Registration),
+    ManagedDrift(Registration),
     Conflict(String),
     Unavailable(String),
 }
@@ -160,20 +160,22 @@ fn inspect_with(harness: Harness, environment: &Environment, runner: &dyn Runner
 pub(super) fn install(
     harness: Harness,
     environment: &Environment,
-    access: AccessMode,
+    registration: &Registration,
 ) -> Result<()> {
-    install_with(harness, environment, access, &SystemRunner)
+    install_with(harness, environment, registration, &SystemRunner)
 }
 
 fn install_with(
     harness: Harness,
     environment: &Environment,
-    access: AccessMode,
+    registration: &Registration,
     runner: &dyn Runner,
 ) -> Result<()> {
     match harness {
-        Harness::Claude | Harness::Codex => install_native(harness, environment, access, runner),
-        Harness::Cursor | Harness::OpenCode => install_json(harness, environment, access),
+        Harness::Claude | Harness::Codex => {
+            install_native(harness, environment, registration, runner)
+        }
+        Harness::Cursor | Harness::OpenCode => install_json(harness, environment, registration),
     }
 }
 
@@ -336,7 +338,7 @@ fn inspect_codex(environment: &Environment, runner: &dyn Runner) -> Result<Nativ
 fn install_native(
     harness: Harness,
     environment: &Environment,
-    access: AccessMode,
+    registration: &Registration,
     runner: &dyn Runner,
 ) -> Result<()> {
     let inspection = inspect_native(harness, environment, runner)?;
@@ -352,7 +354,7 @@ fn install_native(
     };
     let desired = NativeEntry {
         command: environment.current_exe.to_string_lossy().to_string(),
-        args: mcp_args(access),
+        args: mcp_args(registration),
     };
 
     if previous.is_some() {
@@ -410,9 +412,13 @@ fn restore_native(
     Ok(())
 }
 
-fn mcp_args(access: AccessMode) -> Vec<String> {
+fn mcp_args(registration: &Registration) -> Vec<String> {
     let mut args = vec!["mcp".to_string()];
-    if access == AccessMode::Destructive {
+    if let Profile::Named(profile) = &registration.profile {
+        args.push("--profile".to_string());
+        args.push(profile.clone());
+    }
+    if registration.access == AccessMode::Destructive {
         args.push("--allow-destructive".to_string());
     }
     args
@@ -451,12 +457,16 @@ fn inspect_json(harness: Harness, environment: &Environment) -> Result<State> {
     Ok(classify_json_entry(harness, entry, environment))
 }
 
-fn install_json(harness: Harness, environment: &Environment, access: AccessMode) -> Result<()> {
+fn install_json(
+    harness: Harness,
+    environment: &Environment,
+    registration: &Registration,
+) -> Result<()> {
     let path = json_path(harness, environment);
     let mut root = load_json(&path)?.unwrap_or_default();
     let container_key = container_key(harness);
     let servers = object_entry(&mut root, container_key)?;
-    let args = mcp_args(access);
+    let args = mcp_args(registration);
     servers.insert(
         "sift".to_string(),
         match harness {
@@ -551,17 +561,17 @@ fn classify_json_entry(harness: Harness, entry: &Value, environment: &Environmen
 fn classify_command(command: &str, args: &[String], environment: &Environment) -> State {
     let current = environment.current_exe.to_string_lossy();
     let current_command = command == "sift-cli" || command == current;
-    let Some(access) = access_from_args(args) else {
+    let Some(registration) = registration_from_args(args) else {
         return State::Conflict(format!(
             "the existing `sift` MCP entry runs a custom command: `{command} {}`",
             args.join(" ")
         ));
     };
     if current_command {
-        return State::Current(access);
+        return State::Current(registration);
     }
     if is_sift_cli(command) {
-        return State::ManagedDrift(access);
+        return State::ManagedDrift(registration);
     }
     State::Conflict(format!(
         "the existing `sift` MCP entry runs a custom command: `{command} {}`",
@@ -569,14 +579,37 @@ fn classify_command(command: &str, args: &[String], environment: &Environment) -
     ))
 }
 
-fn access_from_args(args: &[String]) -> Option<AccessMode> {
+fn registration_from_args(args: &[String]) -> Option<Registration> {
     match args {
-        [mcp] if mcp == "mcp" => Some(AccessMode::ReadOnly),
+        [mcp] if mcp == "mcp" => Some(Registration::new(AccessMode::ReadOnly, Profile::Default)),
         [mcp, destructive] if mcp == "mcp" && destructive == "--allow-destructive" => {
-            Some(AccessMode::Destructive)
+            Some(Registration::new(AccessMode::Destructive, Profile::Default))
+        }
+        [mcp, profile_flag, profile]
+            if mcp == "mcp" && profile_flag == "--profile" && valid_profile(profile) =>
+        {
+            Some(Registration::new(
+                AccessMode::ReadOnly,
+                Profile::Named(profile.clone()),
+            ))
+        }
+        [mcp, profile_flag, profile, destructive]
+            if mcp == "mcp"
+                && profile_flag == "--profile"
+                && valid_profile(profile)
+                && destructive == "--allow-destructive" =>
+        {
+            Some(Registration::new(
+                AccessMode::Destructive,
+                Profile::Named(profile.clone()),
+            ))
         }
         _ => None,
     }
+}
+
+fn valid_profile(profile: &str) -> bool {
+    !profile.is_empty() && !profile.starts_with('-')
 }
 
 fn is_sift_cli(command: &str) -> bool {
@@ -906,23 +939,27 @@ mod tests {
 
     #[test]
     fn only_exact_sift_mcp_argument_shapes_are_managed() {
-        assert_eq!(
-            access_from_args(&args(&["mcp"])),
-            Some(AccessMode::ReadOnly)
-        );
-        assert_eq!(
-            access_from_args(&args(&["mcp", "--allow-destructive"])),
-            Some(AccessMode::Destructive)
+        assert!(registration_from_args(&args(&["mcp"])).is_some());
+        assert!(registration_from_args(&args(&["mcp", "--allow-destructive"])).is_some());
+        assert!(registration_from_args(&args(&["mcp", "--profile", "localdev"])).is_some());
+        assert!(
+            registration_from_args(&args(&[
+                "mcp",
+                "--profile",
+                "localdev",
+                "--allow-destructive",
+            ]))
+            .is_some()
         );
 
         for custom in [
             args(&["mcp", "--custom"]),
-            args(&["mcp", "--allow-destructive", "--extra"]),
-            args(&["--allow-destructive"]),
-            args(&["mcp", "mcp"]),
-            args(&[]),
+            args(&["mcp", "--profile"]),
+            args(&["mcp", "--profile", "--allow-destructive"]),
+            args(&["mcp", "--allow-destructive", "--profile", "localdev"]),
+            args(&["mcp", "--profile", "localdev", "--extra"]),
         ] {
-            assert_eq!(access_from_args(&custom), None);
+            assert_eq!(registration_from_args(&custom), None);
         }
     }
 
@@ -1014,8 +1051,13 @@ mod tests {
             output(true, Vec::new(), Vec::new()),
         ]);
 
-        let error =
-            install_with(Harness::Codex, &environment, AccessMode::ReadOnly, &runner).unwrap_err();
+        let error = install_with(
+            Harness::Codex,
+            &environment,
+            &Registration::new(AccessMode::ReadOnly, Profile::Default),
+            &runner,
+        )
+        .unwrap_err();
 
         assert!(
             error

--- a/rust/crates/sift_cli/src/cmd/agent/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/mod.rs
@@ -35,6 +35,44 @@ impl AccessMode {
     }
 }
 
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+pub(super) enum Profile {
+    Default,
+    Named(String),
+}
+
+impl Profile {
+    fn from_option(profile: Option<String>) -> Self {
+        match profile {
+            Some(profile) => Self::Named(profile),
+            None => Self::Default,
+        }
+    }
+
+    fn label(&self) -> String {
+        match self {
+            Self::Default => "default profile".to_string(),
+            Self::Named(profile) => format!("profile '{profile}'"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(super) struct Registration {
+    access: AccessMode,
+    profile: Profile,
+}
+
+impl Registration {
+    fn new(access: AccessMode, profile: Profile) -> Self {
+        Self { access, profile }
+    }
+
+    fn label(&self) -> String {
+        format!("{}, {}", self.access.label(), self.profile.label())
+    }
+}
+
 #[derive(Debug, Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(super) enum Harness {
     Claude,
@@ -132,16 +170,17 @@ impl Environment {
     }
 }
 
-pub fn install(args: AgentInstallArgs) -> Result<ExitCode> {
+pub fn install(profile: Option<String>, args: AgentInstallArgs) -> Result<ExitCode> {
     let access = if args.allow_destructive {
         AccessMode::Destructive
     } else {
         AccessMode::ReadOnly
     };
-    install_environment(&Environment::discover()?, "Installed", access)
+    let registration = Registration::new(access, Profile::from_option(profile));
+    install_environment(&Environment::discover()?, "Installed", &registration)
 }
 
-pub async fn update(args: AgentUpdateArgs) -> Result<ExitCode> {
+pub async fn update(profile: Option<String>, args: AgentUpdateArgs) -> Result<ExitCode> {
     let current = Version::parse(env!("CARGO_PKG_VERSION"))?;
     match version::fetch_latest().await {
         Ok(Some(latest)) if latest > current => {
@@ -161,30 +200,49 @@ pub async fn update(args: AgentUpdateArgs) -> Result<ExitCode> {
     }
 
     let environment = Environment::discover()?;
-    let inferred = infer_access(&environment)?;
-    let requested = if args.allow_destructive {
+    let inference = infer_registration(&environment)?;
+    let requested_access = if args.allow_destructive {
         Some(AccessMode::Destructive)
     } else if args.read_only {
         Some(AccessMode::ReadOnly)
     } else {
         None
     };
+    let requested_profile = if args.default_profile {
+        Some(Profile::Default)
+    } else {
+        profile.map(Profile::Named)
+    };
 
-    if requested.is_none() && matches!(inferred, AccessInference::Mixed) {
+    let unresolved_access =
+        requested_access.is_none() && matches!(&inference.access, AccessInference::Mixed);
+    let unresolved_profile =
+        requested_profile.is_none() && matches!(&inference.profile, ProfileInference::Mixed);
+    if unresolved_access || unresolved_profile {
         println!("No changes were made because detected MCP clients are not configured uniformly.");
-        println!("- Access modes are mixed. Choose `--allow-destructive` or `--read-only`.");
+        if unresolved_access {
+            println!("- Access modes are mixed. Choose `--allow-destructive` or `--read-only`.");
+        }
+        if unresolved_profile {
+            println!("- Profiles are mixed. Choose `--profile <name>` or `--default-profile`.");
+        }
         return Ok(ExitCode::FAILURE);
     }
 
-    let access = requested.unwrap_or_else(|| match inferred {
+    let access = requested_access.unwrap_or_else(|| match inference.access {
         AccessInference::Resolved(access) => access,
         AccessInference::Mixed => unreachable!("mixed access was handled above"),
     });
+    let profile = requested_profile.unwrap_or_else(|| match inference.profile {
+        ProfileInference::Resolved(profile) => profile,
+        ProfileInference::Mixed => unreachable!("mixed profiles were handled above"),
+    });
+    let registration = Registration::new(access, profile);
 
-    install_environment(&environment, "Updated", access)
+    install_environment(&environment, "Updated", &registration)
 }
 
-pub async fn doctor() -> Result<ExitCode> {
+pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
     let environment = Environment::discover()?;
     println!("Sift agent bundle {}", env!("CARGO_PKG_VERSION"));
 
@@ -236,28 +294,28 @@ pub async fn doctor() -> Result<ExitCode> {
         }
     }
 
-    let mut access_modes = Vec::new();
+    let mut registrations = Vec::new();
     for harness in &environment.harnesses {
         match config::inspect(*harness, &environment)? {
-            config::State::Current(access) => {
+            config::State::Current(registration) => {
                 println!(
                     "[ok] {} MCP registration ({})",
                     harness.label(),
-                    access.label()
+                    registration.label()
                 );
-                access_modes.push(access);
+                registrations.push(registration);
             }
             config::State::Missing => {
                 println!("[error] {} MCP registration is missing", harness.label());
                 unhealthy = true;
             }
-            config::State::ManagedDrift(access) => {
+            config::State::ManagedDrift(registration) => {
                 println!(
                     "[error] {} MCP registration differs from the current bundle ({})",
                     harness.label(),
-                    access.label()
+                    registration.label()
                 );
-                access_modes.push(access);
+                registrations.push(registration);
                 unhealthy = true;
             }
             config::State::Conflict(detail) => {
@@ -272,9 +330,34 @@ pub async fn doctor() -> Result<ExitCode> {
             }
         }
     }
+    let access_modes = registrations
+        .iter()
+        .map(|registration| registration.access)
+        .collect::<Vec<_>>();
+    let profiles = registrations
+        .iter()
+        .map(|registration| registration.profile.clone())
+        .collect::<Vec<_>>();
     let mixed_access = has_mixed_access_modes(&access_modes);
     if mixed_access {
         println!("[error] Detected MCP clients use mixed access modes.");
+        unhealthy = true;
+    }
+    let mixed_profiles = has_mixed_profiles(&profiles);
+    if mixed_profiles {
+        println!("[error] Detected MCP clients use mixed profiles.");
+        unhealthy = true;
+    }
+    let expected_profile = expected_profile.map(Profile::Named);
+    let unexpected_profile = expected_profile.as_ref().is_some_and(|expected| {
+        profiles.len() != environment.harnesses.len()
+            || profiles.iter().any(|installed| installed != expected)
+    });
+    if unexpected_profile {
+        println!(
+            "[error] Detected MCP clients do not all use the requested {}.",
+            expected_profile.as_ref().expect("checked above").label()
+        );
         unhealthy = true;
     }
 
@@ -291,12 +374,37 @@ pub async fn doctor() -> Result<ExitCode> {
                  `sift-cli agent update --read-only`."
             );
         }
-        if blocked && !mixed_access {
+        if mixed_profiles {
+            match expected_profile.as_ref() {
+                Some(Profile::Named(profile)) => {
+                    println!(
+                        "Run `sift-cli agent update --profile {profile}` to switch every detected \
+                         integration."
+                    );
+                }
+                _ => {
+                    println!(
+                        "Choose one explicitly with `sift-cli agent update --profile <name>` or \
+                         `sift-cli agent update --default-profile`."
+                    );
+                }
+            }
+        }
+        if unexpected_profile && !mixed_profiles {
+            println!(
+                "Run `sift-cli agent update --profile {}` to switch every detected integration.",
+                match expected_profile.as_ref().expect("checked above") {
+                    Profile::Named(profile) => profile,
+                    Profile::Default => unreachable!("doctor only accepts named profiles"),
+                }
+            );
+        }
+        if blocked && !mixed_access && !mixed_profiles && !unexpected_profile {
             println!(
                 "Then run `sift-cli agent update` to repair all detected integrations together."
             );
         }
-        if !blocked && !mixed_access {
+        if !blocked && !mixed_access && !mixed_profiles && !unexpected_profile {
             println!("Run `sift-cli agent update` to repair the detected integrations.");
         }
         Ok(ExitCode::FAILURE)
@@ -386,7 +494,7 @@ fn uninstall_environment(environment: &Environment) -> Result<ExitCode> {
 fn install_environment(
     environment: &Environment,
     verb: &str,
-    access: AccessMode,
+    registration: &Registration,
 ) -> Result<ExitCode> {
     if environment.harnesses.is_empty() {
         println!(
@@ -437,7 +545,7 @@ fn install_environment(
             replacements.push(skill::begin_install(&target.path)?);
         }
         for harness in &environment.harnesses {
-            config::install(*harness, environment, access)?;
+            config::install(*harness, environment, registration)?;
             installed_configs += 1;
         }
         Ok(())
@@ -487,14 +595,14 @@ fn install_environment(
         println!(
             "[ok] {verb} {} MCP registration ({})",
             harness.label(),
-            access.label()
+            registration.label()
         );
     }
 
     println!(
         "{verb} the Sift agent bundle for: {} ({}).",
         harness_labels(&environment.harnesses),
-        access.label()
+        registration.label()
     );
     Ok(ExitCode::SUCCESS)
 }
@@ -505,17 +613,39 @@ enum AccessInference {
     Mixed,
 }
 
-fn infer_access(environment: &Environment) -> Result<AccessInference> {
-    let mut access_modes = Vec::new();
+#[derive(Debug, Eq, PartialEq)]
+enum ProfileInference {
+    Resolved(Profile),
+    Mixed,
+}
+
+struct RegistrationInference {
+    access: AccessInference,
+    profile: ProfileInference,
+}
+
+fn infer_registration(environment: &Environment) -> Result<RegistrationInference> {
+    let mut registrations = Vec::new();
     for harness in &environment.harnesses {
         match config::inspect(*harness, environment)? {
-            config::State::Current(access) | config::State::ManagedDrift(access) => {
-                access_modes.push(access);
+            config::State::Current(registration) | config::State::ManagedDrift(registration) => {
+                registrations.push(registration);
             }
             _ => {}
         }
     }
-    Ok(infer_access_modes(&access_modes))
+    let access_modes = registrations
+        .iter()
+        .map(|registration| registration.access)
+        .collect::<Vec<_>>();
+    let profiles = registrations
+        .into_iter()
+        .map(|registration| registration.profile)
+        .collect::<Vec<_>>();
+    Ok(RegistrationInference {
+        access: infer_access_modes(&access_modes),
+        profile: infer_profiles(&profiles),
+    })
 }
 
 fn infer_access_modes(access_modes: &[AccessMode]) -> AccessInference {
@@ -535,6 +665,20 @@ fn has_mixed_access_modes(access_modes: &[AccessMode]) -> bool {
     access_modes
         .first()
         .is_some_and(|first| access_modes.iter().any(|access| access != first))
+}
+
+fn infer_profiles(profiles: &[Profile]) -> ProfileInference {
+    if has_mixed_profiles(profiles) {
+        ProfileInference::Mixed
+    } else {
+        ProfileInference::Resolved(profiles.first().cloned().unwrap_or(Profile::Default))
+    }
+}
+
+fn has_mixed_profiles(profiles: &[Profile]) -> bool {
+    profiles
+        .first()
+        .is_some_and(|first| profiles.iter().any(|profile| profile != first))
 }
 
 async fn check_release() -> bool {

--- a/rust/crates/sift_cli/src/cmd/agent/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/tests.rs
@@ -4,7 +4,10 @@ use clap::Parser;
 use serde_json::Value;
 use tempdir::TempDir;
 
-use super::{AccessInference, AccessMode, Environment, Harness, config, skill};
+use super::{
+    AccessInference, AccessMode, Environment, Harness, Profile, ProfileInference, Registration,
+    config, skill,
+};
 
 fn environment(harnesses: Vec<Harness>) -> (TempDir, Environment) {
     let directory = TempDir::new("sift-cli-agent-tests").unwrap();
@@ -13,6 +16,14 @@ fn environment(harnesses: Vec<Harness>) -> (TempDir, Environment) {
         directory,
         Environment::for_test(PathBuf::new(), current_exe, harnesses),
     )
+}
+
+fn default_registration(access: AccessMode) -> Registration {
+    Registration::new(access, Profile::Default)
+}
+
+fn named_registration(access: AccessMode, profile: &str) -> Registration {
+    Registration::new(access, Profile::Named(profile.to_string()))
 }
 
 #[test]
@@ -141,7 +152,12 @@ fn cursor_config_merge_preserves_other_servers() {
     )
     .unwrap();
 
-    config::install(Harness::Cursor, &environment, AccessMode::ReadOnly).unwrap();
+    config::install(
+        Harness::Cursor,
+        &environment,
+        &default_registration(AccessMode::ReadOnly),
+    )
+    .unwrap();
 
     let value: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
     assert_eq!(value["setting"], true);
@@ -152,7 +168,7 @@ fn cursor_config_merge_preserves_other_servers() {
     );
     assert_eq!(
         config::inspect(Harness::Cursor, &environment).unwrap(),
-        config::State::Current(AccessMode::ReadOnly)
+        config::State::Current(default_registration(AccessMode::ReadOnly))
     );
 }
 
@@ -166,7 +182,12 @@ fn opencode_config_uses_local_command_array() {
         vec![Harness::OpenCode],
     );
 
-    config::install(Harness::OpenCode, &environment, AccessMode::ReadOnly).unwrap();
+    config::install(
+        Harness::OpenCode,
+        &environment,
+        &default_registration(AccessMode::ReadOnly),
+    )
+    .unwrap();
 
     let path = directory.path().join(".config/opencode/opencode.json");
     let value: Value = serde_json::from_slice(&fs::read(path).unwrap()).unwrap();
@@ -177,6 +198,64 @@ fn opencode_config_uses_local_command_array() {
         current_exe.to_string_lossy().as_ref()
     );
     assert_eq!(value["mcp"]["sift"]["command"][1], "mcp");
+}
+
+#[test]
+fn named_profile_is_installed_for_every_json_backed_client() {
+    let directory = TempDir::new("sift-cli-agent-profile-install").unwrap();
+    let current_exe = directory.path().join("bin/sift-cli");
+    let environment = Environment::for_test(
+        directory.path().to_path_buf(),
+        current_exe,
+        vec![Harness::Cursor, Harness::OpenCode],
+    );
+    let registration = named_registration(AccessMode::ReadOnly, "localdev");
+
+    config::install(Harness::Cursor, &environment, &registration).unwrap();
+    config::install(Harness::OpenCode, &environment, &registration).unwrap();
+
+    let cursor: Value =
+        serde_json::from_slice(&fs::read(directory.path().join(".cursor/mcp.json")).unwrap())
+            .unwrap();
+    assert_eq!(
+        cursor["mcpServers"]["sift"]["args"],
+        serde_json::json!(["mcp", "--profile", "localdev"])
+    );
+
+    let opencode: Value = serde_json::from_slice(
+        &fs::read(directory.path().join(".config/opencode/opencode.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        opencode["mcp"]["sift"]["command"],
+        serde_json::json!([
+            directory
+                .path()
+                .join("bin/sift-cli")
+                .to_string_lossy()
+                .as_ref(),
+            "mcp",
+            "--profile",
+            "localdev"
+        ])
+    );
+    assert_eq!(
+        config::inspect(Harness::Cursor, &environment).unwrap(),
+        config::State::Current(registration.clone())
+    );
+    assert_eq!(
+        config::inspect(Harness::OpenCode, &environment).unwrap(),
+        config::State::Current(registration)
+    );
+}
+
+#[test]
+fn profile_global_flag_is_accepted_after_agent_install() {
+    let args =
+        crate::cli::Args::try_parse_from(["sift-cli", "agent", "install", "--profile", "localdev"])
+            .unwrap();
+
+    assert_eq!(args.profile.as_deref(), Some("localdev"));
 }
 
 #[test]
@@ -213,7 +292,12 @@ fn malformed_config_container_is_caught_during_preflight() {
     fs::create_dir_all(config_path.parent().unwrap()).unwrap();
     fs::write(&config_path, r#"{"mcpServers":[]}"#).unwrap();
 
-    super::install_environment(&environment, "Installed", AccessMode::ReadOnly).unwrap();
+    super::install_environment(
+        &environment,
+        "Installed",
+        &default_registration(AccessMode::ReadOnly),
+    )
+    .unwrap();
 
     assert!(!directory.path().join(".agents/skills/sift").exists());
     assert_eq!(
@@ -258,7 +342,7 @@ fn destructive_access_is_a_current_managed_registration() {
 
     assert_eq!(
         config::inspect(Harness::Cursor, &environment).unwrap(),
-        config::State::Current(AccessMode::Destructive)
+        config::State::Current(default_registration(AccessMode::Destructive))
     );
 }
 
@@ -272,16 +356,17 @@ fn destructive_install_updates_every_json_backed_client() {
         vec![Harness::Cursor, Harness::OpenCode],
     );
 
-    config::install(Harness::Cursor, &environment, AccessMode::Destructive).unwrap();
-    config::install(Harness::OpenCode, &environment, AccessMode::Destructive).unwrap();
+    let registration = default_registration(AccessMode::Destructive);
+    config::install(Harness::Cursor, &environment, &registration).unwrap();
+    config::install(Harness::OpenCode, &environment, &registration).unwrap();
 
     assert_eq!(
         config::inspect(Harness::Cursor, &environment).unwrap(),
-        config::State::Current(AccessMode::Destructive)
+        config::State::Current(registration.clone())
     );
     assert_eq!(
         config::inspect(Harness::OpenCode, &environment).unwrap(),
-        config::State::Current(AccessMode::Destructive)
+        config::State::Current(registration)
     );
 }
 
@@ -302,6 +387,25 @@ fn update_access_inference_preserves_one_mode_and_rejects_mixed_modes() {
 }
 
 #[test]
+fn update_profile_inference_preserves_one_profile_and_rejects_mixed_profiles() {
+    assert_eq!(
+        super::infer_profiles(&[]),
+        ProfileInference::Resolved(Profile::Default)
+    );
+    assert_eq!(
+        super::infer_profiles(&[
+            Profile::Named("localdev".to_string()),
+            Profile::Named("localdev".to_string()),
+        ]),
+        ProfileInference::Resolved(Profile::Named("localdev".to_string()))
+    );
+    assert_eq!(
+        super::infer_profiles(&[Profile::Default, Profile::Named("localdev".to_string()),]),
+        ProfileInference::Mixed
+    );
+}
+
+#[test]
 fn update_access_flags_are_mutually_exclusive() {
     assert!(
         crate::cli::Args::try_parse_from([
@@ -310,6 +414,21 @@ fn update_access_flags_are_mutually_exclusive() {
             "update",
             "--allow-destructive",
             "--read-only",
+        ])
+        .is_err()
+    );
+}
+
+#[test]
+fn update_named_and_default_profile_flags_are_mutually_exclusive() {
+    assert!(
+        crate::cli::Args::try_parse_from([
+            "sift-cli",
+            "agent",
+            "update",
+            "--profile",
+            "localdev",
+            "--default-profile",
         ])
         .is_err()
     );
@@ -354,7 +473,12 @@ fn install_preflight_keeps_every_target_unchanged_on_conflict() {
     )
     .unwrap();
 
-    super::install_environment(&environment, "Installed", AccessMode::ReadOnly).unwrap();
+    super::install_environment(
+        &environment,
+        "Installed",
+        &default_registration(AccessMode::ReadOnly),
+    )
+    .unwrap();
 
     assert!(!directory.path().join(".agents/skills/sift").exists());
 }
@@ -379,7 +503,11 @@ fn failed_later_client_install_rolls_back_earlier_clients_and_skills() {
     fs::create_dir_all(&opencode_dir).unwrap();
     fs::set_permissions(&opencode_dir, fs::Permissions::from_mode(0o555)).unwrap();
 
-    let result = super::install_environment(&environment, "Installed", AccessMode::ReadOnly);
+    let result = super::install_environment(
+        &environment,
+        "Installed",
+        &default_registration(AccessMode::ReadOnly),
+    );
 
     fs::set_permissions(&opencode_dir, fs::Permissions::from_mode(0o755)).unwrap();
     let error = result.unwrap_err();

--- a/rust/crates/sift_cli/src/main.rs
+++ b/rust/crates/sift_cli/src/main.rs
@@ -84,9 +84,11 @@ fn run(clargs: cli::Args) -> Result<ExitCode> {
         },
         #[cfg(feature = "mcp")]
         Cmd::Agent(cmd) => match cmd {
-            AgentCmd::Install(args) => return cmd::agent::install(args),
-            AgentCmd::Update(args) => return run_future(cmd::agent::update(args)),
-            AgentCmd::Doctor => return run_future(cmd::agent::doctor()),
+            AgentCmd::Install(args) => return cmd::agent::install(clargs.profile, args),
+            AgentCmd::Update(args) => {
+                return run_future(cmd::agent::update(clargs.profile, args));
+            }
+            AgentCmd::Doctor => return run_future(cmd::agent::doctor(clargs.profile)),
             AgentCmd::Uninstall => return cmd::agent::uninstall(),
         },
         _ => (),


### PR DESCRIPTION
## Changes

Lets the agent bundle target a named Sift profile. The global `--profile` flag was already parsed but hidden; this unhides it and threads it into the MCP arguments each client is registered with, so a registration points at one profile rather than whatever the default resolves to at runtime.

Widens the managed registration from an access mode to access plus profile. Both are read back out of the client configs, so update preserves the installed profile the same way it already preserved read-only or destructive access, with no state file. Adds `--default-profile` to move every client back to the default, mutually exclusive with `--profile`.

Only the exact argument shapes this CLI writes count as managed, now including `mcp --profile <name>` and `mcp --profile <name> --allow-destructive`. A profile that is empty or starts with `-` is rejected rather than treated as managed.

Mixed profiles across detected clients are an error, matching the existing treatment of mixed access modes: doctor reports them and update refuses to guess.

## Verification

- `cargo fmt --check --all`, `cargo clippy --all-features`, `cargo test --all-features`
- 25 `cmd::agent` tests

## Note for reviewers

No CHANGELOG entry is added here, matching the original branch. If `--profile` / `--default-profile` should be called out for release, that line is worth adding.
