### PR TITLE
rust(feat): Add list_users tool

### DIFF
--- a/rust/crates/sift_cli/assets/docs/src/agents/mcp.md
+++ b/rust/crates/sift_cli/assets/docs/src/agents/mcp.md
@@ -83,6 +83,11 @@ A typical agent flow is `list_assets` → `list_channels` → `get_data` → `sq
 and `upload_dataset` to write results back. To attribute records to a person,
 resolve them with `list_users` first, then filter on `created_by_user_id`.
 
+Every `list_*` tool takes a CEL `filter`. String fields support `contains`,
+`startsWith`, and `endsWith` (case-sensitive) plus `matches` for RE2 regex, so
+prefer `name.matches("(?i)jane")` over an exact `==` when you only have part of
+a name. Prefix a regex with `(?i)` to ignore casing.
+
 ## Identifying yourself
 
 `list_users` accepts `me: true` to return the user whose credentials the server

--- a/rust/crates/sift_cli/assets/docs/src/agents/mcp.md
+++ b/rust/crates/sift_cli/assets/docs/src/agents/mcp.md
@@ -76,10 +76,19 @@ if you want the agent to be able to modify or archive existing resources.
 | `update_rule`    | Update specific fields of a rule; unspecified fields are preserved.          |
 | `archive_rule`   | Archive a rule so it stops evaluating.                                        |
 | `unarchive_rule` | Restore an archived rule.                                                     |
+| `list_users`     | List users, with filtering and ordering; resolves a person to a `user_id`.    |
 | `search_docs`    | Search and read the Sift documentation and REST/gRPC API reference.           |
 
 A typical agent flow is `list_assets` → `list_channels` → `get_data` → `sql`,
-and `upload_dataset` to write results back.
+and `upload_dataset` to write results back. To attribute records to a person,
+resolve them with `list_users` first, then filter on `created_by_user_id`.
+
+## Identifying yourself
+
+`list_users` accepts `me: true` to return the user whose credentials the server
+is running under, which is what lets an agent answer "list the runs I created".
+It resolves from the API key in your profile, so it needs no configuration and
+cannot disagree with the account you are actually querying as.
 
 ## Built-in prompts
 

--- a/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
+++ b/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
@@ -21,6 +21,10 @@ to combine them when working with Sift.
      (start at 200, max 1000). Omitting it defaults to 200 and values above 1000
      clamp to 1000, so raise `limit` when a result comes back capped.
    - `list_report_rule_summaries`: per-rule pass/fail/open breakdown for a report.
+   - `list_users`: resolve a person to a `user_id` by name, email, or id, then
+     filter another list on `created_by_user_id` — that is how you answer "runs
+     Jane created". For "runs I created", pass `me: true`, which resolves the
+     caller from their API key; never guess which listed user is the caller.
    - `list_test_reports`, `list_test_steps`, `list_test_measurements`: inspect
      test-results data (reports own steps own measurements); `count_test_steps`,
      `count_test_measurements`: totals matching a filter without fetching rows.

--- a/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
+++ b/rust/crates/sift_cli/assets/skills/agents-md/AGENTS.md
@@ -23,8 +23,11 @@ to combine them when working with Sift.
    - `list_report_rule_summaries`: per-rule pass/fail/open breakdown for a report.
    - `list_users`: resolve a person to a `user_id` by name, email, or id, then
      filter another list on `created_by_user_id` — that is how you answer "runs
-     Jane created". For "runs I created", pass `me: true`, which resolves the
-     caller from their API key; never guess which listed user is the caller.
+     Jane created". Match names with `name.matches("(?i)jane")` rather than an
+     exact `==` on an address you are guessing at; `contains`, `startsWith`, and
+     `endsWith` also work but are case-sensitive. For "runs I created", pass
+     `me: true`, which resolves the caller from their API key; never guess which
+     listed user is the caller.
    - `list_test_reports`, `list_test_steps`, `list_test_measurements`: inspect
      test-results data (reports own steps own measurements); `count_test_steps`,
      `count_test_measurements`: totals matching a filter without fetching rows.

--- a/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
@@ -40,8 +40,11 @@ to combine them when working with Sift.
    - `list_report_rule_summaries`: per-rule pass/fail/open breakdown for a report.
    - `list_users`: resolve a person to a `user_id` by name, email, or id, then
      filter another list on `created_by_user_id` — that is how you answer "runs
-     Jane created". For "runs I created", pass `me: true`, which resolves the
-     caller from their API key; never guess which listed user is the caller.
+     Jane created". Match names with `name.matches("(?i)jane")` rather than an
+     exact `==` on an address you are guessing at; `contains`, `startsWith`, and
+     `endsWith` also work but are case-sensitive. For "runs I created", pass
+     `me: true`, which resolves the caller from their API key; never guess which
+     listed user is the caller.
    - `list_test_reports`, `list_test_steps`, `list_test_measurements`: inspect
      test-results data (reports own steps own measurements); `count_test_steps`,
      `count_test_measurements`: totals matching a filter without fetching rows.

--- a/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/claude-code/SKILL.md
@@ -2,14 +2,15 @@
 name: sift
 description: >-
   Use when working with Sift: ingesting or importing time-series data,
-  querying assets/runs/channels, exporting data, decimating or running SQL
+  querying assets/runs/channels/users, exporting data, decimating or running SQL
   over data, opening a view in the Sift Explore web app, writing code
   that integrates with Sift, or looking up how Sift works in its product and
   API documentation. Covers the Sift MCP server (started by
   `sift-cli mcp`), the `sift-cli` itself, the Sift REST API over cURL, the
   Sift Python library (`sift_client`), and the Sift Rust streaming library
   (`sift_stream`). Triggers include phrases like "import this file into
-  Sift", "stream data to Sift", "list assets/runs/channels", "export a
+  Sift", "stream data to Sift", "list assets/runs/channels", "runs I created",
+  "runs a teammate created", "export a
   run", "query Sift", "graph", "plot", "visualize", "open in Explore",
   "write code to integrate with Sift", "how does X work in Sift", "what does
   this endpoint do", or "look up the Sift API reference".
@@ -37,6 +38,10 @@ to combine them when working with Sift.
      (start at 200, max 1000). Omitting it defaults to 200 and values above 1000
      clamp to 1000, so raise `limit` when a result comes back capped.
    - `list_report_rule_summaries`: per-rule pass/fail/open breakdown for a report.
+   - `list_users`: resolve a person to a `user_id` by name, email, or id, then
+     filter another list on `created_by_user_id` — that is how you answer "runs
+     Jane created". For "runs I created", pass `me: true`, which resolves the
+     caller from their API key; never guess which listed user is the caller.
    - `list_test_reports`, `list_test_steps`, `list_test_measurements`: inspect
      test-results data (reports own steps own measurements); `count_test_steps`,
      `count_test_measurements`: totals matching a filter without fetching rows.

--- a/rust/crates/sift_mcp/src/server/mod.rs
+++ b/rust/crates/sift_mcp/src/server/mod.rs
@@ -14,7 +14,7 @@ use crate::service::{
     annotations::AnnotationService, assets::AssetService, channels::ChannelService,
     data::DataService, docs::DocsService, ingest::IngestService, ping::PingService,
     reports::ReportService, rules::RuleService, runs::RunService, test_reports::TestReportService,
-    url::UrlService,
+    url::UrlService, users::UserService,
 };
 
 #[derive(Clone)]
@@ -34,6 +34,7 @@ pub struct SiftMcpServer {
     pub rule_service: RuleService,
     pub test_report_service: TestReportService,
     pub docs_service: DocsService,
+    pub user_service: UserService,
 
     pub allow_destructive: bool,
 }
@@ -84,6 +85,7 @@ impl SiftMcpServer {
         tool_router.merge(Self::annotations_router());
         tool_router.merge(Self::test_reports_router());
         tool_router.merge(Self::docs_router());
+        tool_router.merge(Self::users_router());
 
         let prompt_router = Self::prompt_router();
 
@@ -100,7 +102,8 @@ impl SiftMcpServer {
         let report_service = ReportService::new(channel.clone(), retry_policy.clone());
         let rule_service = RuleService::new(channel.clone(), retry_policy.clone());
         let test_report_service = TestReportService::new(channel.clone(), retry_policy.clone());
-        let docs_service = DocsService::new(channel.clone(), retry_policy);
+        let docs_service = DocsService::new(channel.clone(), retry_policy.clone());
+        let user_service = UserService::new(channel.clone(), retry_policy);
 
         Self {
             annotation_service,
@@ -115,6 +118,7 @@ impl SiftMcpServer {
             rule_service,
             test_report_service,
             docs_service,
+            user_service,
             tool_router,
             prompt_router,
             allow_destructive,

--- a/rust/crates/sift_mcp/src/service/mod.rs
+++ b/rust/crates/sift_mcp/src/service/mod.rs
@@ -10,5 +10,6 @@ pub mod rules;
 pub mod runs;
 pub mod test_reports;
 pub mod url;
+pub mod users;
 
 pub(crate) mod common;

--- a/rust/crates/sift_mcp/src/service/users/mod.rs
+++ b/rust/crates/sift_mcp/src/service/users/mod.rs
@@ -1,0 +1,151 @@
+use crate::policy::{RetryPolicy, with_retry};
+use crate::service::common;
+use anyhow::{Context, Result};
+use sift_rs::{
+    SiftChannel,
+    common::r#type::v1::User,
+    me::v2::{GetMeRequest, GetMeResponse, me_service_client::MeServiceClient},
+    users::v2::{
+        ListActiveUsersRequest, ListActiveUsersResponse, ListUsersRequest, ListUsersResponse,
+        user_service_client::UserServiceClient,
+    },
+};
+
+#[cfg(test)]
+mod test;
+
+/// Spans two proto packages: `sift.users.v2` for listing users and
+/// `sift.me.v2` for resolving the caller. Both answer questions about users,
+/// and `list_users` serves them from one tool.
+#[derive(Clone)]
+pub struct UserService {
+    channel: SiftChannel,
+    policy: RetryPolicy,
+}
+
+impl UserService {
+    pub fn new(channel: SiftChannel, policy: RetryPolicy) -> Self {
+        Self { channel, policy }
+    }
+
+    /// `include_inactive` selects the RPC: `ListActiveUsers` by default,
+    /// `ListUsers` when set, which also returns deactivated accounts.
+    pub async fn list_users(
+        &self,
+        filter: String,
+        order_by: Option<String>,
+        limit: Option<u32>,
+        include_inactive: bool,
+    ) -> Result<Vec<User>> {
+        let (page_size, record_limit) = common::paging(limit);
+
+        let mut page_token = String::new();
+        let mut results = Vec::new();
+
+        let order_by = order_by.unwrap_or_default();
+
+        loop {
+            let channel = self.channel.clone();
+            let filter = filter.clone();
+            let order_by = order_by.clone();
+            let token = page_token.clone();
+
+            let (users, next_page_token) = with_retry(&self.policy, move || {
+                let channel = channel.clone();
+                let filter = filter.clone();
+                let order_by = order_by.clone();
+                let token = token.clone();
+                async move {
+                    let mut client = UserServiceClient::new(channel);
+                    if include_inactive {
+                        client
+                            .list_users(ListUsersRequest {
+                                filter,
+                                page_size,
+                                page_token: token,
+                                order_by,
+                            })
+                            .await
+                            .map(|resp| {
+                                let ListUsersResponse {
+                                    users,
+                                    next_page_token,
+                                } = resp.into_inner();
+                                (users, next_page_token)
+                            })
+                    } else {
+                        client
+                            .list_active_users(ListActiveUsersRequest {
+                                filter,
+                                page_size,
+                                page_token: token,
+                                order_by,
+                                organization_id: String::new(),
+                            })
+                            .await
+                            .map(|resp| {
+                                let ListActiveUsersResponse {
+                                    users,
+                                    next_page_token,
+                                } = resp.into_inner();
+                                (users, next_page_token)
+                            })
+                    }
+                }
+            })
+            .await
+            .context("failed to query users")?;
+
+            if users.is_empty() {
+                break;
+            }
+            results.extend(users);
+
+            if results.len() >= record_limit || next_page_token.is_empty() {
+                break;
+            }
+            page_token = next_page_token;
+        }
+
+        results.truncate(record_limit);
+
+        Ok(results)
+    }
+
+    /// Resolve the caller via `sift.me.v2 GetMe`, which takes no arguments —
+    /// the backend derives the user from the API key on the channel.
+    ///
+    /// Returned as a [`User`] so `list_users` emits one row shape either way.
+    /// `user_email` maps onto `user_name`, the sign-in identifier on the list
+    /// side; `is_admin`, `permissions`, and `created_date` are dropped as
+    /// authorization details no tool acts on.
+    pub async fn get_me(&self) -> Result<User> {
+        let channel = self.channel.clone();
+
+        let resp = with_retry(&self.policy, move || {
+            let channel = channel.clone();
+            async move {
+                let mut client = MeServiceClient::new(channel);
+                client
+                    .get_me(GetMeRequest {})
+                    .await
+                    .map(|resp| resp.into_inner())
+            }
+        })
+        .await
+        .context("failed to resolve the calling user")?;
+
+        let GetMeResponse {
+            user_id,
+            user_email,
+            organizations,
+            ..
+        } = resp;
+
+        Ok(User {
+            user_id,
+            user_name: user_email,
+            organizations,
+        })
+    }
+}

--- a/rust/crates/sift_mcp/src/service/users/mod.rs
+++ b/rust/crates/sift_mcp/src/service/users/mod.rs
@@ -14,9 +14,9 @@ use sift_rs::{
 #[cfg(test)]
 mod test;
 
-/// Spans two proto packages: `sift.users.v2` for listing users and
-/// `sift.me.v2` for resolving the caller. Both answer questions about users,
-/// and `list_users` serves them from one tool.
+/// Backs the `list_users` tool: listing users in the organization and
+/// resolving the caller. Both answer questions about users, so one tool serves
+/// them.
 #[derive(Clone)]
 pub struct UserService {
     channel: SiftChannel,
@@ -28,8 +28,13 @@ impl UserService {
         Self { channel, policy }
     }
 
-    /// `include_inactive` selects the RPC: `ListActiveUsers` by default,
-    /// `ListUsers` when set, which also returns deactivated accounts.
+    /// `include_inactive` is false unless the caller sets it, which lists only
+    /// users active in the organization; true also returns deactivated
+    /// accounts.
+    ///
+    /// `filter` is a CEL expression and is passed through untouched. `name`
+    /// (the user's `user_name`) supports `contains`, `matches`, `startsWith`,
+    /// and `endsWith` alongside `==`.
     pub async fn list_users(
         &self,
         filter: String,
@@ -112,13 +117,13 @@ impl UserService {
         Ok(results)
     }
 
-    /// Resolve the caller via `sift.me.v2 GetMe`, which takes no arguments —
-    /// the backend derives the user from the API key on the channel.
+    /// Resolve the user behind the credentials this server runs under. Takes no
+    /// arguments: the caller's identity comes from the configured credentials,
+    /// not from anything passed in here.
     ///
     /// Returned as a [`User`] so `list_users` emits one row shape either way.
-    /// `user_email` maps onto `user_name`, the sign-in identifier on the list
-    /// side; `is_admin`, `permissions`, and `created_date` are dropped as
-    /// authorization details no tool acts on.
+    /// The caller's email maps onto `user_name`, the sign-in identifier used
+    /// when listing; fields no tool acts on are dropped.
     pub async fn get_me(&self) -> Result<User> {
         let channel = self.channel.clone();
 

--- a/rust/crates/sift_mcp/src/service/users/test.rs
+++ b/rust/crates/sift_mcp/src/service/users/test.rs
@@ -32,8 +32,8 @@ async fn service_with_me_mock(mock: MockMeServiceImpl) -> (UserService, JoinHand
     service_with_mocks(MockUserServiceImpl::new(), mock).await
 }
 
-/// Both proto services are registered on one in-memory server, matching how
-/// `UserService` spans them in production.
+/// Both mocks are registered on one in-memory server, matching how
+/// `UserService` uses them together.
 async fn service_with_mocks(
     user_mock: MockUserServiceImpl,
     me_mock: MockMeServiceImpl,
@@ -86,15 +86,15 @@ async fn list_users_returns_single_page() {
 async fn list_users_defaults_to_active_users_rpc() {
     let mut mock = MockUserServiceImpl::new();
     mock.expect_list_active_users().times(1).returning(|req| {
-        // `organization_id` is not exposed as a tool parameter; the caller's
-        // API key already scopes the listing.
+        // `organization_id` is not exposed as a tool parameter, so it must go
+        // out empty.
         assert!(req.get_ref().organization_id.is_empty());
         Ok(Response::new(ListActiveUsersResponse {
             users: vec![user("u1", "jane@siftstack.com")],
             next_page_token: String::new(),
         }))
     });
-    // No expectation on `list_users`: it must not be reached.
+    // The inactive-inclusive path gets no expectation: it must not be reached.
 
     let (service, _h) = service_with_mock(mock).await;
 
@@ -118,7 +118,7 @@ async fn list_users_include_inactive_uses_all_users_rpc() {
             next_page_token: String::new(),
         }))
     });
-    // No expectation on `list_active_users`: it must not be reached.
+    // The active-only path gets no expectation: it must not be reached.
 
     let (service, _h) = service_with_mock(mock).await;
 
@@ -259,8 +259,7 @@ async fn get_me_maps_email_onto_user_name() {
 
 #[tokio::test]
 async fn get_me_sends_an_empty_request() {
-    // Identity comes from the API key on the channel, so the request carries
-    // nothing.
+    // The call takes no arguments, so nothing is assembled to send.
     let mut mock = MockMeServiceImpl::new();
     mock.expect_get_me().times(1).returning(|req| {
         let _: sift_rs::me::v2::GetMeRequest = req.into_inner();

--- a/rust/crates/sift_mcp/src/service/users/test.rs
+++ b/rust/crates/sift_mcp/src/service/users/test.rs
@@ -1,0 +1,296 @@
+use sift_rs::{
+    common::r#type::v1::{Organization, User},
+    me::v2::{GetMeResponse, me_service_server::MeServiceServer},
+    users::v2::{
+        ListActiveUsersResponse, ListUsersResponse, user_service_server::UserServiceServer,
+    },
+};
+use sift_test_util::{
+    grpc::memory_sift_channel,
+    mock::{me::v2::MockMeServiceImpl, users::v2::MockUserServiceImpl},
+};
+use tokio::task::JoinHandle;
+use tonic::{Response, Status, transport::Server};
+
+use super::UserService;
+use crate::policy::RetryPolicy;
+use crate::service::common::DEFAULT_LIMIT;
+
+fn user(id: &str, name: &str) -> User {
+    User {
+        user_id: id.into(),
+        user_name: name.into(),
+        ..Default::default()
+    }
+}
+
+async fn service_with_mock(mock: MockUserServiceImpl) -> (UserService, JoinHandle<()>) {
+    service_with_mocks(mock, MockMeServiceImpl::new()).await
+}
+
+async fn service_with_me_mock(mock: MockMeServiceImpl) -> (UserService, JoinHandle<()>) {
+    service_with_mocks(MockUserServiceImpl::new(), mock).await
+}
+
+/// Both proto services are registered on one in-memory server, matching how
+/// `UserService` spans them in production.
+async fn service_with_mocks(
+    user_mock: MockUserServiceImpl,
+    me_mock: MockMeServiceImpl,
+) -> (UserService, JoinHandle<()>) {
+    let (client, server) = tokio::io::duplex(1024);
+    let channel = memory_sift_channel(client).await;
+
+    let handle = tokio::spawn(async move {
+        Server::builder()
+            .add_service(UserServiceServer::new(user_mock))
+            .add_service(MeServiceServer::new(me_mock))
+            .serve_with_incoming(tokio_stream::once(Ok::<_, std::io::Error>(server)))
+            .await
+            .unwrap();
+    });
+
+    (UserService::new(channel, RetryPolicy::default()), handle)
+}
+
+#[tokio::test]
+async fn list_users_returns_single_page() {
+    let mut mock = MockUserServiceImpl::new();
+    mock.expect_list_active_users()
+        .times(1)
+        .withf(|req| req.get_ref().filter == "name == \"jane@siftstack.com\"")
+        .returning(|_| {
+            Ok(Response::new(ListActiveUsersResponse {
+                users: vec![user("u1", "jane@siftstack.com")],
+                next_page_token: String::new(),
+            }))
+        });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let users = service
+        .list_users(
+            "name == \"jane@siftstack.com\"".to_string(),
+            None,
+            None,
+            false,
+        )
+        .await
+        .expect("list_users failed");
+
+    assert_eq!(users.len(), 1);
+    assert_eq!(users[0].user_id, "u1");
+}
+
+#[tokio::test]
+async fn list_users_defaults_to_active_users_rpc() {
+    let mut mock = MockUserServiceImpl::new();
+    mock.expect_list_active_users().times(1).returning(|req| {
+        // `organization_id` is not exposed as a tool parameter; the caller's
+        // API key already scopes the listing.
+        assert!(req.get_ref().organization_id.is_empty());
+        Ok(Response::new(ListActiveUsersResponse {
+            users: vec![user("u1", "jane@siftstack.com")],
+            next_page_token: String::new(),
+        }))
+    });
+    // No expectation on `list_users`: it must not be reached.
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let users = service
+        .list_users(String::new(), None, None, false)
+        .await
+        .expect("list_users failed");
+
+    assert_eq!(users.len(), 1);
+}
+
+#[tokio::test]
+async fn list_users_include_inactive_uses_all_users_rpc() {
+    let mut mock = MockUserServiceImpl::new();
+    mock.expect_list_users().times(1).returning(|_| {
+        Ok(Response::new(ListUsersResponse {
+            users: vec![
+                user("u1", "jane@siftstack.com"),
+                user("u2", "former@siftstack.com"),
+            ],
+            next_page_token: String::new(),
+        }))
+    });
+    // No expectation on `list_active_users`: it must not be reached.
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let users = service
+        .list_users(String::new(), None, None, true)
+        .await
+        .expect("list_users failed");
+
+    let ids: Vec<&str> = users.iter().map(|u| u.user_id.as_str()).collect();
+    assert_eq!(ids, vec!["u1", "u2"]);
+}
+
+#[tokio::test]
+async fn list_users_paginates_until_token_empty() {
+    let mut mock = MockUserServiceImpl::new();
+    mock.expect_list_active_users().returning(|req| {
+        let req = req.into_inner();
+        assert_eq!(req.page_size, DEFAULT_LIMIT);
+        let (users, next) = match req.page_token.as_str() {
+            "" => (vec![user("u1", "a@siftstack.com")], "page-2".to_string()),
+            "page-2" => (vec![user("u2", "b@siftstack.com")], "page-3".to_string()),
+            "page-3" => (vec![user("u3", "c@siftstack.com")], String::new()),
+            other => return Err(Status::invalid_argument(format!("bad token: {other}"))),
+        };
+        Ok(Response::new(ListActiveUsersResponse {
+            users,
+            next_page_token: next,
+        }))
+    });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let users = service
+        .list_users(String::new(), None, None, false)
+        .await
+        .expect("list_users failed");
+
+    let ids: Vec<&str> = users.iter().map(|u| u.user_id.as_str()).collect();
+    assert_eq!(ids, vec!["u1", "u2", "u3"]);
+}
+
+#[tokio::test]
+async fn list_users_truncates_to_limit_across_pages() {
+    let mut mock = MockUserServiceImpl::new();
+    mock.expect_list_active_users().returning(|req| {
+        let req = req.into_inner();
+        assert_eq!(req.page_size, 3);
+        let (users, next) = match req.page_token.as_str() {
+            "" => (
+                vec![user("u1", "a@siftstack.com"), user("u2", "b@siftstack.com")],
+                "page-2".to_string(),
+            ),
+            "page-2" => (
+                vec![user("u3", "c@siftstack.com"), user("u4", "d@siftstack.com")],
+                String::new(),
+            ),
+            other => return Err(Status::invalid_argument(format!("bad token: {other}"))),
+        };
+        Ok(Response::new(ListActiveUsersResponse {
+            users,
+            next_page_token: next,
+        }))
+    });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let users = service
+        .list_users(String::new(), None, Some(3), false)
+        .await
+        .expect("list_users failed");
+
+    let ids: Vec<&str> = users.iter().map(|u| u.user_id.as_str()).collect();
+    assert_eq!(ids, vec!["u1", "u2", "u3"]);
+}
+
+#[tokio::test]
+async fn list_users_breaks_on_empty_page() {
+    let mut mock = MockUserServiceImpl::new();
+    mock.expect_list_active_users().times(1).returning(|_| {
+        Ok(Response::new(ListActiveUsersResponse {
+            users: vec![],
+            next_page_token: "ignored".into(),
+        }))
+    });
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let users = service
+        .list_users(String::new(), None, None, false)
+        .await
+        .expect("list_users failed");
+
+    assert!(users.is_empty());
+}
+
+#[tokio::test]
+async fn list_users_propagates_grpc_error() {
+    let mut mock = MockUserServiceImpl::new();
+    mock.expect_list_active_users()
+        .returning(|_| Err(Status::invalid_argument("bad filter")));
+
+    let (service, _h) = service_with_mock(mock).await;
+
+    let err = service
+        .list_users("nope".to_string(), None, None, false)
+        .await
+        .expect_err("expected error");
+
+    assert!(err.to_string().contains("failed to query users"));
+}
+
+#[tokio::test]
+async fn get_me_maps_email_onto_user_name() {
+    let mut mock = MockMeServiceImpl::new();
+    mock.expect_get_me().times(1).returning(|_| {
+        Ok(Response::new(GetMeResponse {
+            user_id: "u1".into(),
+            user_email: "jane@siftstack.com".into(),
+            organizations: vec![Organization {
+                organization_id: "org1".into(),
+                organization_name: "Sift".into(),
+                ..Default::default()
+            }],
+            is_admin: true,
+            ..Default::default()
+        }))
+    });
+
+    let (service, _h) = service_with_me_mock(mock).await;
+
+    let user = service.get_me().await.expect("get_me failed");
+
+    assert_eq!(user.user_id, "u1");
+    assert_eq!(user.user_name, "jane@siftstack.com");
+    assert_eq!(user.organizations.len(), 1);
+    assert_eq!(user.organizations[0].organization_id, "org1");
+}
+
+#[tokio::test]
+async fn get_me_sends_an_empty_request() {
+    // Identity comes from the API key on the channel, so the request carries
+    // nothing.
+    let mut mock = MockMeServiceImpl::new();
+    mock.expect_get_me().times(1).returning(|req| {
+        let _: sift_rs::me::v2::GetMeRequest = req.into_inner();
+        Ok(Response::new(GetMeResponse {
+            user_id: "u1".into(),
+            user_email: "jane@siftstack.com".into(),
+            ..Default::default()
+        }))
+    });
+
+    let (service, _h) = service_with_me_mock(mock).await;
+
+    let user = service.get_me().await.expect("get_me failed");
+
+    assert_eq!(user.user_id, "u1");
+    assert!(user.organizations.is_empty());
+}
+
+#[tokio::test]
+async fn get_me_propagates_grpc_error() {
+    let mut mock = MockMeServiceImpl::new();
+    mock.expect_get_me()
+        .returning(|_| Err(Status::unauthenticated("bad api key")));
+
+    let (service, _h) = service_with_me_mock(mock).await;
+
+    let err = service.get_me().await.expect_err("expected error");
+
+    assert!(
+        err.to_string()
+            .contains("failed to resolve the calling user")
+    );
+}

--- a/rust/crates/sift_mcp/src/tool/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/mod.rs
@@ -10,3 +10,4 @@ pub mod reports;
 pub mod rules;
 pub mod runs;
 pub mod test_reports;
+pub mod users;

--- a/rust/crates/sift_mcp/src/tool/users/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/users/mod.rs
@@ -35,21 +35,28 @@ impl SiftMcpServer {
 
             Output:
               - `{ \"users\": [User, ...] }`. Each item is the full Sift `User` shape: `user_id`, `user_name`, and
-                the `organizations` the user belongs to. `user_name` is the identifier the user signs in with and is
-                typically their email address; Sift does not currently store a separate display name, first name, or
-                last name.
+                the `organizations` the user belongs to. `user_name` is the sign-in identifier, typically an email
+                address; Sift does not currently store a separate display, first, or last name.
 
             Parameters:
-              - `filter`: CEL expression. Pass an empty string to list everyone. Filterable fields: `user_id` and
-                `name`. `name` filters on the user's `user_name`, e.g. `name == \"jane@siftstack.com\"`.
+              - `filter`: CEL expression over `user_id` and `name` (`name` is the user's `user_name`). Pass an empty
+                string to list everyone. Prefer pattern matching over `==`: a caller knows a fragment of someone's
+                name far more often than their exact sign-in address.
+                  - `name.matches(\"(?i)liam\")` — RE2 regex, case-insensitive via the `(?i)` prefix. Best default.
+                  - `name.matches(\"(?i)^(liam|evan)@\")` — resolve several people in one call.
+                  - `name.contains(\"liam\")`, `name.startsWith(\"liam\")`, `name.endsWith(\"@siftstack.com\")` —
+                    substring, prefix, and suffix; all case-SENSITIVE, so `Liam@...` slips past them. There is no
+                    `includes(...)` function; `contains` is the substring one.
+                  - `name == \"liam@siftstack.com\"` — only when the full address is already known.
+                  - `user_id == \"<uuid>\"`, or `user_id in [\"<uuid>\", \"<uuid>\"]` — map ids back to names.
               - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `name`,
                 `created_date`, `modified_date`; with `include_inactive` set, only `created_date` and
                 `modified_date`. Default sort is `name` ascending (A-Z). Example: `\"created_date desc,name\"`.
               - `limit`: max items to return. Start at 200 and only raise it if the result is capped and you still
                 need more. Values are clamped to `1..=1000`; omitting it defaults to 200.
-              - `include_inactive`: optional; defaults to false. False lists only users active in the organization.
-                Set true to also return deactivated accounts — needed when attributing older records to someone who
-                has since left.
+              - `include_inactive`: optional; defaults to false, listing only users active in the organization. Set
+                true to also return deactivated accounts — needed when attributing older records to someone who has
+                since left.
               - `me`: optional; defaults to false. Set true to return the user whose credentials the server is
                 running under, resolved from the API key itself. Needs no configuration. Mutually exclusive with a
                 non-empty `filter`; `order_by`, `limit`, and `include_inactive` are ignored when it is set.
@@ -60,10 +67,11 @@ impl SiftMcpServer {
               - `INTERNAL_ERROR` for upstream gRPC failures.
 
             Guidance:
+              - An empty result usually means the pattern was too narrow or the casing was wrong, not that the
+                person is absent. Retry with `name.matches(\"(?i)<shorter fragment>\")` before listing everyone.
               - Resolve a person here first, then filter on `created_by_user_id == \"<user_id>\"` in whichever
                 `list_*` tool the question is about. Runs, assets, channels, rules, reports, annotations, and test
-                reports all expose that field, so the pattern is identical across them. All but annotations also
-                expose `modified_by_user_id`.
+                reports all expose that field; all but annotations also expose `modified_by_user_id`.
               - When the question is about the caller rather than a named person (\"my runs\", \"reports I filed\"),
                 use `me: true` and take the `user_id` from the result. Never guess which listed user is the caller.
         ",

--- a/rust/crates/sift_mcp/src/tool/users/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/users/mod.rs
@@ -1,0 +1,108 @@
+use rmcp::{
+    ErrorData,
+    handler::server::wrapper::Parameters,
+    model::CallToolResult,
+    schemars::{self, JsonSchema},
+    tool, tool_router,
+};
+use serde::Deserialize;
+
+use crate::{
+    error::{self, from_anyhow},
+    server::SiftMcpServer,
+};
+
+#[cfg(test)]
+mod test;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListUsersParams {
+    pub(crate) filter: String,
+    pub(crate) order_by: Option<String>,
+    pub(crate) limit: Option<u32>,
+    pub(crate) include_inactive: Option<bool>,
+    pub(crate) me: Option<bool>,
+}
+
+#[tool_router(router = users_router, vis = "pub(crate)")]
+impl SiftMcpServer {
+    #[tool(
+        name = "list_users",
+        description = "
+            List users in the caller's organization, optionally filtered by a CEL expression and ordered by one or
+            more fields. Use it to resolve a person — by name, email, or id — to the `user_id` that the other
+            `list_*` tools filter on.
+
+            Output:
+              - `{ \"users\": [User, ...] }`. Each item is the full Sift `User` shape: `user_id`, `user_name`, and
+                the `organizations` the user belongs to. `user_name` is the identifier the user signs in with and is
+                typically their email address; Sift does not currently store a separate display name, first name, or
+                last name.
+
+            Parameters:
+              - `filter`: CEL expression. Pass an empty string to list everyone. Filterable fields: `user_id` and
+                `name`. `name` filters on the user's `user_name`, e.g. `name == \"jane@siftstack.com\"`.
+              - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `name`,
+                `created_date`, `modified_date`; with `include_inactive` set, only `created_date` and
+                `modified_date`. Default sort is `name` ascending (A-Z). Example: `\"created_date desc,name\"`.
+              - `limit`: max items to return. Start at 200 and only raise it if the result is capped and you still
+                need more. Values are clamped to `1..=1000`; omitting it defaults to 200.
+              - `include_inactive`: optional; defaults to false. False lists only users active in the organization.
+                Set true to also return deactivated accounts — needed when attributing older records to someone who
+                has since left.
+              - `me`: optional; defaults to false. Set true to return the user whose credentials the server is
+                running under, resolved from the API key itself. Needs no configuration. Mutually exclusive with a
+                non-empty `filter`; `order_by`, `limit`, and `include_inactive` are ignored when it is set.
+
+            Errors:
+              - `INVALID_PARAMS` if `filter` is not a valid CEL expression, `order_by` references an unknown field,
+                or `me` is set alongside a non-empty `filter`.
+              - `INTERNAL_ERROR` for upstream gRPC failures.
+
+            Guidance:
+              - Resolve a person here first, then filter on `created_by_user_id == \"<user_id>\"` in whichever
+                `list_*` tool the question is about. Runs, assets, channels, rules, reports, annotations, and test
+                reports all expose that field, so the pattern is identical across them. All but annotations also
+                expose `modified_by_user_id`.
+              - When the question is about the caller rather than a named person (\"my runs\", \"reports I filed\"),
+                use `me: true` and take the `user_id` from the result. Never guess which listed user is the caller.
+        ",
+        annotations(title = "users/list_users", read_only_hint = true)
+    )]
+    pub async fn list_users(&self, params: Parameters<ListUsersParams>) -> error::McpResult {
+        let Parameters(ListUsersParams {
+            filter,
+            order_by,
+            limit,
+            include_inactive,
+            me,
+        }) = params;
+
+        let include_inactive = include_inactive.unwrap_or(false);
+
+        if me.unwrap_or(false) {
+            if !filter.is_empty() {
+                return Err(ErrorData::invalid_params(
+                    "`me` and `filter` are mutually exclusive; set one or the other",
+                    None,
+                ));
+            }
+
+            let user = self.user_service.get_me().await.map_err(from_anyhow)?;
+
+            return Ok(CallToolResult::structured(
+                serde_json::json!({ "users": [user] }),
+            ));
+        }
+
+        let users = self
+            .user_service
+            .list_users(filter, order_by, limit, include_inactive)
+            .await
+            .map_err(from_anyhow)?;
+
+        Ok(CallToolResult::structured(
+            serde_json::json!({ "users": users }),
+        ))
+    }
+}

--- a/rust/crates/sift_mcp/src/tool/users/test.rs
+++ b/rust/crates/sift_mcp/src/tool/users/test.rs
@@ -1,0 +1,244 @@
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::ErrorCode;
+use sift_rs::{
+    common::r#type::v1::{Organization, User},
+    me::v2::{GetMeResponse, me_service_server::MeServiceServer},
+    users::v2::{
+        ListActiveUsersResponse, ListUsersResponse, user_service_server::UserServiceServer,
+    },
+};
+use sift_test_util::{
+    grpc::memory_sift_channel,
+    mock::{me::v2::MockMeServiceImpl, users::v2::MockUserServiceImpl},
+};
+use tokio::task::JoinHandle;
+use tonic::{Response, Status, transport::Server};
+
+use crate::{
+    server::SiftMcpServer,
+    tool::{common::test_support::structured_field, users::ListUsersParams},
+};
+
+fn user(id: &str, name: &str) -> User {
+    User {
+        user_id: id.into(),
+        user_name: name.into(),
+        ..Default::default()
+    }
+}
+
+fn params(filter: &str) -> Parameters<ListUsersParams> {
+    Parameters(ListUsersParams {
+        filter: filter.into(),
+        order_by: None,
+        limit: None,
+        include_inactive: None,
+        me: None,
+    })
+}
+
+fn me_params() -> Parameters<ListUsersParams> {
+    Parameters(ListUsersParams {
+        filter: String::new(),
+        order_by: None,
+        limit: None,
+        include_inactive: None,
+        me: Some(true),
+    })
+}
+
+async fn server_with_mocks(
+    user_mock: MockUserServiceImpl,
+    me_mock: MockMeServiceImpl,
+) -> (SiftMcpServer, JoinHandle<()>) {
+    let (client, server) = tokio::io::duplex(1024);
+    let channel = memory_sift_channel(client).await;
+
+    let handle = tokio::spawn(async move {
+        Server::builder()
+            .add_service(UserServiceServer::new(user_mock))
+            .add_service(MeServiceServer::new(me_mock))
+            .serve_with_incoming(tokio_stream::once(Ok::<_, std::io::Error>(server)))
+            .await
+            .unwrap();
+    });
+
+    (
+        SiftMcpServer::new(channel, String::from("https://api.test.local"), false),
+        handle,
+    )
+}
+
+#[tokio::test]
+async fn list_users_returns_single_page() {
+    let mut user_mock = MockUserServiceImpl::new();
+    user_mock
+        .expect_list_active_users()
+        .withf(|req| req.get_ref().filter == "name == \"jane@siftstack.com\"")
+        .returning(|_| {
+            Ok(Response::new(ListActiveUsersResponse {
+                users: vec![user("u1", "jane@siftstack.com")],
+                next_page_token: String::new(),
+            }))
+        });
+
+    let (server, _h) = server_with_mocks(user_mock, MockMeServiceImpl::new()).await;
+
+    let resp = server
+        .list_users(params("name == \"jane@siftstack.com\""))
+        .await
+        .expect("list_users failed");
+
+    let users = structured_field(resp, "users");
+    assert_eq!(users.as_array().unwrap().len(), 1);
+    assert_eq!(users[0]["userId"], "u1");
+    assert_eq!(users[0]["userName"], "jane@siftstack.com");
+}
+
+#[tokio::test]
+async fn list_users_include_inactive_uses_all_users_rpc() {
+    let mut user_mock = MockUserServiceImpl::new();
+    user_mock.expect_list_users().times(1).returning(|_| {
+        Ok(Response::new(ListUsersResponse {
+            users: vec![user("u2", "former@siftstack.com")],
+            next_page_token: String::new(),
+        }))
+    });
+
+    let (server, _h) = server_with_mocks(user_mock, MockMeServiceImpl::new()).await;
+
+    let resp = server
+        .list_users(Parameters(ListUsersParams {
+            filter: String::new(),
+            order_by: None,
+            limit: None,
+            include_inactive: Some(true),
+            me: None,
+        }))
+        .await
+        .expect("list_users failed");
+
+    let users = structured_field(resp, "users");
+    assert_eq!(users[0]["userId"], "u2");
+}
+
+#[tokio::test]
+async fn list_users_propagates_grpc_error() {
+    let mut user_mock = MockUserServiceImpl::new();
+    user_mock
+        .expect_list_active_users()
+        .returning(|_| Err(Status::invalid_argument("bad filter")));
+
+    let (server, _h) = server_with_mocks(user_mock, MockMeServiceImpl::new()).await;
+
+    let err = server
+        .list_users(params("nope"))
+        .await
+        .expect_err("expected error");
+
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+    assert!(err.message.contains("bad filter"));
+}
+
+#[tokio::test]
+async fn list_users_me_resolves_caller_via_get_me() {
+    let mut me_mock = MockMeServiceImpl::new();
+    me_mock.expect_get_me().times(1).returning(|_| {
+        Ok(Response::new(GetMeResponse {
+            user_id: "u7".into(),
+            user_email: "liam@siftstack.com".into(),
+            organizations: vec![Organization {
+                organization_id: "org1".into(),
+                organization_name: "Sift".into(),
+                ..Default::default()
+            }],
+            is_admin: false,
+            ..Default::default()
+        }))
+    });
+
+    let (server, _h) = server_with_mocks(MockUserServiceImpl::new(), me_mock).await;
+
+    let resp = server
+        .list_users(me_params())
+        .await
+        .expect("list_users failed");
+
+    let users = structured_field(resp, "users");
+    assert_eq!(users.as_array().unwrap().len(), 1);
+    assert_eq!(users[0]["userId"], "u7");
+    assert_eq!(users[0]["userName"], "liam@siftstack.com");
+    assert_eq!(users[0]["organizations"][0]["organizationId"], "org1");
+}
+
+#[tokio::test]
+async fn list_users_me_ignores_paging_params() {
+    let mut me_mock = MockMeServiceImpl::new();
+    me_mock.expect_get_me().times(1).returning(|_| {
+        Ok(Response::new(GetMeResponse {
+            user_id: "u7".into(),
+            user_email: "liam@siftstack.com".into(),
+            ..Default::default()
+        }))
+    });
+
+    let (server, _h) = server_with_mocks(MockUserServiceImpl::new(), me_mock).await;
+
+    let resp = server
+        .list_users(Parameters(ListUsersParams {
+            filter: String::new(),
+            order_by: Some("created_date desc".into()),
+            limit: Some(50),
+            include_inactive: Some(true),
+            me: Some(true),
+        }))
+        .await
+        .expect("list_users failed");
+
+    let users = structured_field(resp, "users");
+    assert_eq!(users.as_array().unwrap().len(), 1);
+    assert_eq!(users[0]["userId"], "u7");
+}
+
+#[tokio::test]
+async fn list_users_me_with_filter_is_invalid_params() {
+    let (server, _h) =
+        server_with_mocks(MockUserServiceImpl::new(), MockMeServiceImpl::new()).await;
+
+    let err = server
+        .list_users(Parameters(ListUsersParams {
+            filter: "name == \"john@siftstack.com\"".into(),
+            order_by: None,
+            limit: None,
+            include_inactive: None,
+            me: Some(true),
+        }))
+        .await
+        .expect_err("expected error");
+
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+    assert!(err.message.contains("mutually exclusive"));
+}
+
+#[tokio::test]
+async fn list_users_me_propagates_grpc_error() {
+    let mut me_mock = MockMeServiceImpl::new();
+    me_mock
+        .expect_get_me()
+        .returning(|_| Err(Status::unauthenticated("bad api key")));
+
+    let (server, _h) = server_with_mocks(MockUserServiceImpl::new(), me_mock).await;
+
+    let err = server
+        .list_users(me_params())
+        .await
+        .expect_err("expected error");
+
+    assert_eq!(
+        err.data
+            .as_ref()
+            .and_then(|v| v.get("reason"))
+            .and_then(|v| v.as_str()),
+        Some("Unauthenticated")
+    );
+}

--- a/rust/crates/sift_mcp/src/tool/users/test.rs
+++ b/rust/crates/sift_mcp/src/tool/users/test.rs
@@ -95,6 +95,97 @@ async fn list_users_returns_single_page() {
     assert_eq!(users[0]["userName"], "jane@siftstack.com");
 }
 
+/// The description steers callers toward `contains` and `matches` over `==`,
+/// which is the shape a partial name arrives in. Each expression must go out
+/// untouched — rewriting one would silently change what the caller asked for.
+#[tokio::test]
+async fn list_users_forwards_substring_filter_verbatim() {
+    let mut user_mock = MockUserServiceImpl::new();
+    user_mock
+        .expect_list_active_users()
+        .times(1)
+        .withf(|req| req.get_ref().filter == "name.contains(\"jane\")")
+        .returning(|_| {
+            Ok(Response::new(ListActiveUsersResponse {
+                users: vec![user("u1", "jane@siftstack.com")],
+                next_page_token: String::new(),
+            }))
+        });
+
+    let (server, _h) = server_with_mocks(user_mock, MockMeServiceImpl::new()).await;
+
+    let resp = server
+        .list_users(params("name.contains(\"jane\")"))
+        .await
+        .expect("list_users failed");
+
+    let users = structured_field(resp, "users");
+    assert_eq!(users.as_array().unwrap().len(), 1);
+    assert_eq!(users[0]["userName"], "jane@siftstack.com");
+}
+
+/// A case-insensitive regex spanning two people, backslashes and all. This is
+/// the recommended default filter shape, so it stays covered end to end.
+#[tokio::test]
+async fn list_users_forwards_regex_filter_verbatim() {
+    let filter = "name.matches(\"(?i)^(jane|john)@siftstack\\\\.com$\")";
+
+    let mut user_mock = MockUserServiceImpl::new();
+    user_mock
+        .expect_list_active_users()
+        .times(1)
+        .withf(move |req| req.get_ref().filter == filter)
+        .returning(|_| {
+            Ok(Response::new(ListActiveUsersResponse {
+                users: vec![
+                    user("u1", "jane@siftstack.com"),
+                    user("u2", "john@siftstack.com"),
+                ],
+                next_page_token: String::new(),
+            }))
+        });
+
+    let (server, _h) = server_with_mocks(user_mock, MockMeServiceImpl::new()).await;
+
+    let resp = server
+        .list_users(params(filter))
+        .await
+        .expect("list_users failed");
+
+    let users = structured_field(resp, "users");
+    assert_eq!(users.as_array().unwrap().len(), 2);
+    assert_eq!(users[0]["userName"], "jane@siftstack.com");
+    assert_eq!(users[1]["userName"], "john@siftstack.com");
+}
+
+/// `contains` is case-sensitive, which is why the description points at
+/// `matches("(?i)...")` when the casing is unknown. A mismatched-casing
+/// substring filter is a legitimate empty result, not an error.
+#[tokio::test]
+async fn list_users_returns_empty_for_case_mismatched_substring() {
+    let mut user_mock = MockUserServiceImpl::new();
+    user_mock
+        .expect_list_active_users()
+        .times(1)
+        .withf(|req| req.get_ref().filter == "name.contains(\"JANE\")")
+        .returning(|_| {
+            Ok(Response::new(ListActiveUsersResponse {
+                users: vec![],
+                next_page_token: String::new(),
+            }))
+        });
+
+    let (server, _h) = server_with_mocks(user_mock, MockMeServiceImpl::new()).await;
+
+    let resp = server
+        .list_users(params("name.contains(\"JANE\")"))
+        .await
+        .expect("list_users failed");
+
+    let users = structured_field(resp, "users");
+    assert!(users.as_array().unwrap().is_empty());
+}
+
 #[tokio::test]
 async fn list_users_include_inactive_uses_all_users_rpc() {
     let mut user_mock = MockUserServiceImpl::new();

--- a/rust/crates/sift_test_util/src/mock/me/mod.rs
+++ b/rust/crates/sift_test_util/src/mock/me/mod.rs
@@ -1,0 +1,1 @@
+pub mod v2;

--- a/rust/crates/sift_test_util/src/mock/me/v2.rs
+++ b/rust/crates/sift_test_util/src/mock/me/v2.rs
@@ -1,0 +1,19 @@
+use async_trait::async_trait;
+use mockall::mock;
+use sift_rs::me::v2::{GetMeRequest, GetMeResponse, me_service_server::MeService};
+use tonic::{Request, Response, Status};
+
+mock! {
+    pub MeServiceImpl {}
+
+    #[async_trait]
+    impl MeService for MeServiceImpl {
+        async fn get_me(
+            &self,
+            request: Request<GetMeRequest>,
+        ) -> std::result::Result<
+            Response<GetMeResponse>,
+            Status,
+        >;
+    }
+}

--- a/rust/crates/sift_test_util/src/mock/mod.rs
+++ b/rust/crates/sift_test_util/src/mock/mod.rs
@@ -3,10 +3,12 @@ pub mod assets;
 pub mod channels;
 pub mod data;
 pub mod docs;
+pub mod me;
 pub mod reports;
 pub mod rules;
 pub mod runs;
 pub mod test_reports;
+pub mod users;
 
 /// A test demonstrating a little bit of everything of how to leverage the mock API.
 #[cfg(test)]

--- a/rust/crates/sift_test_util/src/mock/users/mod.rs
+++ b/rust/crates/sift_test_util/src/mock/users/mod.rs
@@ -1,0 +1,1 @@
+pub mod v2;

--- a/rust/crates/sift_test_util/src/mock/users/v2.rs
+++ b/rust/crates/sift_test_util/src/mock/users/v2.rs
@@ -1,0 +1,44 @@
+use async_trait::async_trait;
+use mockall::mock;
+use sift_rs::users::v2::{
+    GetUserRequest, GetUserResponse, ListActiveUsersRequest, ListActiveUsersResponse,
+    ListUsersRequest, ListUsersResponse, UpdateUserOrganizationActiveRequest,
+    UpdateUserOrganizationActiveResponse, user_service_server::UserService,
+};
+use tonic::{Request, Response, Status};
+
+mock! {
+    pub UserServiceImpl {}
+
+    #[async_trait]
+    impl UserService for UserServiceImpl {
+        async fn update_user_organization_active(
+            &self,
+            request: Request<UpdateUserOrganizationActiveRequest>,
+        ) -> std::result::Result<
+            Response<UpdateUserOrganizationActiveResponse>,
+            Status,
+        >;
+        async fn get_user(
+            &self,
+            request: Request<GetUserRequest>,
+        ) -> std::result::Result<
+            Response<GetUserResponse>,
+            Status,
+        >;
+        async fn list_active_users(
+            &self,
+            request: Request<ListActiveUsersRequest>,
+        ) -> std::result::Result<
+            Response<ListActiveUsersResponse>,
+            Status,
+        >;
+        async fn list_users(
+            &self,
+            request: Request<ListUsersRequest>,
+        ) -> std::result::Result<
+            Response<ListUsersResponse>,
+            Status,
+        >;
+    }
+}


### PR DESCRIPTION
Adds a new `list_users` tool which can be used to list out users within a Sift organization as well as get the current user so that other `list_*` tools can do things like "Get all the runs I created" or "List all of the assets created by <teammate>"


## Demo
- Built sift MCP locally and installed it as a local mcp server named `sift-local` which I've installed in Claude Code 👇  

