### PR TITLE
rust(feat): require app URI in CLI profiles

### DIFF
--- a/rust/crates/sift_cli/AGENTS.md
+++ b/rust/crates/sift_cli/AGENTS.md
@@ -17,15 +17,15 @@ The skill is embedded at compile time, so rebuild `sift-cli` after changing it.
 
 - `sift-cli agent install`
 - `sift-cli agent update`
-- `sift-cli agent doctor [--fix]`
+- `sift-cli agent doctor`
 - `sift-cli agent uninstall`
 
 Install and update operate on every detected supported client. They preflight
 all targets before writing and refuse to overwrite an unmanaged same-name skill
 or MCP entry. Doctor checks installed files, client configs, and Sift profiles.
-Plain doctor does not write files. `doctor --fix` can set a missing `app_uri`
-for a known production or government REST URL. Uninstall removes only content
-identifiable as Sift-managed. Do not add a state file or version tracking.
+Doctor does not write files. It reports a missing required `app_uri` and prints
+the config command. Uninstall removes only content identifiable as Sift-managed.
+Do not add a state file or version tracking.
 
 Install defaults every MCP registration to read-only. Install accepts
 `--allow-destructive` as an explicit opt-in. Install uses the default Sift
@@ -66,6 +66,6 @@ cargo test -p sift_cli --features mcp cmd::agent
 ```
 
 `agent install` changes real user-level client configuration and points it at
-the exact `sift-cli` executable that runs the command. Use plain `doctor` for a
-read-only check. Use `doctor --fix` only when a profile change is intended.
-Run install, update, or uninstall only when those client changes are intended.
+the exact `sift-cli` executable that runs the command. Use `doctor` for a
+read-only check. Run install, update, or uninstall only when those client
+changes are intended.

--- a/rust/crates/sift_cli/AGENTS.md
+++ b/rust/crates/sift_cli/AGENTS.md
@@ -23,9 +23,12 @@ The skill is embedded at compile time, so rebuild `sift-cli` after changing it.
 Install and update operate on every detected supported client. They preflight
 all targets before writing and refuse to overwrite an unmanaged same-name skill
 or MCP entry. Doctor checks installed files, client configs, and Sift profiles.
-Doctor does not write files. It reports a missing required `app_uri` and prints
-the config command. Uninstall removes only content identifiable as Sift-managed.
+Doctor does not write files. It treats a missing required `app_uri` as an error.
+It prints the config command. Uninstall removes only identifiable Sift content.
 Do not add a state file or version tracking.
+
+The `mcp` command rejects a profile without a usable `app_uri`. Other commands
+can load an incomplete old profile so the user can recover it.
 
 Install defaults every MCP registration to read-only. Install accepts
 `--allow-destructive` as an explicit opt-in. Install uses the default Sift

--- a/rust/crates/sift_cli/AGENTS.md
+++ b/rust/crates/sift_cli/AGENTS.md
@@ -17,14 +17,15 @@ The skill is embedded at compile time, so rebuild `sift-cli` after changing it.
 
 - `sift-cli agent install`
 - `sift-cli agent update`
-- `sift-cli agent doctor`
+- `sift-cli agent doctor [--fix]`
 - `sift-cli agent uninstall`
 
 Install and update operate on every detected supported client. They preflight
 all targets before writing and refuse to overwrite an unmanaged same-name skill
-or MCP entry. Doctor derives status from the installed files and client configs.
-Uninstall removes only content identifiable as Sift-managed. Do not add a state
-file or per-client version tracking.
+or MCP entry. Doctor checks installed files, client configs, and Sift profiles.
+Plain doctor does not write files. `doctor --fix` can set a missing `app_uri`
+for a known production or government REST URL. Uninstall removes only content
+identifiable as Sift-managed. Do not add a state file or version tracking.
 
 Install defaults every MCP registration to read-only. Install accepts
 `--allow-destructive` as an explicit opt-in. Install uses the default Sift
@@ -65,6 +66,6 @@ cargo test -p sift_cli --features mcp cmd::agent
 ```
 
 `agent install` changes real user-level client configuration and points it at
-the exact `sift-cli` executable running the command. Use `doctor` for read-only
-validation, and only run install/update/uninstall when those user-level changes
-are intended.
+the exact `sift-cli` executable that runs the command. Use plain `doctor` for a
+read-only check. Use `doctor --fix` only when a profile change is intended.
+Run install, update, or uninstall only when those client changes are intended.

--- a/rust/crates/sift_cli/CHANGELOG.md
+++ b/rust/crates/sift_cli/CHANGELOG.md
@@ -24,9 +24,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Removed the MCP server, built-in prompt, and agent skill pages from the
   bundled `sift-cli` documentation. The agent-facing tool surface is documented
   in the installed skill instead.
-- Added profile-aware `app_uri` checks to `sift-cli agent doctor`. The new
-  `--fix` flag sets missing production and government app URLs. Profile setup
-  now asks for the web app origin. MCP links now use the selected profile value.
+- Added `app_uri` as a required profile field. Profile setup now asks for the
+  web app origin. `sift-cli agent doctor` reports a missing value and prints the
+  config command. MCP links now use the selected profile value.
 
 ## [v0.3.0] - July 13, 2026
 

--- a/rust/crates/sift_cli/CHANGELOG.md
+++ b/rust/crates/sift_cli/CHANGELOG.md
@@ -24,6 +24,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Removed the MCP server, built-in prompt, and agent skill pages from the
   bundled `sift-cli` documentation. The agent-facing tool surface is documented
   in the installed skill instead.
+- Added profile-aware `app_uri` checks to `sift-cli agent doctor`. The new
+  `--fix` flag sets missing production and government app URLs. Profile setup
+  now asks for the web app origin. MCP links now use the selected profile value.
 
 ## [v0.3.0] - July 13, 2026
 

--- a/rust/crates/sift_cli/CHANGELOG.md
+++ b/rust/crates/sift_cli/CHANGELOG.md
@@ -25,8 +25,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   bundled `sift-cli` documentation. The agent-facing tool surface is documented
   in the installed skill instead.
 - Added `app_uri` as a required profile field. Profile setup now asks for the
-  web app origin. `sift-cli agent doctor` reports a missing value and prints the
-  config command. MCP links now use the selected profile value.
+  web app origin. `sift-cli agent doctor` treats a missing value as an error and
+  prints the config command. `sift-cli mcp` does not expose tools for an
+  incomplete profile. MCP links now use only the selected profile value. The
+  MCP tool-list error includes the config command.
 
 ## [v0.3.0] - July 13, 2026
 

--- a/rust/crates/sift_cli/assets/docs/src/getting-started/configuration.md
+++ b/rust/crates/sift_cli/assets/docs/src/getting-started/configuration.md
@@ -9,15 +9,19 @@ Each CLI profile needs four values:
 | `app_uri`  | Required web app origin from your browser    | `https://app.siftstack.com`      |
 | `apikey`   | Your Sift API key                            | `sift_...`                       |
 
-For Sift Cloud, both URIs are `https://api.siftstack.com`. For self-hosted or
-non-cloud environments, use the endpoints provided by your administrator (and
-see [Disabling TLS](#disabling-tls) below if they are not served over TLS).
+For Sift Cloud, use the gRPC and REST values in the table. For other
+environments, use the endpoints from your administrator. See
+[Disabling TLS](#disabling-tls) if the endpoints do not use TLS.
 
 The config command can infer `app_uri` for PubCloud and GovCloud Sift. For any
 other domain, open the Sift web app and copy its URL origin. Keep the scheme and
 host. Do not include a page path, query, or fragment.
 
-Commands reject a profile when `app_uri` is missing, empty, or not a string.
+A profile without a usable `app_uri` is incomplete. API commands can continue
+so users can recover an old profile. Imports omit their web link. MCP URL tools
+need `app_uri`. `sift-cli mcp` does not expose tools for the incomplete profile.
+Its tool-list error includes the repair command, so the MCP client can show the
+reason. `sift-cli agent doctor` treats a missing or unusable value as an error.
 
 You can generate an API key from the Sift web app under your account settings.
 
@@ -47,9 +51,9 @@ sift-cli config create
 sift-cli config update --interactive
 ```
 
-The interactive prompt asks for the profile, API URLs, app origin, and API key.
-It shows the result before it writes the file. A blank profile selects the
-`default` profile.
+The interactive prompt asks for the profile, API URLs, API key, and app origin.
+The prompt shows the result before it writes the file. A blank profile selects
+the `default` profile.
 
 ### Non-interactive setup
 

--- a/rust/crates/sift_cli/assets/docs/src/getting-started/configuration.md
+++ b/rust/crates/sift_cli/assets/docs/src/getting-started/configuration.md
@@ -1,16 +1,21 @@
 # Configuration
 
-Before the CLI can talk to Sift it needs three things:
+The CLI needs three connection values. It also uses a web app origin for links.
 
-| Field      | Description                                  | Example                        |
-| ---------- | -------------------------------------------- | ------------------------------ |
-| `grpc_uri` | Base gRPC endpoint for Sift                  | `https://api.siftstack.com`    |
-| `rest_uri` | Base REST endpoint for Sift                  | `https://api.siftstack.com`    |
-| `apikey`   | Your Sift API key                            | `sift_...`                     |
+| Field      | Description                                  | Example                         |
+| ---------- | -------------------------------------------- | ------------------------------- |
+| `grpc_uri` | Base gRPC endpoint for Sift                  | `https://api.siftstack.com`     |
+| `rest_uri` | Base REST endpoint for Sift                  | `https://api.siftstack.com`     |
+| `app_uri`  | Web app origin from your browser             | `https://app.siftstack.com`     |
+| `apikey`   | Your Sift API key                            | `sift_...`                      |
 
 For Sift Cloud, both URIs are `https://api.siftstack.com`. For self-hosted or
 non-cloud environments, use the endpoints provided by your administrator (and
 see [Disabling TLS](#disabling-tls) below if they are not served over TLS).
+
+The CLI can infer `app_uri` for production and government Sift. For any other
+domain, open the Sift web app and copy its URL origin. Keep the scheme and host.
+Do not include a page path, query, or fragment.
 
 You can generate an API key from the Sift web app under your account settings.
 
@@ -40,9 +45,9 @@ sift-cli config create
 sift-cli config update --interactive
 ```
 
-The interactive prompt walks you through the profile name, both URIs, and your
-API key, then shows the result for confirmation before writing it. Leaving the
-profile blank configures the `default` profile.
+The interactive prompt asks for the profile, API URLs, app origin, and API key.
+It shows the result before it writes the file. A blank profile selects the
+`default` profile.
 
 ### Non-interactive setup
 
@@ -53,11 +58,12 @@ values as flags:
 sift-cli config update \
   --grpc-uri https://api.siftstack.com \
   --rest-uri https://api.siftstack.com \
+  --app-uri https://app.siftstack.com \
   --api-key "$SIFT_API_KEY"
 ```
 
-Short forms: `-g` (grpc), `-r` (rest), `-k` (api key). Any field you omit is
-left untouched, so you can update one value at a time:
+Short forms are `-g` for gRPC, `-r` for REST, and `-k` for the API key.
+Omitted fields stay unchanged. You can update one value at a time:
 
 ```sh
 sift-cli config update --api-key "$SIFT_API_KEY"
@@ -75,6 +81,7 @@ A configured `default` profile looks like this:
 ```toml
 grpc_uri = "https://api.siftstack.com"
 rest_uri = "https://api.siftstack.com"
+app_uri = "https://app.siftstack.com"
 apikey = "sift_..."
 ```
 

--- a/rust/crates/sift_cli/assets/docs/src/getting-started/configuration.md
+++ b/rust/crates/sift_cli/assets/docs/src/getting-started/configuration.md
@@ -2,12 +2,12 @@
 
 Each CLI profile needs four values:
 
-| Field      | Description                                  | Example                         |
-| ---------- | -------------------------------------------- | ------------------------------- |
-| `grpc_uri` | Base gRPC endpoint for Sift                  | `https://api.siftstack.com`     |
-| `rest_uri` | Base REST endpoint for Sift                  | `https://api.siftstack.com`     |
-| `app_uri`  | Required web app origin from your browser    | `https://app.siftstack.com`     |
-| `apikey`   | Your Sift API key                            | `sift_...`                      |
+| Field      | Description                                  | Example                          |
+| ---------- | -------------------------------------------- | -------------------------------- |
+| `grpc_uri` | Base gRPC endpoint for Sift                  | `https://grpc-api.siftstack.com` |
+| `rest_uri` | Base REST endpoint for Sift                  | `https://api.siftstack.com`      |
+| `app_uri`  | Required web app origin from your browser    | `https://app.siftstack.com`      |
+| `apikey`   | Your Sift API key                            | `sift_...`                       |
 
 For Sift Cloud, both URIs are `https://api.siftstack.com`. For self-hosted or
 non-cloud environments, use the endpoints provided by your administrator (and
@@ -27,9 +27,9 @@ Settings live in a TOML file named `sift.toml` inside your OS config directory:
 
 | Platform | Location                                            |
 | -------- | --------------------------------------------------- |
-| macOS    | `~/Library/Application Support/sift.toml`            |
-| Linux    | `~/.config/sift.toml`                                |
-| Windows  | `%APPDATA%\sift.toml`                                |
+| macOS    | `~/Library/Application Support/sift.toml`           |
+| Linux    | `~/.config/sift.toml`                               |
+| Windows  | `%APPDATA%\sift.toml`                               |
 
 Find the exact path on your machine:
 
@@ -58,7 +58,7 @@ values as flags:
 
 ```sh
 sift-cli config update \
-  --grpc-uri https://api.siftstack.com \
+  --grpc-uri https://grpc-api.siftstack.com \
   --rest-uri https://api.siftstack.com \
   --app-uri https://app.siftstack.com \
   --api-key "$SIFT_API_KEY"
@@ -81,7 +81,7 @@ sift-cli config where    # print the path to the config file
 A configured `default` profile looks like this:
 
 ```toml
-grpc_uri = "https://api.siftstack.com"
+grpc_uri = "https://grpc-api.siftstack.com"
 rest_uri = "https://api.siftstack.com"
 app_uri = "https://app.siftstack.com"
 apikey = "sift_..."

--- a/rust/crates/sift_cli/assets/docs/src/getting-started/configuration.md
+++ b/rust/crates/sift_cli/assets/docs/src/getting-started/configuration.md
@@ -1,21 +1,23 @@
 # Configuration
 
-The CLI needs three connection values. It also uses a web app origin for links.
+Each CLI profile needs four values:
 
 | Field      | Description                                  | Example                         |
 | ---------- | -------------------------------------------- | ------------------------------- |
 | `grpc_uri` | Base gRPC endpoint for Sift                  | `https://api.siftstack.com`     |
 | `rest_uri` | Base REST endpoint for Sift                  | `https://api.siftstack.com`     |
-| `app_uri`  | Web app origin from your browser             | `https://app.siftstack.com`     |
+| `app_uri`  | Required web app origin from your browser    | `https://app.siftstack.com`     |
 | `apikey`   | Your Sift API key                            | `sift_...`                      |
 
 For Sift Cloud, both URIs are `https://api.siftstack.com`. For self-hosted or
 non-cloud environments, use the endpoints provided by your administrator (and
 see [Disabling TLS](#disabling-tls) below if they are not served over TLS).
 
-The CLI can infer `app_uri` for PubCloud and GovCloud Sift. For any other
-domain, open the Sift web app and copy its URL origin. Keep the scheme and host.
-Do not include a page path, query, or fragment.
+The config command can infer `app_uri` for PubCloud and GovCloud Sift. For any
+other domain, open the Sift web app and copy its URL origin. Keep the scheme and
+host. Do not include a page path, query, or fragment.
+
+Commands reject a profile when `app_uri` is missing, empty, or not a string.
 
 You can generate an API key from the Sift web app under your account settings.
 

--- a/rust/crates/sift_cli/assets/docs/src/getting-started/configuration.md
+++ b/rust/crates/sift_cli/assets/docs/src/getting-started/configuration.md
@@ -13,7 +13,7 @@ For Sift Cloud, both URIs are `https://api.siftstack.com`. For self-hosted or
 non-cloud environments, use the endpoints provided by your administrator (and
 see [Disabling TLS](#disabling-tls) below if they are not served over TLS).
 
-The CLI can infer `app_uri` for production and government Sift. For any other
+The CLI can infer `app_uri` for PubCloud and GovCloud Sift. For any other
 domain, open the Sift web app and copy its URL origin. Keep the scheme and host.
 Do not include a page path, query, or fragment.
 

--- a/rust/crates/sift_cli/assets/docs/src/getting-started/profiles.md
+++ b/rust/crates/sift_cli/assets/docs/src/getting-started/profiles.md
@@ -10,7 +10,7 @@ When you do not name a profile, settings are read from and written to the top
 level of the config file. This is the `default` profile:
 
 ```toml
-grpc_uri = "https://api.siftstack.com"
+grpc_uri = "https://grpc-api.siftstack.com"
 rest_uri = "https://api.siftstack.com"
 app_uri = "https://app.siftstack.com"
 apikey = "sift_prod_..."
@@ -32,13 +32,13 @@ sift-cli config update --profile mission \
 The resulting file:
 
 ```toml
-grpc_uri = "https://api.siftstack.com"
+grpc_uri = "https://grpc-api.siftstack.com"
 rest_uri = "https://api.siftstack.com"
 app_uri = "https://app.siftstack.com"
 apikey = "sift_prod_..."
 
 [staging]
-grpc_uri = "https://api.staging.example.com"
+grpc_uri = "https://grpc-api.staging.example.com"
 rest_uri = "https://api.staging.example.com"
 app_uri = "https://sift.staging.example.com"
 apikey = "sift_staging_..."

--- a/rust/crates/sift_cli/assets/docs/src/getting-started/profiles.md
+++ b/rust/crates/sift_cli/assets/docs/src/getting-started/profiles.md
@@ -12,6 +12,7 @@ level of the config file. This is the `default` profile:
 ```toml
 grpc_uri = "https://api.siftstack.com"
 rest_uri = "https://api.siftstack.com"
+app_uri = "https://app.siftstack.com"
 apikey = "sift_prod_..."
 ```
 
@@ -24,6 +25,7 @@ TOML table:
 sift-cli config update --profile mission \
   --grpc-uri https://api.staging.example.com \
   --rest-uri https://api.staging.example.com \
+  --app-uri https://sift.staging.example.com \
   --api-key "$SIFT_STAGING_API_KEY"
 ```
 
@@ -32,11 +34,13 @@ The resulting file:
 ```toml
 grpc_uri = "https://api.siftstack.com"
 rest_uri = "https://api.siftstack.com"
+app_uri = "https://app.siftstack.com"
 apikey = "sift_prod_..."
 
 [staging]
 grpc_uri = "https://api.staging.example.com"
 rest_uri = "https://api.staging.example.com"
+app_uri = "https://sift.staging.example.com"
 apikey = "sift_staging_..."
 ```
 

--- a/rust/crates/sift_cli/assets/docs/src/reference/commands.md
+++ b/rust/crates/sift_cli/assets/docs/src/reference/commands.md
@@ -21,7 +21,7 @@ Manage CLI configuration. See [Configuration](../getting-started/configuration.m
 | `config create`         | Create a new (empty) config file.                 |
 | `config show`           | Print the current config file.                    |
 | `config where`          | Print the path to the config file.                |
-| `config update`         | Set fields (`-g`, `-r`, `-k`) or use `--interactive`. |
+| `config update`         | Set connection, app, or key fields. Use `--interactive` for prompts. |
 
 ## `import`
 

--- a/rust/crates/sift_cli/assets/skills/sift/references/agent-setup.md
+++ b/rust/crates/sift_cli/assets/skills/sift/references/agent-setup.md
@@ -3,8 +3,20 @@
 Use the CLI lifecycle instead of editing one client's MCP configuration or
 skill:
 
-- Run `sift-cli agent doctor` to diagnose setup, including the installed
-  profile and access mode, without changing it.
+- Run `sift-cli agent doctor` to diagnose setup. It checks the installed
+  profile, access mode, and profile `app_uri` without a change.
+- If doctor finds a missing `app_uri`, follow its guidance. For a production
+  or government profile, propose `sift-cli agent doctor --fix` for the default
+  profile. For a named profile, add `--profile <name>` before `agent`. Show the
+  profile and exact command, then wait for approval. This command sets only a
+  known public Sift app URL. Ask the user to restart the MCP client after the
+  fix.
+- For any other domain, do not guess `app_uri`. Ask the user to open their Sift
+  web app. Ask them to copy the URL origin from the browser address bar. The
+  origin contains the scheme and host. It can use any top-level domain. Then
+  propose `sift-cli --profile <name> config update --app-uri
+  <SIFT_WEB_ORIGIN>`. Omit `--profile` for the default profile. Wait for
+  approval before the config change. Ask for an MCP client restart afterward.
 - For first-time setup, explain that `sift-cli agent install` installs the
   release-matched skill and read-only MCP registration for every detected
   client using the default Sift profile. If the user selected a named profile,

--- a/rust/crates/sift_cli/assets/skills/sift/references/agent-setup.md
+++ b/rust/crates/sift_cli/assets/skills/sift/references/agent-setup.md
@@ -5,16 +5,18 @@ skill:
 
 - Run `sift-cli agent doctor` to diagnose setup. It checks the installed
   profile, access mode, and profile `app_uri` without a change.
-- Treat `app_uri` as a required profile field. If doctor finds a missing value
-  for PubCloud or GovCloud, relay its exact `sift-cli config update --app-uri`
+- Treat `app_uri` as a required profile field. Doctor treats a missing or
+  unusable value as an error. The `mcp` command returns the same reason when the
+  client lists its tools. For PubCloud or GovCloud, relay the exact config
   command. Show the profile and command, then wait for approval. Ask the user
   to restart the MCP client after the config change.
-- For any other domain, do not guess `app_uri`. Ask the user to open their Sift
+- For another domain, do not guess `app_uri`. Ask the user to open their Sift
   web app. Ask them to copy the URL origin from the browser address bar. The
   origin contains the scheme and host. It can use any top-level domain. For the
-  default profile, propose `sift-cli config update --app-uri <SIFT_WEB_ORIGIN>`.
-  For a named profile, add `--profile <name>` before `config`. Wait for approval
-  before the config change. Ask for an MCP client restart afterward.
+  default profile, propose
+  `sift-cli config update --app-uri <SIFT_WEB_ORIGIN>`. For a named profile, add
+  `--profile <name>` before `config`. Wait for approval before the config
+  change. Ask for an MCP client restart afterward.
 - For first-time setup, explain that `sift-cli agent install` installs the
   release-matched skill and read-only MCP registration for every detected
   client using the default Sift profile. If the user selected a named profile,

--- a/rust/crates/sift_cli/assets/skills/sift/references/agent-setup.md
+++ b/rust/crates/sift_cli/assets/skills/sift/references/agent-setup.md
@@ -5,18 +5,16 @@ skill:
 
 - Run `sift-cli agent doctor` to diagnose setup. It checks the installed
   profile, access mode, and profile `app_uri` without a change.
-- If doctor finds a missing `app_uri`, follow its guidance. For a production
-  or government profile, propose `sift-cli agent doctor --fix` for the default
-  profile. For a named profile, add `--profile <name>` before `agent`. Show the
-  profile and exact command, then wait for approval. This command sets only a
-  known public Sift app URL. Ask the user to restart the MCP client after the
-  fix.
+- Treat `app_uri` as a required profile field. If doctor finds a missing value
+  for PubCloud or GovCloud, relay its exact `sift-cli config update --app-uri`
+  command. Show the profile and command, then wait for approval. Ask the user
+  to restart the MCP client after the config change.
 - For any other domain, do not guess `app_uri`. Ask the user to open their Sift
   web app. Ask them to copy the URL origin from the browser address bar. The
-  origin contains the scheme and host. It can use any top-level domain. Then
-  propose `sift-cli --profile <name> config update --app-uri
-  <SIFT_WEB_ORIGIN>`. Omit `--profile` for the default profile. Wait for
-  approval before the config change. Ask for an MCP client restart afterward.
+  origin contains the scheme and host. It can use any top-level domain. For the
+  default profile, propose `sift-cli config update --app-uri <SIFT_WEB_ORIGIN>`.
+  For a named profile, add `--profile <name>` before `config`. Wait for approval
+  before the config change. Ask for an MCP client restart afterward.
 - For first-time setup, explain that `sift-cli agent install` installs the
   release-matched skill and read-only MCP registration for every detected
   client using the default Sift profile. If the user selected a named profile,

--- a/rust/crates/sift_cli/assets/skills/sift/references/cli.md
+++ b/rust/crates/sift_cli/assets/skills/sift/references/cli.md
@@ -70,14 +70,13 @@ per session. The rest apply to each subcommand invocation.
    accepts no `--wait`, `--preview`, or `--run`.
 7. **Surface the Explore link from import output.** `sift-cli import`
    prints a `View in Sift: <URL>` tip line after a successful upload when
-   the URL can be resolved — either because the profile sets `app_uri`
-   or because the API host is a recognized Sift environment (prod, gov,
-   or Sift's dev SaaS). Surface that URL to the user as plain text, in
+   the URL can be resolved. The profile can set `app_uri`. The CLI can also
+   infer the production and government app URLs. Surface the URL as plain text, in
    full. Do not wrap it in a markdown link, do not summarize it away —
    the URL is part of the deliverable, and not every IDE renders
-   markdown. Otherwise the CLI prints a fallback note telling the user
-   how to configure `app_uri`; relay that note verbatim and do not
-   invent a URL.
+   markdown. Otherwise the CLI prints a fallback note. Relay that note
+   verbatim. Ask the user to open their Sift web app and copy its URL origin.
+   Do not assume `.com` or any other top-level domain. Do not invent a URL.
 8. **On failure, read stderr and retry.** A non-zero exit usually means a
    bad flag combination or missing required argument; the CLI's stderr
    names the exact issue. Adjust the command and run again rather than

--- a/rust/crates/sift_cli/assets/skills/sift/references/cli.md
+++ b/rust/crates/sift_cli/assets/skills/sift/references/cli.md
@@ -69,14 +69,14 @@ per session. The rest apply to each subcommand invocation.
    line to the user verbatim. `import backups` is the one exception: it
    accepts no `--wait`, `--preview`, or `--run`.
 7. **Surface the Explore link from import output.** `sift-cli import`
-   prints a `View in Sift: <URL>` tip line after a successful upload when
-   the URL can be resolved. The profile can set `app_uri`. The CLI can also
-   infer the production and government app URLs. Surface the URL as plain text, in
-   full. Do not wrap it in a markdown link, do not summarize it away —
+   prints a `View in Sift: <URL>` tip line after a successful upload. Each
+   profile must set `app_uri`. The config command can infer it for PubCloud
+   and GovCloud. Surface the URL as plain text, in full. Do not wrap it in a
+   markdown link, do not summarize it away —
    the URL is part of the deliverable, and not every IDE renders
-   markdown. Otherwise the CLI prints a fallback note. Relay that note
-   verbatim. Ask the user to open their Sift web app and copy its URL origin.
-   Do not assume `.com` or any other top-level domain. Do not invent a URL.
+   markdown. If the CLI rejects a profile with no `app_uri`, relay its config
+   command. For an unknown domain, ask the user to copy the origin from their
+   Sift web app. Do not assume a top-level domain. Do not invent a URL.
 8. **On failure, read stderr and retry.** A non-zero exit usually means a
    bad flag combination or missing required argument; the CLI's stderr
    names the exact issue. Adjust the command and run again rather than

--- a/rust/crates/sift_cli/assets/skills/sift/references/cli.md
+++ b/rust/crates/sift_cli/assets/skills/sift/references/cli.md
@@ -13,6 +13,10 @@ Key subcommands:
 - `config`: manage profiles and credentials.
 - `agent`: install, update, diagnose, or uninstall Sift's agent integration.
 
+The `mcp` command requires a usable `app_uri` in the selected profile. If the
+profile is incomplete, the server returns the reason when the client lists its
+tools. Relay its exact config command.
+
 ## Protocol
 
 Invoke the CLI through your client's shell execution. The first step runs once
@@ -68,15 +72,13 @@ per session. The rest apply to each subcommand invocation.
    it you cannot confirm the data actually landed. Relay the final stdout
    line to the user verbatim. `import backups` is the one exception: it
    accepts no `--wait`, `--preview`, or `--run`.
-7. **Surface the Explore link from import output.** `sift-cli import`
-   prints a `View in Sift: <URL>` tip line after a successful upload. Each
-   profile must set `app_uri`. The config command can infer it for PubCloud
-   and GovCloud. Surface the URL as plain text, in full. Do not wrap it in a
-   markdown link, do not summarize it away —
-   the URL is part of the deliverable, and not every IDE renders
-   markdown. If the CLI rejects a profile with no `app_uri`, relay its config
-   command. For an unknown domain, ask the user to copy the origin from their
-   Sift web app. Do not assume a top-level domain. Do not invent a URL.
+7. **Surface the Explore link from import output.** Each profile must set
+   `app_uri`. `sift-cli import` prints a `View in Sift: <URL>` tip when this
+   value is usable. Surface the URL as plain text, in full. Do not wrap it in a
+   markdown link. An incomplete old profile does not block the import. The CLI
+   prints a config note instead. Relay that note. For an unknown domain, ask
+   the user to copy the origin from their Sift web app. Do not assume a
+   top-level domain. Do not invent a URL.
 8. **On failure, read stderr and retry.** A non-zero exit usually means a
    bad flag combination or missing required argument; the CLI's stderr
    names the exact issue. Adjust the command and run again rather than

--- a/rust/crates/sift_cli/assets/skills/sift/references/explore-links.md
+++ b/rust/crates/sift_cli/assets/skills/sift/references/explore-links.md
@@ -14,18 +14,16 @@ Prefix the channels for the panel you chose:
 - `x:`, `y:`, and `color:` for a scatter plot.
 - `lat:`, `lon:`, and `color:` for a geo map.
 
-`explore_url` needs `app_uri` in the user's `sift-cli` profile, or an
-`explore_host` passed on the call. Without either it fails with
-`INVALID_PARAMS`.
+`explore_url` uses the required `app_uri` from the user's `sift-cli` profile.
+An `explore_host` passed on the call overrides this value.
 
-If `app_uri` is missing, run `sift-cli agent doctor`. For a production or
-government profile, doctor gives a safe `--fix` command. Show that command and
-wait for approval before you run it. For any other domain, ask the user to open
-their Sift web app. Ask them to copy the URL origin from the browser address
-bar. Keep the scheme and host. Do not assume a top-level domain. Propose the
-profile-specific `sift-cli config update --app-uri <SIFT_WEB_ORIGIN>` command.
-Wait for approval before you run it. Ask the user to restart the MCP client
-before you retry `explore_url`.
+If `app_uri` is missing, run `sift-cli agent doctor`. Relay the exact config
+command for PubCloud or GovCloud. For any other domain, ask the user to copy the
+URL origin from their Sift web app. Keep the scheme and host. Do not assume a
+top-level domain. For the default profile, propose
+`sift-cli config update --app-uri <SIFT_WEB_ORIGIN>`. Add `--profile <name>`
+before `config` for a named profile. Wait for approval before you run it. Ask
+the user to restart the MCP client before you retry `explore_url`.
 
 When the user wants a chart and numbers together, build the link and also run
 `get_data` then `sql`.

--- a/rust/crates/sift_cli/assets/skills/sift/references/explore-links.md
+++ b/rust/crates/sift_cli/assets/skills/sift/references/explore-links.md
@@ -15,7 +15,7 @@ Prefix the channels for the panel you chose:
 - `lat:`, `lon:`, and `color:` for a geo map.
 
 `explore_url` uses the required `app_uri` from the user's `sift-cli` profile.
-An `explore_host` passed on the call overrides this value.
+The `sift-cli mcp` command rejects a profile without this value.
 
 If `app_uri` is missing, run `sift-cli agent doctor`. Relay the exact config
 command for PubCloud or GovCloud. For any other domain, ask the user to copy the

--- a/rust/crates/sift_cli/assets/skills/sift/references/explore-links.md
+++ b/rust/crates/sift_cli/assets/skills/sift/references/explore-links.md
@@ -18,5 +18,14 @@ Prefix the channels for the panel you chose:
 `explore_host` passed on the call. Without either it fails with
 `INVALID_PARAMS`.
 
+If `app_uri` is missing, run `sift-cli agent doctor`. For a production or
+government profile, doctor gives a safe `--fix` command. Show that command and
+wait for approval before you run it. For any other domain, ask the user to open
+their Sift web app. Ask them to copy the URL origin from the browser address
+bar. Keep the scheme and host. Do not assume a top-level domain. Propose the
+profile-specific `sift-cli config update --app-uri <SIFT_WEB_ORIGIN>` command.
+Wait for approval before you run it. Ask the user to restart the MCP client
+before you retry `explore_url`.
+
 When the user wants a chart and numbers together, build the link and also run
 `get_data` then `sql`.

--- a/rust/crates/sift_cli/src/cli/mod.rs
+++ b/rust/crates/sift_cli/src/cli/mod.rs
@@ -111,7 +111,7 @@ pub enum AgentCmd {
     Update(AgentUpdateArgs),
 
     /// Check the CLI version, skill files, MCP profiles, and access modes
-    Doctor,
+    Doctor(AgentDoctorArgs),
 
     /// Remove Sift-owned agent files and registrations
     Uninstall,
@@ -123,6 +123,14 @@ pub struct AgentInstallArgs {
     /// Enable tools that modify or archive resources for every detected MCP client
     #[arg(long)]
     pub allow_destructive: bool,
+}
+
+#[cfg(feature = "mcp")]
+#[derive(clap::Args)]
+pub struct AgentDoctorArgs {
+    /// Set a missing app_uri when the selected profile uses a known public Sift REST URL
+    #[arg(long)]
+    pub fix: bool,
 }
 
 #[cfg(feature = "mcp")]
@@ -318,9 +326,8 @@ pub struct ConfigUpdateArgs {
     #[arg(short = 'k', long)]
     pub api_key: Option<String>,
 
-    /// Sift web app URL (e.g. https://app.siftstack.com). Optional for standard
-    /// Sift hosts; required for custom or on-prem deployments to render Explore
-    /// links.
+    /// Sift web app origin from your browser (e.g. https://sift.example.net).
+    /// Production and government profiles can infer this value from rest_uri.
     #[arg(long)]
     pub app_uri: Option<String>,
 }

--- a/rust/crates/sift_cli/src/cli/mod.rs
+++ b/rust/crates/sift_cli/src/cli/mod.rs
@@ -111,7 +111,7 @@ pub enum AgentCmd {
     Update(AgentUpdateArgs),
 
     /// Check the CLI version, skill files, MCP profiles, and access modes
-    Doctor(AgentDoctorArgs),
+    Doctor,
 
     /// Remove Sift-owned agent files and registrations
     Uninstall,
@@ -123,14 +123,6 @@ pub struct AgentInstallArgs {
     /// Enable tools that modify or archive resources for every detected MCP client
     #[arg(long)]
     pub allow_destructive: bool,
-}
-
-#[cfg(feature = "mcp")]
-#[derive(clap::Args)]
-pub struct AgentDoctorArgs {
-    /// Set a missing app_uri when the selected profile uses a known public Sift REST URL
-    #[arg(long)]
-    pub fix: bool,
 }
 
 #[cfg(feature = "mcp")]
@@ -327,7 +319,7 @@ pub struct ConfigUpdateArgs {
     pub api_key: Option<String>,
 
     /// Sift web app origin from your browser (e.g. https://sift.example.net).
-    /// Production and government profiles can infer this value from rest_uri.
+    /// PubCloud and GovCloud profiles can infer this value from rest_uri.
     #[arg(long)]
     pub app_uri: Option<String>,
 }

--- a/rust/crates/sift_cli/src/cmd/agent/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/mod.rs
@@ -426,6 +426,7 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
         );
         unhealthy = true;
     }
+    let integration_unhealthy = unhealthy;
 
     if !mixed_profiles
         && !unexpected_profile
@@ -436,15 +437,15 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
                 println!("{} {} app_uri: {app_uri}", ok_status(), profile.label());
             }
             Ok(AppUriState::MissingKnown(app_uri)) => {
-                println!("{} {} has no app_uri.", warning_status(), profile.label());
+                println!("{} {} has no app_uri.", error_status(), profile.label());
                 println!(
                     "Run `{} config update --app-uri {app_uri}` to set it.",
                     profile.command_prefix()
                 );
-                warnings = true;
+                unhealthy = true;
             }
             Ok(AppUriState::MissingUnknown(rest_uri)) => {
-                println!("{} {} has no app_uri.", warning_status(), profile.label());
+                println!("{} {} has no app_uri.", error_status(), profile.label());
                 if let Some(rest_uri) = rest_uri {
                     println!("No public Sift app URL maps from {rest_uri}.");
                 }
@@ -453,19 +454,19 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
                     "Then run `{} config update --app-uri <SIFT_WEB_ORIGIN>`.",
                     profile.command_prefix()
                 );
-                warnings = true;
+                unhealthy = true;
             }
             Ok(AppUriState::Invalid) => {
                 println!(
                     "{} {} has an app_uri value that is not a string.",
-                    warning_status(),
+                    error_status(),
                     profile.label()
                 );
                 println!(
                     "Set it with `{} config update --app-uri <SIFT_WEB_ORIGIN>`.",
                     profile.command_prefix()
                 );
-                warnings = true;
+                unhealthy = true;
             }
             Err(error) => {
                 println!(
@@ -521,7 +522,12 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
                 "Then run `sift-cli agent update` to repair all detected integrations together."
             );
         }
-        if !blocked && !mixed_access && !mixed_profiles && !unexpected_profile {
+        if integration_unhealthy
+            && !blocked
+            && !mixed_access
+            && !mixed_profiles
+            && !unexpected_profile
+        {
             println!("Run `sift-cli agent update` to repair the detected integrations.");
         }
         Ok(ExitCode::FAILURE)

--- a/rust/crates/sift_cli/src/cmd/agent/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/mod.rs
@@ -17,7 +17,7 @@ use crossterm::style::Stylize;
 use semver::Version;
 
 use crate::{
-    cli::{AgentDoctorArgs, AgentInstallArgs, AgentUpdateArgs},
+    cli::{AgentInstallArgs, AgentUpdateArgs},
     cmd::{config as profile_config, config::AppUriState, version},
     util::progress::Spinner,
 };
@@ -258,14 +258,13 @@ pub async fn update(profile: Option<String>, args: AgentUpdateArgs) -> Result<Ex
     install_environment(&environment, "Updated", &registration)
 }
 
-pub async fn doctor(expected_profile: Option<String>, args: AgentDoctorArgs) -> Result<ExitCode> {
+pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
     let environment = Environment::discover()?;
     println!("Sift agent bundle {}", env!("CARGO_PKG_VERSION"));
 
     let mut unhealthy = check_release().await;
     let mut blocked = false;
     let mut warnings = false;
-    let mut fixed_app_uri = false;
     if environment.harnesses.is_empty() {
         println!("[error] No supported AI coding clients were detected.");
         return Ok(ExitCode::FAILURE);
@@ -397,28 +396,10 @@ pub async fn doctor(expected_profile: Option<String>, args: AgentDoctorArgs) -> 
             Ok(AppUriState::Configured(app_uri)) => {
                 println!("[ok] {} app_uri: {app_uri}", profile.label());
             }
-            Ok(AppUriState::MissingKnown(app_uri)) if args.fix => {
-                match profile_config::set_missing_app_uri(profile.config_name(), &app_uri) {
-                    Ok(true) => {
-                        println!("[fixed] {} app_uri: {app_uri}", profile.label());
-                        fixed_app_uri = true;
-                    }
-                    Ok(false) => {
-                        println!("[ok] {} app_uri is already configured", profile.label());
-                    }
-                    Err(error) => {
-                        println!(
-                            "[warning] Could not set app_uri for {}: {error}",
-                            profile.label()
-                        );
-                        warnings = true;
-                    }
-                }
-            }
             Ok(AppUriState::MissingKnown(app_uri)) => {
                 println!("[warning] {} has no app_uri.", profile.label());
                 println!(
-                    "Run `{} agent doctor --fix` to set it to {app_uri}.",
+                    "Run `{} config update --app-uri {app_uri}` to set it.",
                     profile.command_prefix()
                 );
                 warnings = true;
@@ -454,12 +435,6 @@ pub async fn doctor(expected_profile: Option<String>, args: AgentDoctorArgs) -> 
                 warnings = true;
             }
         }
-    } else if args.fix && (mixed_profiles || unexpected_profile) {
-        println!("[skip] app_uri fix needs one profile across all detected MCP clients.");
-    }
-
-    if fixed_app_uri {
-        println!("Restart your MCP client to load the updated profile.");
     }
 
     if unhealthy {

--- a/rust/crates/sift_cli/src/cmd/agent/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/mod.rs
@@ -17,8 +17,8 @@ use crossterm::style::Stylize;
 use semver::Version;
 
 use crate::{
-    cli::{AgentInstallArgs, AgentUpdateArgs},
-    cmd::version,
+    cli::{AgentDoctorArgs, AgentInstallArgs, AgentUpdateArgs},
+    cmd::{config as profile_config, config::AppUriState, version},
     util::progress::Spinner,
 };
 
@@ -55,6 +55,20 @@ impl Profile {
         match self {
             Self::Default => "default profile".to_string(),
             Self::Named(profile) => format!("profile '{profile}'"),
+        }
+    }
+
+    fn config_name(&self) -> Option<&str> {
+        match self {
+            Self::Default => None,
+            Self::Named(profile) => Some(profile),
+        }
+    }
+
+    fn command_prefix(&self) -> String {
+        match self {
+            Self::Default => "sift-cli".to_string(),
+            Self::Named(profile) => format!("sift-cli --profile {profile}"),
         }
     }
 }
@@ -244,12 +258,14 @@ pub async fn update(profile: Option<String>, args: AgentUpdateArgs) -> Result<Ex
     install_environment(&environment, "Updated", &registration)
 }
 
-pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
+pub async fn doctor(expected_profile: Option<String>, args: AgentDoctorArgs) -> Result<ExitCode> {
     let environment = Environment::discover()?;
     println!("Sift agent bundle {}", env!("CARGO_PKG_VERSION"));
 
     let mut unhealthy = check_release().await;
     let mut blocked = false;
+    let mut warnings = false;
+    let mut fixed_app_uri = false;
     if environment.harnesses.is_empty() {
         println!("[error] No supported AI coding clients were detected.");
         return Ok(ExitCode::FAILURE);
@@ -373,6 +389,79 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
         unhealthy = true;
     }
 
+    if !mixed_profiles
+        && !unexpected_profile
+        && let Some(profile) = profiles.first()
+    {
+        match profile_config::inspect_app_uri(profile.config_name()) {
+            Ok(AppUriState::Configured(app_uri)) => {
+                println!("[ok] {} app_uri: {app_uri}", profile.label());
+            }
+            Ok(AppUriState::MissingKnown(app_uri)) if args.fix => {
+                match profile_config::set_missing_app_uri(profile.config_name(), &app_uri) {
+                    Ok(true) => {
+                        println!("[fixed] {} app_uri: {app_uri}", profile.label());
+                        fixed_app_uri = true;
+                    }
+                    Ok(false) => {
+                        println!("[ok] {} app_uri is already configured", profile.label());
+                    }
+                    Err(error) => {
+                        println!(
+                            "[warning] Could not set app_uri for {}: {error}",
+                            profile.label()
+                        );
+                        warnings = true;
+                    }
+                }
+            }
+            Ok(AppUriState::MissingKnown(app_uri)) => {
+                println!("[warning] {} has no app_uri.", profile.label());
+                println!(
+                    "Run `{} agent doctor --fix` to set it to {app_uri}.",
+                    profile.command_prefix()
+                );
+                warnings = true;
+            }
+            Ok(AppUriState::MissingUnknown(rest_uri)) => {
+                println!("[warning] {} has no app_uri.", profile.label());
+                if let Some(rest_uri) = rest_uri {
+                    println!("No public Sift app URL maps from {rest_uri}.");
+                }
+                println!("Open your Sift web app and copy its URL origin.");
+                println!(
+                    "Then run `{} config update --app-uri <SIFT_WEB_ORIGIN>`.",
+                    profile.command_prefix()
+                );
+                warnings = true;
+            }
+            Ok(AppUriState::Invalid) => {
+                println!(
+                    "[warning] {} has an app_uri value that is not a string.",
+                    profile.label()
+                );
+                println!(
+                    "Set it with `{} config update --app-uri <SIFT_WEB_ORIGIN>`.",
+                    profile.command_prefix()
+                );
+                warnings = true;
+            }
+            Err(error) => {
+                println!(
+                    "[warning] Could not inspect app_uri for {}: {error}",
+                    profile.label()
+                );
+                warnings = true;
+            }
+        }
+    } else if args.fix && (mixed_profiles || unexpected_profile) {
+        println!("[skip] app_uri fix needs one profile across all detected MCP clients.");
+    }
+
+    if fixed_app_uri {
+        println!("Restart your MCP client to load the updated profile.");
+    }
+
     if unhealthy {
         if blocked {
             println!(
@@ -420,6 +509,9 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
             println!("Run `sift-cli agent update` to repair the detected integrations.");
         }
         Ok(ExitCode::FAILURE)
+    } else if warnings {
+        println!("All detected Sift agent integrations are healthy with warnings.");
+        Ok(ExitCode::SUCCESS)
     } else {
         println!("All detected Sift agent integrations are healthy.");
         Ok(ExitCode::SUCCESS)

--- a/rust/crates/sift_cli/src/cmd/agent/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/mod.rs
@@ -30,6 +30,10 @@ fn error_status() -> StyledContent<&'static str> {
     "[error]".red()
 }
 
+fn warning_status() -> StyledContent<&'static str> {
+    "[warning]".yellow()
+}
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub(super) enum AccessMode {
     ReadOnly,
@@ -432,7 +436,7 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
                 println!("{} {} app_uri: {app_uri}", ok_status(), profile.label());
             }
             Ok(AppUriState::MissingKnown(app_uri)) => {
-                println!("[warning] {} has no app_uri.", profile.label());
+                println!("{} {} has no app_uri.", warning_status(), profile.label());
                 println!(
                     "Run `{} config update --app-uri {app_uri}` to set it.",
                     profile.command_prefix()
@@ -440,7 +444,7 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
                 warnings = true;
             }
             Ok(AppUriState::MissingUnknown(rest_uri)) => {
-                println!("[warning] {} has no app_uri.", profile.label());
+                println!("{} {} has no app_uri.", warning_status(), profile.label());
                 if let Some(rest_uri) = rest_uri {
                     println!("No public Sift app URL maps from {rest_uri}.");
                 }
@@ -453,7 +457,8 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
             }
             Ok(AppUriState::Invalid) => {
                 println!(
-                    "[warning] {} has an app_uri value that is not a string.",
+                    "{} {} has an app_uri value that is not a string.",
+                    warning_status(),
                     profile.label()
                 );
                 println!(
@@ -464,7 +469,8 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
             }
             Err(error) => {
                 println!(
-                    "[warning] Could not inspect app_uri for {}: {error}",
+                    "{} Could not inspect app_uri for {}: {error}",
+                    warning_status(),
                     profile.label()
                 );
                 warnings = true;
@@ -809,7 +815,10 @@ async fn check_release() -> bool {
     let current = match Version::parse(env!("CARGO_PKG_VERSION")) {
         Ok(current) => current,
         Err(error) => {
-            println!("[warning] Could not parse the installed CLI version: {error}");
+            println!(
+                "{} Could not parse the installed CLI version: {error}",
+                warning_status()
+            );
             return false;
         }
     };
@@ -835,11 +844,17 @@ async fn check_release() -> bool {
             false
         }
         Ok(None) => {
-            println!("[warning] No stable sift-cli releases were found on GitHub");
+            println!(
+                "{} No stable sift-cli releases were found on GitHub",
+                warning_status()
+            );
             false
         }
         Err(error) => {
-            println!("[warning] Could not check for a newer sift-cli release: {error}");
+            println!(
+                "{} Could not check for a newer sift-cli release: {error}",
+                warning_status()
+            );
             false
         }
     }

--- a/rust/crates/sift_cli/src/cmd/agent/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/mod.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use anyhow::{Context, Result, anyhow};
-use crossterm::style::Stylize;
+use crossterm::style::{StyledContent, Stylize};
 use semver::Version;
 
 use crate::{
@@ -21,6 +21,14 @@ use crate::{
     cmd::{config as profile_config, config::AppUriState, version},
     util::progress::Spinner,
 };
+
+fn ok_status() -> StyledContent<&'static str> {
+    "[ok]".green()
+}
+
+fn error_status() -> StyledContent<&'static str> {
+    "[error]".red()
+}
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub(super) enum AccessMode {
@@ -266,7 +274,10 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
     let mut blocked = false;
     let mut warnings = false;
     if environment.harnesses.is_empty() {
-        println!("[error] No supported AI coding clients were detected.");
+        println!(
+            "{} No supported AI coding clients were detected.",
+            error_status()
+        );
         return Ok(ExitCode::FAILURE);
     }
 
@@ -284,25 +295,28 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
         let clients = harness_labels(&target.harnesses);
         match skill::inspect(&target.path)? {
             skill::State::Current => {
-                println!("[ok] {clients} skill: {}", target.path.display());
+                println!("{} {clients} skill: {}", ok_status(), target.path.display());
             }
             skill::State::Missing => {
                 println!(
-                    "[error] {clients} skill is missing: {}",
+                    "{} {clients} skill is missing: {}",
+                    error_status(),
                     target.path.display()
                 );
                 unhealthy = true;
             }
             skill::State::ManagedOutdated => {
                 println!(
-                    "[error] {clients} skill is from a different sift-cli release: {}",
+                    "{} {clients} skill is from a different sift-cli release: {}",
+                    error_status(),
                     target.path.display()
                 );
                 unhealthy = true;
             }
             skill::State::Conflict => {
                 println!(
-                    "[error] {clients} has an unmanaged skill at {}",
+                    "{} {clients} has an unmanaged skill at {}",
+                    error_status(),
                     target.path.display()
                 );
                 unhealthy = true;
@@ -326,19 +340,25 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
         match state {
             config::State::Current(registration) => {
                 println!(
-                    "[ok] {} MCP registration ({})",
+                    "{} {} MCP registration ({})",
+                    ok_status(),
                     harness.label(),
                     registration.label()
                 );
                 registrations.push(registration);
             }
             config::State::Missing => {
-                println!("[error] {} MCP registration is missing", harness.label());
+                println!(
+                    "{} {} MCP registration is missing",
+                    error_status(),
+                    harness.label()
+                );
                 unhealthy = true;
             }
             config::State::ManagedDrift(registration) => {
                 println!(
-                    "[error] {} MCP registration differs from the current bundle ({})",
+                    "{} {} MCP registration differs from the current bundle ({})",
+                    error_status(),
                     harness.label(),
                     registration.label()
                 );
@@ -346,12 +366,20 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
                 unhealthy = true;
             }
             config::State::Conflict(detail) => {
-                println!("[error] {} MCP registration: {detail}", harness.label());
+                println!(
+                    "{} {} MCP registration: {detail}",
+                    error_status(),
+                    harness.label()
+                );
                 unhealthy = true;
                 blocked = true;
             }
             config::State::Unavailable(detail) => {
-                println!("[error] {} MCP registration: {detail}", harness.label());
+                println!(
+                    "{} {} MCP registration: {detail}",
+                    error_status(),
+                    harness.label()
+                );
                 unhealthy = true;
                 blocked = true;
             }
@@ -367,12 +395,18 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
         .collect::<Vec<_>>();
     let mixed_access = has_mixed_access_modes(&access_modes);
     if mixed_access {
-        println!("[error] Detected MCP clients use mixed access modes.");
+        println!(
+            "{} Detected MCP clients use mixed access modes.",
+            error_status()
+        );
         unhealthy = true;
     }
     let mixed_profiles = has_mixed_profiles(&profiles);
     if mixed_profiles {
-        println!("[error] Detected MCP clients use mixed profiles.");
+        println!(
+            "{} Detected MCP clients use mixed profiles.",
+            error_status()
+        );
         unhealthy = true;
     }
     let expected_profile = expected_profile.map(Profile::Named);
@@ -382,7 +416,8 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
     });
     if unexpected_profile {
         println!(
-            "[error] Detected MCP clients do not all use the requested {}.",
+            "{} Detected MCP clients do not all use the requested {}.",
+            error_status(),
             expected_profile.as_ref().expect("checked above").label()
         );
         unhealthy = true;
@@ -394,7 +429,7 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
     {
         match profile_config::inspect_app_uri(profile.config_name()) {
             Ok(AppUriState::Configured(app_uri)) => {
-                println!("[ok] {} app_uri: {app_uri}", profile.label());
+                println!("{} {} app_uri: {app_uri}", ok_status(), profile.label());
             }
             Ok(AppUriState::MissingKnown(app_uri)) => {
                 println!("[warning] {} has no app_uri.", profile.label());
@@ -673,14 +708,16 @@ fn install_environment(
 
     for target in &targets {
         println!(
-            "[ok] {verb} {} skill: {}",
+            "{} {verb} {} skill: {}",
+            ok_status(),
             harness_labels(&target.harnesses),
             target.path.display()
         );
     }
     for harness in &environment.harnesses {
         println!(
-            "[ok] {verb} {} MCP registration ({})",
+            "{} {verb} {} MCP registration ({})",
+            ok_status(),
             harness.label(),
             registration.label()
         );
@@ -786,12 +823,15 @@ async fn check_release() -> bool {
     };
     match latest {
         Ok(Some(latest)) if latest > current => {
-            println!("[error] sift-cli {current} is outdated; latest is {latest}");
+            println!(
+                "{} sift-cli {current} is outdated; latest is {latest}",
+                error_status()
+            );
             println!("Update with:\n\n  {}\n", version::install_command(&latest));
             true
         }
         Ok(Some(_)) => {
-            println!("[ok] sift-cli {current} is current");
+            println!("{} sift-cli {current} is current", ok_status());
             false
         }
         Ok(None) => {

--- a/rust/crates/sift_cli/src/cmd/agent/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/tests.rs
@@ -1,6 +1,7 @@
 use std::{fs, path::PathBuf};
 
 use clap::Parser;
+use crossterm::style::Stylize;
 use serde_json::Value;
 use tempdir::TempDir;
 
@@ -24,6 +25,12 @@ fn default_registration(access: AccessMode) -> Registration {
 
 fn named_registration(access: AccessMode, profile: &str) -> Registration {
     Registration::new(access, Profile::Named(profile.to_string()))
+}
+
+#[test]
+fn status_tags_use_expected_colors() {
+    assert_eq!(super::ok_status(), "[ok]".green());
+    assert_eq!(super::error_status(), "[error]".red());
 }
 
 #[test]

--- a/rust/crates/sift_cli/src/cmd/agent/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/tests.rs
@@ -31,6 +31,7 @@ fn named_registration(access: AccessMode, profile: &str) -> Registration {
 fn status_tags_use_expected_colors() {
     assert_eq!(super::ok_status(), "[ok]".green());
     assert_eq!(super::error_status(), "[error]".red());
+    assert_eq!(super::warning_status(), "[warning]".yellow());
 }
 
 #[test]

--- a/rust/crates/sift_cli/src/cmd/agent/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/tests.rs
@@ -476,6 +476,15 @@ fn update_named_and_default_profile_flags_are_mutually_exclusive() {
 }
 
 #[test]
+fn doctor_fix_flag_is_parsed() {
+    let args = crate::cli::Args::parse_from(["sift-cli", "agent", "doctor", "--fix"]);
+    let Some(crate::cli::Cmd::Agent(crate::cli::AgentCmd::Doctor(doctor))) = args.cmd else {
+        panic!("expected agent doctor arguments");
+    };
+    assert!(doctor.fix);
+}
+
+#[test]
 fn uninstall_removes_only_sift_json_entry() {
     let directory = TempDir::new("sift-cli-agent-uninstall").unwrap();
     let environment = Environment::for_test(

--- a/rust/crates/sift_cli/src/cmd/agent/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/tests.rs
@@ -476,12 +476,8 @@ fn update_named_and_default_profile_flags_are_mutually_exclusive() {
 }
 
 #[test]
-fn doctor_fix_flag_is_parsed() {
-    let args = crate::cli::Args::parse_from(["sift-cli", "agent", "doctor", "--fix"]);
-    let Some(crate::cli::Cmd::Agent(crate::cli::AgentCmd::Doctor(doctor))) = args.cmd else {
-        panic!("expected agent doctor arguments");
-    };
-    assert!(doctor.fix);
+fn doctor_fix_flag_is_rejected() {
+    assert!(crate::cli::Args::try_parse_from(["sift-cli", "agent", "doctor", "--fix"]).is_err());
 }
 
 #[test]

--- a/rust/crates/sift_cli/src/cmd/config/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/config/mod.rs
@@ -15,7 +15,7 @@ use toml::{Table, Value};
 use crate::{
     cli::ConfigUpdateArgs,
     util::{
-        app_uri::infer_app_uri,
+        app_uri::{infer_app_uri, normalize_app_uri},
         tty::{Output, PromptUser},
     },
 };
@@ -236,7 +236,7 @@ fn apply_profile_updates(
     };
 
     let infer_missing_app_uri =
-        rest_uri.is_some() && app_uri.as_deref().is_none_or(|uri| uri.trim().is_empty());
+        rest_uri.is_some() && app_uri.as_deref().and_then(normalize_app_uri).is_none();
 
     if let Some(uri) = grpc_uri {
         target.insert(String::from("grpc_uri"), Value::String(uri));
@@ -247,13 +247,14 @@ fn apply_profile_updates(
     if let Some(token) = api_key {
         target.insert(String::from("apikey"), Value::String(token));
     }
-    if let Some(uri) = app_uri.filter(|uri| !uri.trim().is_empty()) {
-        target.insert(String::from("app_uri"), Value::String(uri));
+    if let Some(uri) = app_uri.as_deref().and_then(normalize_app_uri) {
+        target.insert(String::from("app_uri"), Value::String(uri.to_string()));
     }
     let app_uri_is_missing = target
         .get("app_uri")
         .and_then(Value::as_str)
-        .is_none_or(|uri| uri.trim().is_empty());
+        .and_then(normalize_app_uri)
+        .is_none();
     if infer_missing_app_uri
         && app_uri_is_missing
         && let Some(rest_uri) = target.get("rest_uri").and_then(Value::as_str)
@@ -278,8 +279,8 @@ pub(super) fn inspect_app_uri(profile: Option<&str>) -> Result<AppUriState> {
 fn app_uri_state(config_toml: &Table, profile: Option<&str>) -> Result<AppUriState> {
     let target = profile_table(config_toml, profile)?;
     match target.get("app_uri") {
-        Some(Value::String(uri)) if !uri.trim().is_empty() => {
-            return Ok(AppUriState::Configured(uri.trim().to_string()));
+        Some(Value::String(uri)) if let Some(uri) = normalize_app_uri(uri) => {
+            return Ok(AppUriState::Configured(uri.to_string()));
         }
         Some(Value::String(_)) | None => {}
         Some(_) => return Ok(AppUriState::Invalid),

--- a/rust/crates/sift_cli/src/cmd/config/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/config/mod.rs
@@ -275,37 +275,6 @@ pub(super) fn inspect_app_uri(profile: Option<&str>) -> Result<AppUriState> {
     app_uri_state(&config_toml, profile)
 }
 
-#[cfg(feature = "mcp")]
-pub(super) fn set_missing_app_uri(profile: Option<&str>, app_uri: &str) -> Result<bool> {
-    let path = get_config_file_path()?;
-    let contents = read_to_string(path).context("failed to read config file")?;
-    let mut config_toml = contents
-        .parse::<Table>()
-        .context("config file is invalid TOML")?;
-    if !set_missing_app_uri_value(&mut config_toml, profile, app_uri)? {
-        return Ok(false);
-    }
-    update_config_file(config_toml.to_string())?;
-    Ok(true)
-}
-
-#[cfg(any(feature = "mcp", test))]
-fn set_missing_app_uri_value(
-    config_toml: &mut Table,
-    profile: Option<&str>,
-    app_uri: &str,
-) -> Result<bool> {
-    let target = profile_table_mut(config_toml, profile)?;
-    match target.get("app_uri") {
-        Some(Value::String(uri)) if !uri.trim().is_empty() => return Ok(false),
-        Some(Value::String(_)) | None => {}
-        Some(_) => return Err(anyhow!("Expected value of 'app_uri' to be a string")),
-    }
-
-    target.insert(String::from("app_uri"), Value::String(app_uri.to_string()));
-    Ok(true)
-}
-
 fn app_uri_state(config_toml: &Table, profile: Option<&str>) -> Result<AppUriState> {
     let target = profile_table(config_toml, profile)?;
     match target.get("app_uri") {
@@ -331,20 +300,6 @@ fn profile_table<'a>(config_toml: &'a Table, profile: Option<&str>) -> Result<&'
         Some(profile) => config_toml
             .get(profile)
             .and_then(Value::as_table)
-            .ok_or_else(|| anyhow!("Profile '{profile}' not found or not a TOML table.")),
-        None => Ok(config_toml),
-    }
-}
-
-#[cfg(any(feature = "mcp", test))]
-fn profile_table_mut<'a>(
-    config_toml: &'a mut Table,
-    profile: Option<&str>,
-) -> Result<&'a mut Table> {
-    match profile {
-        Some(profile) => config_toml
-            .get_mut(profile)
-            .and_then(Value::as_table_mut)
             .ok_or_else(|| anyhow!("Profile '{profile}' not found or not a TOML table.")),
         None => Ok(config_toml),
     }

--- a/rust/crates/sift_cli/src/cmd/config/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/config/mod.rs
@@ -14,10 +14,21 @@ use toml::{Table, Value};
 
 use crate::{
     cli::ConfigUpdateArgs,
-    util::tty::{Output, PromptUser},
+    util::{
+        app_uri::infer_app_uri,
+        tty::{Output, PromptUser},
+    },
 };
 
 pub const CONFIG_FILE_NAME: &str = "sift.toml";
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(super) enum AppUriState {
+    Configured(String),
+    MissingKnown(String),
+    MissingUnknown(Option<String>),
+    Invalid,
+}
 
 pub fn show() -> Result<ExitCode> {
     let p = get_config_file_path()?;
@@ -58,8 +69,7 @@ pub fn create() -> Result<ExitCode> {
 }
 
 pub fn update(profile: Option<String>, args: ConfigUpdateArgs) -> Result<ExitCode> {
-    let prof = profile.clone();
-    let mut target = prof.unwrap_or_else(|| String::from("default"));
+    let mut configured_profile = profile.clone();
 
     let updated_config = {
         if !args.interactive {
@@ -68,32 +78,40 @@ pub fn update(profile: Option<String>, args: ConfigUpdateArgs) -> Result<ExitCod
                 return Ok(ExitCode::SUCCESS);
             }
             get_updated_config(
-                profile,
+                profile.clone(),
                 args.grpc_uri,
                 args.rest_uri,
                 args.api_key,
                 args.app_uri,
             )?
         } else {
-            let [prof, grpc, rest, key, app]: [Option<String>; 5] = PromptUser::new()
+            let [prof, grpc, rest, key]: [Option<String>; 4] = PromptUser::new()
                 .header("Any blank values will be ignored preserving the original.")
                 .prompt("  Specify the profile to configure (leave blank for default profile): ")
                 .prompt("  Specify the gRPC API base URL: ")
                 .prompt("  Specify the REST API base URL: ")
                 .prompt("  Provide your Sift API key: ")
-                .prompt(
-                    "  Specify the Sift web app URL — the address you visit in your browser \
-                     when signed in to Sift (e.g. https://app.siftstack.com). Optional for \
-                     standard Sift hosts; set it for custom or on-prem deployments to enable \
-                     Explore links: ",
-                )
                 .run()?
                 .try_into()
                 .unwrap();
 
-            if let Some(p) = prof.as_ref() {
-                target = p.clone();
-            }
+            configured_profile = prof.clone();
+            let suggested_app_uri = rest.as_deref().and_then(infer_app_uri);
+            let app_prompt = suggested_app_uri.map_or_else(
+                || {
+                    "  Open your Sift web app and copy its URL origin. Keep the scheme and host. \
+                     Specify that origin here (for example, https://sift.example.net): "
+                        .to_string()
+                },
+                |uri| format!("  Specify the Sift web app URL [{uri}]: "),
+            );
+            let [app]: [Option<String>; 1] = PromptUser::new()
+                .prompt(app_prompt)
+                .run()?
+                .try_into()
+                .unwrap();
+            let app = app.or_else(|| suggested_app_uri.map(str::to_string));
+
             let updated = get_updated_config(prof, grpc, rest, key, app)?;
             let divider = "-".repeat(40);
 
@@ -113,14 +131,23 @@ pub fn update(profile: Option<String>, args: ConfigUpdateArgs) -> Result<ExitCod
         }
     };
 
+    let config_toml = updated_config
+        .parse::<Table>()
+        .context("updated config is invalid TOML")?;
+    let app_uri_state = app_uri_state(&config_toml, configured_profile.as_deref())?;
     update_config_file(updated_config)?;
 
+    let target = configured_profile
+        .as_deref()
+        .unwrap_or("default")
+        .to_string();
     Output::new()
         .line(format!(
             "Successfully configured the '{}' profile.",
             target.yellow()
         ))
         .print();
+    print_app_uri_guidance(configured_profile.as_deref(), &app_uri_state);
 
     Ok(ExitCode::SUCCESS)
 }
@@ -177,6 +204,26 @@ fn get_updated_config(
         .parse::<Table>()
         .context("config file is invalid TOML")?;
 
+    apply_profile_updates(
+        &mut config_toml,
+        profile,
+        grpc_uri,
+        rest_uri,
+        api_key,
+        app_uri,
+    )?;
+
+    Ok(config_toml.to_string())
+}
+
+fn apply_profile_updates(
+    config_toml: &mut Table,
+    profile: Option<String>,
+    grpc_uri: Option<String>,
+    rest_uri: Option<String>,
+    api_key: Option<String>,
+    app_uri: Option<String>,
+) -> Result<()> {
     let target = match profile {
         Some(prof) => match config_toml.get_mut(&prof) {
             Some(Value::Table(profile_config)) => profile_config,
@@ -185,8 +232,11 @@ fn get_updated_config(
                 config_toml[&prof].as_table_mut().unwrap()
             }
         },
-        None => &mut config_toml,
+        None => config_toml,
     };
+
+    let infer_missing_app_uri =
+        rest_uri.is_some() && app_uri.as_deref().is_none_or(|uri| uri.trim().is_empty());
 
     if let Some(uri) = grpc_uri {
         target.insert(String::from("grpc_uri"), Value::String(uri));
@@ -197,11 +247,126 @@ fn get_updated_config(
     if let Some(token) = api_key {
         target.insert(String::from("apikey"), Value::String(token));
     }
-    if let Some(uri) = app_uri {
+    if let Some(uri) = app_uri.filter(|uri| !uri.trim().is_empty()) {
         target.insert(String::from("app_uri"), Value::String(uri));
     }
+    let app_uri_is_missing = target
+        .get("app_uri")
+        .and_then(Value::as_str)
+        .is_none_or(|uri| uri.trim().is_empty());
+    if infer_missing_app_uri
+        && app_uri_is_missing
+        && let Some(rest_uri) = target.get("rest_uri").and_then(Value::as_str)
+        && let Some(app_uri) = infer_app_uri(rest_uri)
+    {
+        target.insert(String::from("app_uri"), Value::String(app_uri.to_string()));
+    }
 
-    Ok(config_toml.to_string())
+    Ok(())
+}
+
+#[cfg(feature = "mcp")]
+pub(super) fn inspect_app_uri(profile: Option<&str>) -> Result<AppUriState> {
+    let path = get_config_file_path()?;
+    let contents = read_to_string(path).context("failed to read config file")?;
+    let config_toml = contents
+        .parse::<Table>()
+        .context("config file is invalid TOML")?;
+    app_uri_state(&config_toml, profile)
+}
+
+#[cfg(feature = "mcp")]
+pub(super) fn set_missing_app_uri(profile: Option<&str>, app_uri: &str) -> Result<bool> {
+    let path = get_config_file_path()?;
+    let contents = read_to_string(path).context("failed to read config file")?;
+    let mut config_toml = contents
+        .parse::<Table>()
+        .context("config file is invalid TOML")?;
+    if !set_missing_app_uri_value(&mut config_toml, profile, app_uri)? {
+        return Ok(false);
+    }
+    update_config_file(config_toml.to_string())?;
+    Ok(true)
+}
+
+#[cfg(any(feature = "mcp", test))]
+fn set_missing_app_uri_value(
+    config_toml: &mut Table,
+    profile: Option<&str>,
+    app_uri: &str,
+) -> Result<bool> {
+    let target = profile_table_mut(config_toml, profile)?;
+    match target.get("app_uri") {
+        Some(Value::String(uri)) if !uri.trim().is_empty() => return Ok(false),
+        Some(Value::String(_)) | None => {}
+        Some(_) => return Err(anyhow!("Expected value of 'app_uri' to be a string")),
+    }
+
+    target.insert(String::from("app_uri"), Value::String(app_uri.to_string()));
+    Ok(true)
+}
+
+fn app_uri_state(config_toml: &Table, profile: Option<&str>) -> Result<AppUriState> {
+    let target = profile_table(config_toml, profile)?;
+    match target.get("app_uri") {
+        Some(Value::String(uri)) if !uri.trim().is_empty() => {
+            return Ok(AppUriState::Configured(uri.trim().to_string()));
+        }
+        Some(Value::String(_)) | None => {}
+        Some(_) => return Ok(AppUriState::Invalid),
+    }
+
+    let rest_uri = target
+        .get("rest_uri")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    Ok(match rest_uri.as_deref().and_then(infer_app_uri) {
+        Some(app_uri) => AppUriState::MissingKnown(app_uri.to_string()),
+        None => AppUriState::MissingUnknown(rest_uri),
+    })
+}
+
+fn profile_table<'a>(config_toml: &'a Table, profile: Option<&str>) -> Result<&'a Table> {
+    match profile {
+        Some(profile) => config_toml
+            .get(profile)
+            .and_then(Value::as_table)
+            .ok_or_else(|| anyhow!("Profile '{profile}' not found or not a TOML table.")),
+        None => Ok(config_toml),
+    }
+}
+
+#[cfg(any(feature = "mcp", test))]
+fn profile_table_mut<'a>(
+    config_toml: &'a mut Table,
+    profile: Option<&str>,
+) -> Result<&'a mut Table> {
+    match profile {
+        Some(profile) => config_toml
+            .get_mut(profile)
+            .and_then(Value::as_table_mut)
+            .ok_or_else(|| anyhow!("Profile '{profile}' not found or not a TOML table.")),
+        None => Ok(config_toml),
+    }
+}
+
+fn print_app_uri_guidance(profile: Option<&str>, state: &AppUriState) {
+    let profile_flag = profile.map_or_else(String::new, |profile| format!("--profile {profile} "));
+    match state {
+        AppUriState::Configured(_) => {}
+        AppUriState::MissingKnown(app_uri) => println!(
+            "[warning] This profile has no app_uri. Set it with `sift-cli {profile_flag}config \
+             update --app-uri {app_uri}`."
+        ),
+        AppUriState::MissingUnknown(_) => println!(
+            "[warning] This profile has no app_uri. Open your Sift web app and copy its URL \
+             origin. Then run `sift-cli {profile_flag}config update --app-uri \
+             <SIFT_WEB_ORIGIN>`."
+        ),
+        AppUriState::Invalid => {
+            println!("[warning] This profile has an app_uri value that is not a string.")
+        }
+    }
 }
 
 fn update_config_file(updated: String) -> Result<()> {

--- a/rust/crates/sift_cli/src/cmd/config/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/config/mod.rs
@@ -310,16 +310,21 @@ fn print_app_uri_guidance(profile: Option<&str>, state: &AppUriState) {
     match state {
         AppUriState::Configured(_) => {}
         AppUriState::MissingKnown(app_uri) => println!(
-            "[warning] This profile has no app_uri. Set it with `sift-cli {profile_flag}config \
-             update --app-uri {app_uri}`."
+            "{} This profile has no app_uri. Set it with `sift-cli {profile_flag}config \
+             update --app-uri {app_uri}`.",
+            "[warning]".yellow()
         ),
         AppUriState::MissingUnknown(_) => println!(
-            "[warning] This profile has no app_uri. Open your Sift web app and copy its URL \
+            "{} This profile has no app_uri. Open your Sift web app and copy its URL \
              origin. Then run `sift-cli {profile_flag}config update --app-uri \
-             <SIFT_WEB_ORIGIN>`."
+             <SIFT_WEB_ORIGIN>`.",
+            "[warning]".yellow()
         ),
         AppUriState::Invalid => {
-            println!("[warning] This profile has an app_uri value that is not a string.")
+            println!(
+                "{} This profile has an app_uri value that is not a string.",
+                "[warning]".yellow()
+            )
         }
     }
 }

--- a/rust/crates/sift_cli/src/cmd/config/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/config/tests.rs
@@ -52,9 +52,7 @@ mod test_is_update_empty {
 }
 
 mod app_uri {
-    use super::super::{
-        AppUriState, app_uri_state, apply_profile_updates, set_missing_app_uri_value,
-    };
+    use super::super::{AppUriState, app_uri_state, apply_profile_updates};
     use toml::{Table, Value};
 
     fn config(input: &str) -> Table {
@@ -164,37 +162,6 @@ app_uri = "https://sift.example.net"
 
         assert_eq!(
             config["customer"]["app_uri"].as_str(),
-            Some("https://sift.example.net")
-        );
-    }
-
-    #[test]
-    fn doctor_fix_sets_only_a_missing_app_uri() {
-        let mut config = config(
-            r#"
-[production]
-rest_uri = "https://api.siftstack.com"
-
-[custom]
-rest_uri = "https://api.example.net"
-app_uri = "https://sift.example.net"
-"#,
-        );
-
-        assert!(
-            set_missing_app_uri_value(&mut config, Some("production"), "https://app.siftstack.com")
-                .unwrap()
-        );
-        assert!(
-            !set_missing_app_uri_value(&mut config, Some("custom"), "https://wrong.example.net")
-                .unwrap()
-        );
-        assert_eq!(
-            config["production"]["app_uri"].as_str(),
-            Some("https://app.siftstack.com")
-        );
-        assert_eq!(
-            config["custom"]["app_uri"].as_str(),
             Some("https://sift.example.net")
         );
     }

--- a/rust/crates/sift_cli/src/cmd/config/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/config/tests.rs
@@ -50,3 +50,152 @@ mod test_is_update_empty {
         )));
     }
 }
+
+mod app_uri {
+    use super::super::{
+        AppUriState, app_uri_state, apply_profile_updates, set_missing_app_uri_value,
+    };
+    use toml::{Table, Value};
+
+    fn config(input: &str) -> Table {
+        input.parse().unwrap()
+    }
+
+    #[test]
+    fn reports_configured_and_missing_app_uris() {
+        let config = config(
+            r#"
+rest_uri = "https://api.siftstack.com"
+app_uri = "https://app.siftstack.com"
+
+[gov]
+rest_uri = "https://gov.api.siftstack.com"
+
+[custom]
+rest_uri = "https://api.example.net"
+"#,
+        );
+
+        assert_eq!(
+            app_uri_state(&config, None).unwrap(),
+            AppUriState::Configured("https://app.siftstack.com".to_string())
+        );
+        assert_eq!(
+            app_uri_state(&config, Some("gov")).unwrap(),
+            AppUriState::MissingKnown("https://gov.siftstack.com".to_string())
+        );
+        assert_eq!(
+            app_uri_state(&config, Some("custom")).unwrap(),
+            AppUriState::MissingUnknown(Some("https://api.example.net".to_string()))
+        );
+    }
+
+    #[test]
+    fn known_rest_uri_sets_a_missing_app_uri() {
+        let mut config = Table::new();
+        apply_profile_updates(
+            &mut config,
+            None,
+            None,
+            Some("https://api.siftstack.com".to_string()),
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.get("app_uri"),
+            Some(&Value::String("https://app.siftstack.com".to_string()))
+        );
+    }
+
+    #[test]
+    fn unknown_rest_uri_does_not_set_app_uri() {
+        let mut config = Table::new();
+        apply_profile_updates(
+            &mut config,
+            None,
+            None,
+            Some("https://api.example.net".to_string()),
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert!(!config.contains_key("app_uri"));
+    }
+
+    #[test]
+    fn inferred_app_uri_does_not_replace_an_existing_value() {
+        let mut config = config(
+            r#"
+rest_uri = "https://api.example.net"
+app_uri = "https://sift.example.net"
+"#,
+        );
+        apply_profile_updates(
+            &mut config,
+            None,
+            None,
+            Some("https://api.siftstack.com".to_string()),
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.get("app_uri"),
+            Some(&Value::String("https://sift.example.net".to_string()))
+        );
+    }
+
+    #[test]
+    fn explicit_app_uri_is_written_to_a_named_profile() {
+        let mut config = Table::new();
+        apply_profile_updates(
+            &mut config,
+            Some("customer".to_string()),
+            None,
+            None,
+            None,
+            Some("https://sift.example.net".to_string()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            config["customer"]["app_uri"].as_str(),
+            Some("https://sift.example.net")
+        );
+    }
+
+    #[test]
+    fn doctor_fix_sets_only_a_missing_app_uri() {
+        let mut config = config(
+            r#"
+[production]
+rest_uri = "https://api.siftstack.com"
+
+[custom]
+rest_uri = "https://api.example.net"
+app_uri = "https://sift.example.net"
+"#,
+        );
+
+        assert!(
+            set_missing_app_uri_value(&mut config, Some("production"), "https://app.siftstack.com")
+                .unwrap()
+        );
+        assert!(
+            !set_missing_app_uri_value(&mut config, Some("custom"), "https://wrong.example.net")
+                .unwrap()
+        );
+        assert_eq!(
+            config["production"]["app_uri"].as_str(),
+            Some("https://app.siftstack.com")
+        );
+        assert_eq!(
+            config["custom"]["app_uri"].as_str(),
+            Some("https://sift.example.net")
+        );
+    }
+}

--- a/rust/crates/sift_cli/src/cmd/config/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/config/tests.rs
@@ -90,37 +90,50 @@ rest_uri = "https://api.example.net"
 
     #[test]
     fn known_rest_uri_sets_a_missing_app_uri() {
-        let mut config = Table::new();
-        apply_profile_updates(
-            &mut config,
-            None,
-            None,
-            Some("https://api.siftstack.com".to_string()),
-            None,
-            None,
-        )
-        .unwrap();
+        for (rest_uri, app_uri) in [
+            ("https://api.siftstack.com", "https://app.siftstack.com"),
+            ("https://gov.api.siftstack.com", "https://gov.siftstack.com"),
+        ] {
+            let mut config = Table::new();
+            apply_profile_updates(
+                &mut config,
+                None,
+                None,
+                Some(rest_uri.to_string()),
+                None,
+                None,
+            )
+            .unwrap();
 
-        assert_eq!(
-            config.get("app_uri"),
-            Some(&Value::String("https://app.siftstack.com".to_string()))
-        );
+            assert_eq!(
+                config.get("app_uri"),
+                Some(&Value::String(app_uri.to_string())),
+                "rest_uri: {rest_uri}"
+            );
+        }
     }
 
     #[test]
     fn unknown_rest_uri_does_not_set_app_uri() {
-        let mut config = Table::new();
-        apply_profile_updates(
-            &mut config,
-            None,
-            None,
-            Some("https://api.example.net".to_string()),
-            None,
-            None,
-        )
-        .unwrap();
+        for rest_uri in [
+            "https://api.example.net",
+            "https://api.development.siftstack.com",
+            "https://api.staging.internal",
+            "https://api.sift.test",
+        ] {
+            let mut config = Table::new();
+            apply_profile_updates(
+                &mut config,
+                None,
+                None,
+                Some(rest_uri.to_string()),
+                None,
+                None,
+            )
+            .unwrap();
 
-        assert!(!config.contains_key("app_uri"));
+            assert!(!config.contains_key("app_uri"), "rest_uri: {rest_uri}");
+        }
     }
 
     #[test]

--- a/rust/crates/sift_cli/src/cmd/config/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/config/tests.rs
@@ -71,6 +71,14 @@ rest_uri = "https://gov.api.siftstack.com"
 
 [custom]
 rest_uri = "https://api.example.net"
+
+[slash]
+rest_uri = "https://api.siftstack.com"
+app_uri = " / "
+
+[invalid]
+rest_uri = "https://api.siftstack.com"
+app_uri = 42
 "#,
         );
 
@@ -85,6 +93,14 @@ rest_uri = "https://api.example.net"
         assert_eq!(
             app_uri_state(&config, Some("custom")).unwrap(),
             AppUriState::MissingUnknown(Some("https://api.example.net".to_string()))
+        );
+        assert_eq!(
+            app_uri_state(&config, Some("slash")).unwrap(),
+            AppUriState::MissingKnown("https://app.siftstack.com".to_string())
+        );
+        assert_eq!(
+            app_uri_state(&config, Some("invalid")).unwrap(),
+            AppUriState::Invalid
         );
     }
 

--- a/rust/crates/sift_cli/src/cmd/import/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/import/mod.rs
@@ -7,7 +7,8 @@ use sift_rs::{SiftChannel, common::r#type::v1::ChannelConfig, jobs::v1::JobStatu
 
 use crate::cmd::Context;
 use crate::util::{
-    explore_url::{explore_or_note, import_target, pending_import_tip, resolve_app_uri},
+    app_uri::resolve_app_uri,
+    explore_url::{explore_or_note, import_target, pending_import_tip},
     job::JobServiceWrapper,
     progress::Spinner,
     tty::Output,

--- a/rust/crates/sift_cli/src/cmd/import/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/import/mod.rs
@@ -7,7 +7,6 @@ use sift_rs::{SiftChannel, common::r#type::v1::ChannelConfig, jobs::v1::JobStatu
 
 use crate::cmd::Context;
 use crate::util::{
-    app_uri::resolve_app_uri,
     explore_url::{explore_or_note, import_target, pending_import_tip},
     job::JobServiceWrapper,
     progress::Spinner,
@@ -36,8 +35,7 @@ pub async fn finish_import(
     run_id: Option<&str>,
     wait: bool,
 ) -> Result<ExitCode> {
-    let app_uri = resolve_app_uri(ctx.app_uri.as_deref(), &ctx.rest_uri);
-    let target = import_target(asset, run_name, run_id, app_uri.as_deref());
+    let target = import_target(asset, run_name, run_id, Some(&ctx.app_uri));
 
     if !wait {
         Output::new()

--- a/rust/crates/sift_cli/src/cmd/import/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/import/mod.rs
@@ -35,7 +35,7 @@ pub async fn finish_import(
     run_id: Option<&str>,
     wait: bool,
 ) -> Result<ExitCode> {
-    let target = import_target(asset, run_name, run_id, Some(&ctx.app_uri));
+    let target = import_target(asset, run_name, run_id, ctx.app_uri.as_deref());
 
     if !wait {
         Output::new()

--- a/rust/crates/sift_cli/src/cmd/mcp.rs
+++ b/rust/crates/sift_cli/src/cmd/mcp.rs
@@ -5,10 +5,8 @@ use sift_rs::Credentials;
 
 use crate::cli::McpArgs;
 use crate::cmd::Context;
-use crate::util::app_uri::resolve_app_uri;
 
 pub async fn run(ctx: Context, args: McpArgs) -> Result<ExitCode> {
-    let app_uri = resolve_app_uri(ctx.app_uri.as_deref(), &ctx.rest_uri);
     let credentials = Credentials::Config {
         uri: ctx.grpc_uri,
         apikey: ctx.api_key,
@@ -16,7 +14,7 @@ pub async fn run(ctx: Context, args: McpArgs) -> Result<ExitCode> {
     match sift_mcp::run(
         credentials,
         !ctx.disable_tls,
-        app_uri,
+        Some(ctx.app_uri),
         args.allow_destructive,
     )
     .await

--- a/rust/crates/sift_cli/src/cmd/mcp.rs
+++ b/rust/crates/sift_cli/src/cmd/mcp.rs
@@ -1,12 +1,26 @@
-use std::process::ExitCode;
+use std::{
+    io::{self, IsTerminal},
+    process::ExitCode,
+};
 
-use anyhow::Result;
+use anyhow::{Error, Result};
 use sift_rs::Credentials;
 
 use crate::cli::McpArgs;
 use crate::cmd::Context;
+use crate::util::tty::Output;
 
-pub async fn run(ctx: Context, args: McpArgs) -> Result<ExitCode> {
+pub async fn report_startup_error(error: Error) -> Result<ExitCode> {
+    let message = format!("{error:#}");
+    Output::new().line(&message).eprint();
+    if io::stdin().is_terminal() {
+        return Ok(ExitCode::FAILURE);
+    }
+    sift_mcp::report_startup_error(message).await?;
+    Ok(ExitCode::FAILURE)
+}
+
+pub async fn run(ctx: Context, args: McpArgs, app_uri: String) -> Result<ExitCode> {
     let credentials = Credentials::Config {
         uri: ctx.grpc_uri,
         apikey: ctx.api_key,
@@ -14,7 +28,7 @@ pub async fn run(ctx: Context, args: McpArgs) -> Result<ExitCode> {
     match sift_mcp::run(
         credentials,
         !ctx.disable_tls,
-        Some(ctx.app_uri),
+        app_uri,
         args.allow_destructive,
     )
     .await

--- a/rust/crates/sift_cli/src/cmd/mcp.rs
+++ b/rust/crates/sift_cli/src/cmd/mcp.rs
@@ -5,8 +5,10 @@ use sift_rs::Credentials;
 
 use crate::cli::McpArgs;
 use crate::cmd::Context;
+use crate::util::app_uri::resolve_app_uri;
 
 pub async fn run(ctx: Context, args: McpArgs) -> Result<ExitCode> {
+    let app_uri = resolve_app_uri(ctx.app_uri.as_deref(), &ctx.rest_uri);
     let credentials = Credentials::Config {
         uri: ctx.grpc_uri,
         apikey: ctx.api_key,
@@ -14,7 +16,7 @@ pub async fn run(ctx: Context, args: McpArgs) -> Result<ExitCode> {
     match sift_mcp::run(
         credentials,
         !ctx.disable_tls,
-        ctx.rest_uri,
+        app_uri,
         args.allow_destructive,
     )
     .await

--- a/rust/crates/sift_cli/src/cmd/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 use crate::BIN_NAME;
+use crate::util::app_uri::infer_app_uri;
 use anyhow::{Context as AnyhowContext, Result, anyhow};
 use crossterm::style::Stylize;
 use std::{fs::read_to_string, io::ErrorKind};
@@ -22,7 +23,7 @@ pub struct Context {
     pub disable_tls: bool,
     #[allow(dead_code)]
     pub rest_uri: String,
-    pub app_uri: Option<String>,
+    pub app_uri: String,
 }
 
 impl Context {
@@ -47,9 +48,9 @@ impl Context {
             .parse::<Table>()
             .context("failed to parse config file")?;
 
-        let target_profile = match profile {
+        let target_profile = match profile.as_deref() {
             Some(prof) => {
-                let Some(Value::Table(target)) = config_toml.get(&prof) else {
+                let Some(Value::Table(target)) = config_toml.get(prof) else {
                     return Err(anyhow!(
                         "Profile '{}' not found or not a TOML table.",
                         prof.yellow()
@@ -86,10 +87,7 @@ impl Context {
             ));
         }
 
-        let app_uri = match target_profile.get("app_uri") {
-            Some(Value::String(s)) if !s.is_empty() => Some(s.clone()),
-            _ => None,
-        };
+        let app_uri = required_app_uri(target_profile, profile.as_deref(), &rest_uri)?;
 
         let Some(Value::String(api_key)) = target_profile.get("apikey").cloned() else {
             return Err(anyhow!(
@@ -111,5 +109,81 @@ impl Context {
             disable_tls,
             app_uri,
         })
+    }
+}
+
+fn required_app_uri(
+    target_profile: &Table,
+    profile: Option<&str>,
+    rest_uri: &str,
+) -> Result<String> {
+    let guidance = app_uri_guidance(profile, rest_uri);
+    let Some(Value::String(app_uri)) = target_profile.get("app_uri").cloned() else {
+        return Err(anyhow!(
+            "Expected value of '{}' to be a string",
+            "app_uri".yellow()
+        ))
+        .context(guidance);
+    };
+    if app_uri.trim().is_empty() {
+        return Err(anyhow!(
+            "Expected value of '{}' to be present",
+            "app_uri".yellow()
+        ))
+        .context(guidance);
+    }
+    Ok(app_uri)
+}
+
+fn app_uri_guidance(profile: Option<&str>, rest_uri: &str) -> String {
+    let profile_flag = profile.map_or_else(String::new, |profile| format!("--profile {profile} "));
+    match infer_app_uri(rest_uri) {
+        Some(app_uri) => {
+            format!("Set it with '{BIN_NAME} {profile_flag}config update --app-uri {app_uri}'.")
+        }
+        None => format!(
+            "Open your Sift web app and copy its URL origin. Then run '{BIN_NAME} {profile_flag}config update --app-uri <SIFT_WEB_ORIGIN>'."
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::required_app_uri;
+    use toml::Table;
+
+    #[test]
+    fn app_uri_is_required() {
+        for input in [
+            r#"rest_uri = "https://api.siftstack.com""#,
+            r#"app_uri = """#,
+            r#"app_uri = "   ""#,
+            "app_uri = 42",
+        ] {
+            let profile = input.parse::<Table>().unwrap();
+            assert!(
+                required_app_uri(&profile, None, "https://api.siftstack.com")
+                    .unwrap_err()
+                    .to_string()
+                    .contains("Set it with"),
+                "input: {input}"
+            );
+        }
+
+        let configured = r#"app_uri = "https://app.siftstack.com""#.parse::<Table>().unwrap();
+        assert_eq!(
+            required_app_uri(&configured, None, "https://api.siftstack.com").unwrap(),
+            "https://app.siftstack.com"
+        );
+    }
+
+    #[test]
+    fn unknown_app_uri_guidance_uses_the_profile() {
+        let missing = Table::new();
+        let error =
+            required_app_uri(&missing, Some("mission"), "https://api.example.net").unwrap_err();
+        let message = format!("{error:#}");
+        assert!(message.contains("Open your Sift web app"));
+        assert!(message.contains("sift-cli --profile mission config update"));
     }
 }

--- a/rust/crates/sift_cli/src/cmd/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/mod.rs
@@ -1,5 +1,7 @@
 use crate::BIN_NAME;
+#[cfg(feature = "mcp")]
 use crate::util::app_uri::infer_app_uri;
+use crate::util::app_uri::normalize_app_uri;
 use anyhow::{Context as AnyhowContext, Result, anyhow};
 use crossterm::style::Stylize;
 use std::{fs::read_to_string, io::ErrorKind, path::Path};
@@ -23,7 +25,7 @@ pub struct Context {
     pub disable_tls: bool,
     #[allow(dead_code)]
     pub rest_uri: String,
-    pub app_uri: String,
+    pub app_uri: Option<String>,
 }
 
 impl Context {
@@ -95,7 +97,11 @@ impl Context {
             ));
         }
 
-        let app_uri = required_app_uri(target_profile, profile.as_deref(), &rest_uri)?;
+        let app_uri = target_profile
+            .get("app_uri")
+            .and_then(Value::as_str)
+            .and_then(normalize_app_uri)
+            .map(str::to_string);
 
         let Some(Value::String(api_key)) = target_profile.get("apikey").cloned() else {
             return Err(anyhow!(
@@ -118,49 +124,39 @@ impl Context {
             app_uri,
         })
     }
-}
 
-fn required_app_uri(
-    target_profile: &Table,
-    profile: Option<&str>,
-    rest_uri: &str,
-) -> Result<String> {
-    let guidance = app_uri_guidance(profile, rest_uri);
-    let Some(Value::String(app_uri)) = target_profile.get("app_uri").cloned() else {
-        return Err(anyhow!(
-            "Expected value of '{}' to be a string",
-            "app_uri".yellow()
-        ))
-        .context(guidance);
-    };
-    if app_uri.trim().is_empty() {
-        return Err(anyhow!(
-            "Expected value of '{}' to be present",
-            "app_uri".yellow()
-        ))
-        .context(guidance);
+    #[cfg(feature = "mcp")]
+    pub fn require_app_uri(&self, profile: Option<&str>) -> Result<&str> {
+        self.app_uri
+            .as_deref()
+            .ok_or_else(|| anyhow!(app_uri_guidance(profile, &self.rest_uri)))
     }
-    Ok(app_uri)
 }
 
+#[cfg(feature = "mcp")]
 fn app_uri_guidance(profile: Option<&str>, rest_uri: &str) -> String {
+    let profile_name = profile.unwrap_or("default");
     let profile_flag = profile.map_or_else(String::new, |profile| format!("--profile {profile} "));
     match infer_app_uri(rest_uri) {
-        Some(app_uri) => {
-            format!("Set it with '{BIN_NAME} {profile_flag}config update --app-uri {app_uri}'.")
-        }
+        Some(app_uri) => format!(
+            "The Sift MCP server cannot start because profile '{profile_name}' has no usable \
+             'app_uri'. Run '{BIN_NAME} {profile_flag}config update --app-uri {app_uri}', then \
+             restart the MCP client."
+        ),
         None => format!(
-            "Open your Sift web app and copy its URL origin. Then run '{BIN_NAME} {profile_flag}config update --app-uri <SIFT_WEB_ORIGIN>'."
+            "The Sift MCP server cannot start because profile '{profile_name}' has no usable \
+             'app_uri'. Open your Sift web app and copy its URL origin. Run '{BIN_NAME} \
+             {profile_flag}config update --app-uri <SIFT_WEB_ORIGIN>', then restart the MCP \
+             client."
         ),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Context, required_app_uri};
+    use super::Context;
     use std::fs;
     use tempdir::TempDir;
-    use toml::Table;
 
     const COMPLETE_CONFIG: &str = r#"
 grpc_uri = "https://grpc-api.siftstack.com"
@@ -187,18 +183,21 @@ apikey = "mission-key"
         let default = context(COMPLETE_CONFIG, None).unwrap();
         assert_eq!(default.grpc_uri, "https://grpc-api.siftstack.com");
         assert_eq!(default.rest_uri, "https://api.siftstack.com");
-        assert_eq!(default.app_uri, "https://app.siftstack.com");
+        assert_eq!(
+            default.app_uri.as_deref(),
+            Some("https://app.siftstack.com")
+        );
         assert_eq!(default.api_key, "default-key");
 
         let mission = context(COMPLETE_CONFIG, Some("mission")).unwrap();
         assert_eq!(mission.grpc_uri, "https://grpc.example.net");
         assert_eq!(mission.rest_uri, "https://api.example.net");
-        assert_eq!(mission.app_uri, "https://sift.example.net");
+        assert_eq!(mission.app_uri.as_deref(), Some("https://sift.example.net"));
         assert_eq!(mission.api_key, "mission-key");
     }
 
     #[test]
-    fn rejects_each_missing_required_field() {
+    fn rejects_each_missing_required_connection_field() {
         for (field, config) in [
             (
                 "grpc_uri",
@@ -217,14 +216,6 @@ apikey = "key"
 "#,
             ),
             (
-                "app_uri",
-                r#"
-grpc_uri = "https://grpc-api.siftstack.com"
-rest_uri = "https://api.siftstack.com"
-apikey = "key"
-"#,
-            ),
-            (
                 "apikey",
                 r#"
 grpc_uri = "https://grpc-api.siftstack.com"
@@ -239,13 +230,50 @@ app_uri = "https://app.siftstack.com"
     }
 
     #[test]
-    fn missing_app_uri_reports_known_and_custom_commands() {
+    fn incomplete_app_uri_remains_loadable_for_recovery() {
+        for app_uri in [
+            "",
+            "app_uri = \"\"",
+            "app_uri = \"   \"",
+            "app_uri = \" / \"",
+            "app_uri = 42",
+        ] {
+            let config = format!(
+                r#"
+grpc_uri = "https://grpc-api.siftstack.com"
+rest_uri = "https://api.siftstack.com"
+apikey = "key"
+{app_uri}
+"#
+            );
+            assert_eq!(context(&config, None).unwrap().app_uri, None);
+        }
+    }
+
+    #[test]
+    fn app_uri_is_trimmed_for_consumers() {
+        let config = r#"
+grpc_uri = "https://grpc-api.siftstack.com"
+rest_uri = "https://api.siftstack.com"
+app_uri = "  https://app.siftstack.com///  "
+apikey = "key"
+"#;
+        assert_eq!(
+            context(config, None).unwrap().app_uri.as_deref(),
+            Some("https://app.siftstack.com")
+        );
+    }
+
+    #[cfg(feature = "mcp")]
+    #[test]
+    fn mcp_requires_app_uri_with_profile_guidance() {
         let known = r#"
 grpc_uri = "https://grpc-api.siftstack.com"
 rest_uri = "https://api.siftstack.com"
 apikey = "key"
 "#;
-        let known_message = format!("{:#}", context(known, None).err().unwrap());
+        let known = context(known, None).unwrap();
+        let known_message = format!("{:#}", known.require_app_uri(None).unwrap_err());
         assert!(
             known_message.contains("sift-cli config update --app-uri https://app.siftstack.com")
         );
@@ -256,43 +284,9 @@ grpc_uri = "https://grpc.example.net"
 rest_uri = "https://api.example.net"
 apikey = "key"
 "#;
-        let custom_message = format!("{:#}", context(custom, Some("mission")).err().unwrap());
+        let custom = context(custom, Some("mission")).unwrap();
+        let custom_message = format!("{:#}", custom.require_app_uri(Some("mission")).unwrap_err());
         assert!(custom_message.contains("Open your Sift web app"));
         assert!(custom_message.contains("sift-cli --profile mission config update --app-uri"));
-    }
-
-    #[test]
-    fn app_uri_is_required() {
-        for input in [
-            r#"rest_uri = "https://api.siftstack.com""#,
-            r#"app_uri = """#,
-            r#"app_uri = "   ""#,
-            "app_uri = 42",
-        ] {
-            let profile = input.parse::<Table>().unwrap();
-            assert!(
-                required_app_uri(&profile, None, "https://api.siftstack.com")
-                    .unwrap_err()
-                    .to_string()
-                    .contains("Set it with"),
-                "input: {input}"
-            );
-        }
-
-        let configured = r#"app_uri = "https://app.siftstack.com""#.parse::<Table>().unwrap();
-        assert_eq!(
-            required_app_uri(&configured, None, "https://api.siftstack.com").unwrap(),
-            "https://app.siftstack.com"
-        );
-    }
-
-    #[test]
-    fn unknown_app_uri_guidance_uses_the_profile() {
-        let missing = Table::new();
-        let error =
-            required_app_uri(&missing, Some("mission"), "https://api.example.net").unwrap_err();
-        let message = format!("{error:#}");
-        assert!(message.contains("Open your Sift web app"));
-        assert!(message.contains("sift-cli --profile mission config update"));
     }
 }

--- a/rust/crates/sift_cli/src/cmd/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/mod.rs
@@ -2,7 +2,7 @@ use crate::BIN_NAME;
 use crate::util::app_uri::infer_app_uri;
 use anyhow::{Context as AnyhowContext, Result, anyhow};
 use crossterm::style::Stylize;
-use std::{fs::read_to_string, io::ErrorKind};
+use std::{fs::read_to_string, io::ErrorKind, path::Path};
 use toml::{Table, Value};
 
 #[cfg(feature = "mcp")]
@@ -29,6 +29,14 @@ pub struct Context {
 impl Context {
     pub fn new(profile: Option<String>, disable_tls: bool) -> Result<Self> {
         let config_path = config::get_config_file_path()?;
+        Self::from_config_path(&config_path, profile, disable_tls)
+    }
+
+    fn from_config_path(
+        config_path: &Path,
+        profile: Option<String>,
+        disable_tls: bool,
+    ) -> Result<Self> {
         let p = config_path.display().to_string();
 
         let config_txt = match read_to_string(config_path) {
@@ -149,8 +157,109 @@ fn app_uri_guidance(profile: Option<&str>, rest_uri: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::required_app_uri;
+    use super::{Context, required_app_uri};
+    use std::fs;
+    use tempdir::TempDir;
     use toml::Table;
+
+    const COMPLETE_CONFIG: &str = r#"
+grpc_uri = "https://api.siftstack.com"
+rest_uri = "https://api.siftstack.com"
+app_uri = "https://app.siftstack.com"
+apikey = "default-key"
+
+[mission]
+grpc_uri = "https://grpc.example.net"
+rest_uri = "https://api.example.net"
+app_uri = "https://sift.example.net"
+apikey = "mission-key"
+"#;
+
+    fn context(config: &str, profile: Option<&str>) -> anyhow::Result<Context> {
+        let directory = TempDir::new("sift-cli-context").unwrap();
+        let path = directory.path().join("sift.toml");
+        fs::write(&path, config).unwrap();
+        Context::from_config_path(&path, profile.map(str::to_string), false)
+    }
+
+    #[test]
+    fn loads_complete_default_and_named_profiles() {
+        let default = context(COMPLETE_CONFIG, None).unwrap();
+        assert_eq!(default.grpc_uri, "https://api.siftstack.com");
+        assert_eq!(default.rest_uri, "https://api.siftstack.com");
+        assert_eq!(default.app_uri, "https://app.siftstack.com");
+        assert_eq!(default.api_key, "default-key");
+
+        let mission = context(COMPLETE_CONFIG, Some("mission")).unwrap();
+        assert_eq!(mission.grpc_uri, "https://grpc.example.net");
+        assert_eq!(mission.rest_uri, "https://api.example.net");
+        assert_eq!(mission.app_uri, "https://sift.example.net");
+        assert_eq!(mission.api_key, "mission-key");
+    }
+
+    #[test]
+    fn rejects_each_missing_required_field() {
+        for (field, config) in [
+            (
+                "grpc_uri",
+                r#"
+rest_uri = "https://api.siftstack.com"
+app_uri = "https://app.siftstack.com"
+apikey = "key"
+"#,
+            ),
+            (
+                "rest_uri",
+                r#"
+grpc_uri = "https://api.siftstack.com"
+app_uri = "https://app.siftstack.com"
+apikey = "key"
+"#,
+            ),
+            (
+                "app_uri",
+                r#"
+grpc_uri = "https://api.siftstack.com"
+rest_uri = "https://api.siftstack.com"
+apikey = "key"
+"#,
+            ),
+            (
+                "apikey",
+                r#"
+grpc_uri = "https://api.siftstack.com"
+rest_uri = "https://api.siftstack.com"
+app_uri = "https://app.siftstack.com"
+"#,
+            ),
+        ] {
+            let message = format!("{:#}", context(config, None).err().unwrap());
+            assert!(message.contains(field), "field: {field}, error: {message}");
+        }
+    }
+
+    #[test]
+    fn missing_app_uri_reports_known_and_custom_commands() {
+        let known = r#"
+grpc_uri = "https://api.siftstack.com"
+rest_uri = "https://api.siftstack.com"
+apikey = "key"
+"#;
+        let known_message = format!("{:#}", context(known, None).err().unwrap());
+        assert!(
+            known_message.contains("sift-cli config update --app-uri https://app.siftstack.com")
+        );
+
+        let custom = r#"
+[mission]
+grpc_uri = "https://grpc.example.net"
+rest_uri = "https://api.example.net"
+apikey = "key"
+"#;
+        let custom_message = format!("{:#}", context(custom, Some("mission")).err().unwrap());
+        assert!(custom_message.contains("Open your Sift web app"));
+        assert!(custom_message.contains("sift-cli --profile mission config update --app-uri"));
+    }
 
     #[test]
     fn app_uri_is_required() {

--- a/rust/crates/sift_cli/src/cmd/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/mod.rs
@@ -163,7 +163,7 @@ mod tests {
     use toml::Table;
 
     const COMPLETE_CONFIG: &str = r#"
-grpc_uri = "https://api.siftstack.com"
+grpc_uri = "https://grpc-api.siftstack.com"
 rest_uri = "https://api.siftstack.com"
 app_uri = "https://app.siftstack.com"
 apikey = "default-key"
@@ -185,7 +185,7 @@ apikey = "mission-key"
     #[test]
     fn loads_complete_default_and_named_profiles() {
         let default = context(COMPLETE_CONFIG, None).unwrap();
-        assert_eq!(default.grpc_uri, "https://api.siftstack.com");
+        assert_eq!(default.grpc_uri, "https://grpc-api.siftstack.com");
         assert_eq!(default.rest_uri, "https://api.siftstack.com");
         assert_eq!(default.app_uri, "https://app.siftstack.com");
         assert_eq!(default.api_key, "default-key");
@@ -211,7 +211,7 @@ apikey = "key"
             (
                 "rest_uri",
                 r#"
-grpc_uri = "https://api.siftstack.com"
+grpc_uri = "https://grpc-api.siftstack.com"
 app_uri = "https://app.siftstack.com"
 apikey = "key"
 "#,
@@ -219,7 +219,7 @@ apikey = "key"
             (
                 "app_uri",
                 r#"
-grpc_uri = "https://api.siftstack.com"
+grpc_uri = "https://grpc-api.siftstack.com"
 rest_uri = "https://api.siftstack.com"
 apikey = "key"
 "#,
@@ -227,7 +227,7 @@ apikey = "key"
             (
                 "apikey",
                 r#"
-grpc_uri = "https://api.siftstack.com"
+grpc_uri = "https://grpc-api.siftstack.com"
 rest_uri = "https://api.siftstack.com"
 app_uri = "https://app.siftstack.com"
 "#,
@@ -241,7 +241,7 @@ app_uri = "https://app.siftstack.com"
     #[test]
     fn missing_app_uri_reports_known_and_custom_commands() {
         let known = r#"
-grpc_uri = "https://api.siftstack.com"
+grpc_uri = "https://grpc-api.siftstack.com"
 rest_uri = "https://api.siftstack.com"
 apikey = "key"
 "#;

--- a/rust/crates/sift_cli/src/main.rs
+++ b/rust/crates/sift_cli/src/main.rs
@@ -88,9 +88,7 @@ fn run(clargs: cli::Args) -> Result<ExitCode> {
             AgentCmd::Update(args) => {
                 return run_future(cmd::agent::update(clargs.profile, args));
             }
-            AgentCmd::Doctor(args) => {
-                return run_future(cmd::agent::doctor(clargs.profile, args));
-            }
+            AgentCmd::Doctor => return run_future(cmd::agent::doctor(clargs.profile)),
             AgentCmd::Uninstall => return cmd::agent::uninstall(),
         },
         _ => (),

--- a/rust/crates/sift_cli/src/main.rs
+++ b/rust/crates/sift_cli/src/main.rs
@@ -99,7 +99,11 @@ fn run(clargs: cli::Args) -> Result<ExitCode> {
     // Mcp Server
     #[cfg(feature = "mcp")]
     if let Cmd::Mcp(args) = cmd {
-        return run_future_mt(cmd::mcp::run(ctx, args));
+        let app_uri = match ctx.require_app_uri(clargs.profile.as_deref()) {
+            Ok(app_uri) => app_uri.to_string(),
+            Err(error) => return run_future_mt(cmd::mcp::report_startup_error(error)),
+        };
+        return run_future_mt(cmd::mcp::run(ctx, args, app_uri));
     }
 
     let profile = clargs

--- a/rust/crates/sift_cli/src/main.rs
+++ b/rust/crates/sift_cli/src/main.rs
@@ -88,7 +88,9 @@ fn run(clargs: cli::Args) -> Result<ExitCode> {
             AgentCmd::Update(args) => {
                 return run_future(cmd::agent::update(clargs.profile, args));
             }
-            AgentCmd::Doctor => return run_future(cmd::agent::doctor(clargs.profile)),
+            AgentCmd::Doctor(args) => {
+                return run_future(cmd::agent::doctor(clargs.profile, args));
+            }
             AgentCmd::Uninstall => return cmd::agent::uninstall(),
         },
         _ => (),

--- a/rust/crates/sift_cli/src/util/app_uri.rs
+++ b/rust/crates/sift_cli/src/util/app_uri.rs
@@ -34,6 +34,7 @@ mod tests {
             "http://api.siftstack.com",
             "https://api.siftstack.com",
             "https://api.siftstack.com/",
+            "https://API.SIFTSTACK.COM",
         ] {
             assert_eq!(infer_app_uri(rest_uri), Some("https://app.siftstack.com"));
         }
@@ -51,7 +52,14 @@ mod tests {
         for rest_uri in [
             "https://api.example.net",
             "https://app.siftstack.com",
+            "https://api.development.siftstack.com",
+            "https://api.staging.internal",
+            "https://api.sift.test",
             "https://api.siftstack.com/v1",
+            "https://api.siftstack.com?query=value",
+            "https://api.siftstack.com#fragment",
+            "https://api.siftstack.com:443",
+            "https://api.siftstack.com.example.net",
             "api.siftstack.com",
         ] {
             assert_eq!(infer_app_uri(rest_uri), None, "rest_uri: {rest_uri}");

--- a/rust/crates/sift_cli/src/util/app_uri.rs
+++ b/rust/crates/sift_cli/src/util/app_uri.rs
@@ -3,6 +3,11 @@ const PROD_APP_URI: &str = "https://app.siftstack.com";
 const GOV_REST_HOST: &str = "gov.api.siftstack.com";
 const GOV_APP_URI: &str = "https://gov.siftstack.com";
 
+pub fn normalize_app_uri(app_uri: &str) -> Option<&str> {
+    let app_uri = app_uri.trim().trim_end_matches('/');
+    (!app_uri.is_empty()).then_some(app_uri)
+}
+
 pub fn infer_app_uri(rest_uri: &str) -> Option<&'static str> {
     let rest_uri = rest_uri.trim();
     let authority_and_path = rest_uri
@@ -26,7 +31,18 @@ pub fn infer_app_uri(rest_uri: &str) -> Option<&'static str> {
 
 #[cfg(test)]
 mod tests {
-    use super::infer_app_uri;
+    use super::{infer_app_uri, normalize_app_uri};
+
+    #[test]
+    fn normalizes_usable_app_uris() {
+        assert_eq!(
+            normalize_app_uri("  https://app.siftstack.com///  "),
+            Some("https://app.siftstack.com")
+        );
+        for app_uri in ["", "   ", "/", " / ", "///"] {
+            assert_eq!(normalize_app_uri(app_uri), None);
+        }
+    }
 
     #[test]
     fn infers_public_sift_app_uris() {

--- a/rust/crates/sift_cli/src/util/app_uri.rs
+++ b/rust/crates/sift_cli/src/util/app_uri.rs
@@ -24,17 +24,9 @@ pub fn infer_app_uri(rest_uri: &str) -> Option<&'static str> {
     }
 }
 
-pub fn resolve_app_uri(app_uri: Option<&str>, rest_uri: &str) -> Option<String> {
-    app_uri
-        .map(str::trim)
-        .filter(|uri| !uri.is_empty())
-        .map(str::to_string)
-        .or_else(|| infer_app_uri(rest_uri).map(str::to_string))
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{infer_app_uri, resolve_app_uri};
+    use super::infer_app_uri;
 
     #[test]
     fn infers_public_sift_app_uris() {
@@ -64,24 +56,5 @@ mod tests {
         ] {
             assert_eq!(infer_app_uri(rest_uri), None, "rest_uri: {rest_uri}");
         }
-    }
-
-    #[test]
-    fn explicit_app_uri_takes_priority() {
-        assert_eq!(
-            resolve_app_uri(
-                Some(" https://sift.example.net/ "),
-                "https://api.siftstack.com"
-            ),
-            Some("https://sift.example.net/".to_string())
-        );
-    }
-
-    #[test]
-    fn empty_app_uri_uses_a_known_mapping() {
-        assert_eq!(
-            resolve_app_uri(Some("  "), "https://api.siftstack.com"),
-            Some("https://app.siftstack.com".to_string())
-        );
     }
 }

--- a/rust/crates/sift_cli/src/util/app_uri.rs
+++ b/rust/crates/sift_cli/src/util/app_uri.rs
@@ -1,0 +1,87 @@
+const PROD_REST_HOST: &str = "api.siftstack.com";
+const PROD_APP_URI: &str = "https://app.siftstack.com";
+const GOV_REST_HOST: &str = "gov.api.siftstack.com";
+const GOV_APP_URI: &str = "https://gov.siftstack.com";
+
+pub fn infer_app_uri(rest_uri: &str) -> Option<&'static str> {
+    let rest_uri = rest_uri.trim();
+    let authority_and_path = rest_uri
+        .strip_prefix("https://")
+        .or_else(|| rest_uri.strip_prefix("http://"))?;
+    let (authority, path) = authority_and_path
+        .split_once('/')
+        .unwrap_or((authority_and_path, ""));
+    if !path.trim_matches('/').is_empty() {
+        return None;
+    }
+
+    if authority.eq_ignore_ascii_case(PROD_REST_HOST) {
+        Some(PROD_APP_URI)
+    } else if authority.eq_ignore_ascii_case(GOV_REST_HOST) {
+        Some(GOV_APP_URI)
+    } else {
+        None
+    }
+}
+
+pub fn resolve_app_uri(app_uri: Option<&str>, rest_uri: &str) -> Option<String> {
+    app_uri
+        .map(str::trim)
+        .filter(|uri| !uri.is_empty())
+        .map(str::to_string)
+        .or_else(|| infer_app_uri(rest_uri).map(str::to_string))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{infer_app_uri, resolve_app_uri};
+
+    #[test]
+    fn infers_public_sift_app_uris() {
+        for rest_uri in [
+            "http://api.siftstack.com",
+            "https://api.siftstack.com",
+            "https://api.siftstack.com/",
+        ] {
+            assert_eq!(infer_app_uri(rest_uri), Some("https://app.siftstack.com"));
+        }
+        for rest_uri in [
+            "http://gov.api.siftstack.com",
+            "https://gov.api.siftstack.com",
+            "https://gov.api.siftstack.com/",
+        ] {
+            assert_eq!(infer_app_uri(rest_uri), Some("https://gov.siftstack.com"));
+        }
+    }
+
+    #[test]
+    fn does_not_infer_non_public_hosts_or_paths() {
+        for rest_uri in [
+            "https://api.example.net",
+            "https://app.siftstack.com",
+            "https://api.siftstack.com/v1",
+            "api.siftstack.com",
+        ] {
+            assert_eq!(infer_app_uri(rest_uri), None, "rest_uri: {rest_uri}");
+        }
+    }
+
+    #[test]
+    fn explicit_app_uri_takes_priority() {
+        assert_eq!(
+            resolve_app_uri(
+                Some(" https://sift.example.net/ "),
+                "https://api.siftstack.com"
+            ),
+            Some("https://sift.example.net/".to_string())
+        );
+    }
+
+    #[test]
+    fn empty_app_uri_uses_a_known_mapping() {
+        assert_eq!(
+            resolve_app_uri(Some("  "), "https://api.siftstack.com"),
+            Some("https://app.siftstack.com".to_string())
+        );
+    }
+}

--- a/rust/crates/sift_cli/src/util/explore_url.rs
+++ b/rust/crates/sift_cli/src/util/explore_url.rs
@@ -57,12 +57,59 @@ pub fn build_explore_url(
     asset_name: &str,
     run: Option<&str>,
 ) -> Option<String> {
-    let host = app_uri.map(str::trim).filter(|s| !s.is_empty())?;
-    let host = host.trim_end_matches('/');
+    let host = app_uri
+        .map(str::trim)
+        .map(|host| host.trim_end_matches('/'))
+        .filter(|host| !host.is_empty())?;
 
     let mut url = format!("{host}/explore?method=single&assets={}", encode(asset_name));
     if let Some(run) = run {
         url.push_str(&format!("&runs={}", encode(run)));
     }
     Some(url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_explore_url, import_target};
+
+    #[test]
+    fn import_target_uses_the_configured_app_uri() {
+        let target = import_target(
+            "Engine / 7",
+            Some("Test Run"),
+            None,
+            Some("https://sift.example.net/"),
+        );
+        assert_eq!(
+            target.explore_url.as_deref(),
+            Some(
+                "https://sift.example.net/explore?method=single&assets=Engine%20%2F%207&runs=Test%20Run"
+            )
+        );
+    }
+
+    #[test]
+    fn run_id_takes_priority_over_run_name() {
+        let target = import_target(
+            "asset",
+            Some("name"),
+            Some("run-id"),
+            Some("https://app.siftstack.com"),
+        );
+        assert!(
+            target
+                .explore_url
+                .as_deref()
+                .unwrap()
+                .ends_with("&runs=run-id")
+        );
+    }
+
+    #[test]
+    fn empty_or_slash_only_app_uri_does_not_build_a_link() {
+        for app_uri in [None, Some(""), Some("   "), Some(" / ")] {
+            assert_eq!(build_explore_url(app_uri, "asset", None), None);
+        }
+    }
 }

--- a/rust/crates/sift_cli/src/util/explore_url.rs
+++ b/rust/crates/sift_cli/src/util/explore_url.rs
@@ -1,6 +1,8 @@
 use crossterm::style::Stylize;
 use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
 
+use super::app_uri::normalize_app_uri;
+
 const VALUE_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
     .remove(b'-')
     .remove(b'_')
@@ -57,10 +59,7 @@ pub fn build_explore_url(
     asset_name: &str,
     run: Option<&str>,
 ) -> Option<String> {
-    let host = app_uri
-        .map(str::trim)
-        .map(|host| host.trim_end_matches('/'))
-        .filter(|host| !host.is_empty())?;
+    let host = app_uri.and_then(normalize_app_uri)?;
 
     let mut url = format!("{host}/explore?method=single&assets={}", encode(asset_name));
     if let Some(run) = run {

--- a/rust/crates/sift_cli/src/util/explore_url.rs
+++ b/rust/crates/sift_cli/src/util/explore_url.rs
@@ -35,31 +35,12 @@ pub fn import_target(
     }
 }
 
-pub fn resolve_app_uri(app_uri: Option<&str>, rest_uri: &str) -> Option<String> {
-    if let Some(uri) = app_uri.map(str::trim).filter(|s| !s.is_empty()) {
-        return Some(uri.to_string());
-    }
-    match host_of(rest_uri)? {
-        "api.siftstack.com" => Some("https://app.siftstack.com".to_string()),
-        "gov.api.siftstack.com" => Some("https://gov.siftstack.com".to_string()),
-        "api.development.siftstack.com" => {
-            Some("https://app.development.siftstack.com".to_string())
-        }
-        _ => None,
-    }
-}
-
-fn host_of(url: &str) -> Option<&str> {
-    let after_scheme = url.split_once("://").map(|(_, rest)| rest).unwrap_or(url);
-    let host_with_port = after_scheme.split('/').next()?;
-    Some(host_with_port.split(':').next().unwrap_or(host_with_port))
-}
-
 pub fn explore_or_note(explore_url: Option<&str>) -> String {
     match explore_url {
         Some(url) => format!("\nView in Sift: {url}"),
-        None => "\nRun `sift-cli config update --app-uri <SIFT_WEB_URL>` so future imports \
-                 include a Sift Explore link."
+        None => "\nOpen your Sift web app and copy its URL origin. Then run `sift-cli config \
+                 update --app-uri <SIFT_WEB_ORIGIN>`. Add `--profile <name>` when you use a \
+                 named profile."
             .to_string(),
     }
 }

--- a/rust/crates/sift_cli/src/util/mod.rs
+++ b/rust/crates/sift_cli/src/util/mod.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod app_uri;
 pub mod calculated_channel;
 pub mod channel;
 pub mod explore_url;

--- a/rust/crates/sift_mcp/src/lib.rs
+++ b/rust/crates/sift_mcp/src/lib.rs
@@ -6,6 +6,9 @@ use sift_rs::{Credentials, SiftChannelBuilder};
 mod server;
 use server::SiftMcpServer;
 
+mod startup;
+pub use startup::report_startup_error;
+
 mod error;
 mod policy;
 mod prompt;
@@ -15,7 +18,7 @@ mod tool;
 pub async fn run(
     credentials: Credentials,
     use_tls: bool,
-    app_uri: Option<String>,
+    app_uri: String,
     allow_destructive: bool,
 ) -> Result<()> {
     let channel = SiftChannelBuilder::new(credentials)

--- a/rust/crates/sift_mcp/src/lib.rs
+++ b/rust/crates/sift_mcp/src/lib.rs
@@ -15,7 +15,7 @@ mod tool;
 pub async fn run(
     credentials: Credentials,
     use_tls: bool,
-    rest_uri: String,
+    app_uri: Option<String>,
     allow_destructive: bool,
 ) -> Result<()> {
     let channel = SiftChannelBuilder::new(credentials)
@@ -24,7 +24,7 @@ pub async fn run(
         .build()
         .context("failed to build gRPC channel to connect to Sift")?;
 
-    let service = SiftMcpServer::new(channel, rest_uri, allow_destructive)
+    let service = SiftMcpServer::new(channel, app_uri, allow_destructive)
         .serve(stdio())
         .await
         .context("failed to start MCP server")?;

--- a/rust/crates/sift_mcp/src/server/mod.rs
+++ b/rust/crates/sift_mcp/src/server/mod.rs
@@ -76,7 +76,7 @@ impl ServerHandler for SiftMcpServer {
 }
 
 impl SiftMcpServer {
-    pub fn new(channel: SiftChannel, rest_uri: String, allow_destructive: bool) -> Self {
+    pub fn new(channel: SiftChannel, app_uri: Option<String>, allow_destructive: bool) -> Self {
         // Add more routers here as new tool groups are introduced, e.g.
         //   tool_router.merge(Self::ingestion_router())
         let mut tool_router = Self::assets_router();
@@ -100,7 +100,7 @@ impl SiftMcpServer {
         let asset_service = AssetService::new(channel.clone(), retry_policy.clone());
         let data_service = DataService::new(channel.clone(), retry_policy.clone());
         let channel_service = ChannelService::new(channel.clone(), retry_policy.clone());
-        let url_service = UrlService::new(rest_uri);
+        let url_service = UrlService::new(app_uri);
         let ingest_service = IngestService::new(channel.clone());
         let ping_service = PingService::new(channel.clone(), retry_policy.clone());
         let run_service = RunService::new(channel.clone(), retry_policy.clone());

--- a/rust/crates/sift_mcp/src/server/mod.rs
+++ b/rust/crates/sift_mcp/src/server/mod.rs
@@ -76,7 +76,7 @@ impl ServerHandler for SiftMcpServer {
 }
 
 impl SiftMcpServer {
-    pub fn new(channel: SiftChannel, app_uri: Option<String>, allow_destructive: bool) -> Self {
+    pub fn new(channel: SiftChannel, app_uri: String, allow_destructive: bool) -> Self {
         // Add more routers here as new tool groups are introduced, e.g.
         //   tool_router.merge(Self::ingestion_router())
         let mut tool_router = Self::assets_router();

--- a/rust/crates/sift_mcp/src/service/url/mod.rs
+++ b/rust/crates/sift_mcp/src/service/url/mod.rs
@@ -33,12 +33,12 @@ pub struct ExploreUrlRequest {
 
 #[derive(Clone)]
 pub struct UrlService {
-    rest_uri: String,
+    app_uri: Option<String>,
 }
 
 impl UrlService {
-    pub fn new(rest_uri: String) -> Self {
-        Self { rest_uri }
+    pub fn new(app_uri: Option<String>) -> Self {
+        Self { app_uri }
     }
 
     pub fn build_explore_url(&self, request: ExploreUrlRequest) -> Result<String, ErrorData> {
@@ -87,10 +87,19 @@ impl UrlService {
             ));
         }
 
-        let host = match explore_host {
-            Some(h) => h,
-            None => derive_web_host(&self.rest_uri)?,
-        };
+        let host = explore_host
+            .as_deref()
+            .map(str::trim)
+            .map(|host| host.trim_end_matches('/'))
+            .filter(|host| !host.is_empty())
+            .or_else(|| self.app_host().ok())
+            .ok_or_else(|| {
+                ErrorData::invalid_params(
+                    "could not build a Sift Explore URL because `app_uri` is not configured; \
+                     set it in the selected sift-cli profile or pass `explore_host`",
+                    None,
+                )
+            })?;
 
         let mut query = String::from("method=single");
         if let Some(v) = assets.as_ref().filter(|v| !v.is_empty()) {
@@ -127,58 +136,52 @@ impl UrlService {
         Ok(format!("{host}/explore?{query}"))
     }
 
-    /// Build the Sift web URL for a single report: `<host>/reports/<report_id>`.
-    /// The host is derived from `rest_uri`; there is no override for this URL
-    /// shape. Returns `INVALID_PARAMS` if the host cannot be derived (e.g. a
-    /// self-hosted `rest_uri` without an `api.` subdomain).
     pub fn build_report_url(&self, report_id: &str) -> Result<String, ErrorData> {
-        let host = derive_web_host(&self.rest_uri)?;
+        let host = self.app_host()?;
         Ok(format!("{host}/reports/{}", encode_value(report_id)))
     }
 
-    /// Build the Sift web URL for a single test report:
-    /// `<host>/test-results/<test_report_id>`. The host is derived from
-    /// `rest_uri`. Returns `INVALID_PARAMS` if the host cannot be derived (e.g. a
-    /// self-hosted `rest_uri` without an `api.` subdomain).
     pub fn build_test_report_url(&self, test_report_id: &str) -> Result<String, ErrorData> {
-        let host = derive_web_host(&self.rest_uri)?;
+        let host = self.app_host()?;
         Ok(format!(
             "{host}/test-results/{}",
             encode_value(test_report_id)
         ))
     }
 
-    /// Build the Sift web URL for a single rule: `<host>/rules/<rule_id>`. The
-    /// host is derived from `rest_uri`. Returns `INVALID_PARAMS` if the host
-    /// cannot be derived (e.g. a self-hosted `rest_uri` without an `api.`
-    /// subdomain).
     pub fn build_rule_url(&self, rule_id: &str) -> Result<String, ErrorData> {
-        let host = derive_web_host(&self.rest_uri)?;
+        let host = self.app_host()?;
         Ok(format!("{host}/rules/{}", encode_value(rule_id)))
     }
 
-    /// Build the Sift web URL for a single annotation:
-    /// `<host>/annotation/<annotation_id>`. The host is derived from `rest_uri`.
-    /// Returns `INVALID_PARAMS` if the host cannot be derived.
     pub fn build_annotation_url(&self, annotation_id: &str) -> Result<String, ErrorData> {
-        let host = derive_web_host(&self.rest_uri)?;
+        let host = self.app_host()?;
         Ok(format!("{host}/annotation/{}", encode_value(annotation_id)))
     }
 
-    /// Build the Sift web URL for a single asset: `<host>/asset/<asset_id>`. The
-    /// host is derived from `rest_uri`. Returns `INVALID_PARAMS` if the host
-    /// cannot be derived.
     pub fn build_asset_url(&self, asset_id: &str) -> Result<String, ErrorData> {
-        let host = derive_web_host(&self.rest_uri)?;
+        let host = self.app_host()?;
         Ok(format!("{host}/asset/{}", encode_value(asset_id)))
     }
 
-    /// Build the Sift web URL for a single run: `<host>/run/<run_id>`. The host
-    /// is derived from `rest_uri`. Returns `INVALID_PARAMS` if the host cannot be
-    /// derived.
     pub fn build_run_url(&self, run_id: &str) -> Result<String, ErrorData> {
-        let host = derive_web_host(&self.rest_uri)?;
+        let host = self.app_host()?;
         Ok(format!("{host}/run/{}", encode_value(run_id)))
+    }
+
+    fn app_host(&self) -> Result<&str, ErrorData> {
+        self.app_uri
+            .as_deref()
+            .map(str::trim)
+            .map(|host| host.trim_end_matches('/'))
+            .filter(|host| !host.is_empty())
+            .ok_or_else(|| {
+                ErrorData::invalid_params(
+                    "could not build a Sift web URL because `app_uri` is not configured in the \
+                     selected sift-cli profile",
+                    None,
+                )
+            })
     }
 }
 
@@ -192,16 +195,4 @@ fn join_encoded(values: &[String]) -> String {
         .map(|v| encode_value(v))
         .collect::<Vec<_>>()
         .join(",")
-}
-
-fn derive_web_host(rest_uri: &str) -> Result<String, ErrorData> {
-    let swapped = rest_uri.replacen("://api.", "://app.", 1);
-    if swapped == rest_uri {
-        return Err(ErrorData::invalid_params(
-            "could not derive Sift web host from `rest_uri` (no `api.` subdomain); pass \
-             `explore_host` explicitly",
-            None,
-        ));
-    }
-    Ok(swapped.split('/').take(3).collect::<Vec<_>>().join("/"))
 }

--- a/rust/crates/sift_mcp/src/service/url/mod.rs
+++ b/rust/crates/sift_mcp/src/service/url/mod.rs
@@ -28,16 +28,15 @@ pub struct ExploreUrlRequest {
     pub panel_type: Option<String>,
     pub start_time_unix_nanos: Option<i64>,
     pub end_time_unix_nanos: Option<i64>,
-    pub explore_host: Option<String>,
 }
 
 #[derive(Clone)]
 pub struct UrlService {
-    app_uri: Option<String>,
+    app_uri: String,
 }
 
 impl UrlService {
-    pub fn new(app_uri: Option<String>) -> Self {
+    pub fn new(app_uri: String) -> Self {
         Self { app_uri }
     }
 
@@ -49,7 +48,6 @@ impl UrlService {
             panel_type,
             start_time_unix_nanos,
             end_time_unix_nanos,
-            explore_host,
         } = request;
 
         let no_selection = assets.as_ref().is_none_or(|v| v.is_empty())
@@ -87,19 +85,7 @@ impl UrlService {
             ));
         }
 
-        let host = explore_host
-            .as_deref()
-            .map(str::trim)
-            .map(|host| host.trim_end_matches('/'))
-            .filter(|host| !host.is_empty())
-            .or_else(|| self.app_host().ok())
-            .ok_or_else(|| {
-                ErrorData::invalid_params(
-                    "could not build a Sift Explore URL because `app_uri` is not configured; \
-                     set it in the selected sift-cli profile or pass `explore_host`",
-                    None,
-                )
-            })?;
+        let host = self.app_host()?;
 
         let mut query = String::from("method=single");
         if let Some(v) = assets.as_ref().filter(|v| !v.is_empty()) {
@@ -170,18 +156,14 @@ impl UrlService {
     }
 
     fn app_host(&self) -> Result<&str, ErrorData> {
-        self.app_uri
-            .as_deref()
-            .map(str::trim)
-            .map(|host| host.trim_end_matches('/'))
-            .filter(|host| !host.is_empty())
-            .ok_or_else(|| {
-                ErrorData::invalid_params(
-                    "could not build a Sift web URL because `app_uri` is not configured in the \
+        let host = self.app_uri.trim().trim_end_matches('/');
+        (!host.is_empty()).then_some(host).ok_or_else(|| {
+            ErrorData::invalid_params(
+                "could not build a Sift web URL because `app_uri` is not configured in the \
                      selected sift-cli profile",
-                    None,
-                )
-            })
+                None,
+            )
+        })
     }
 }
 

--- a/rust/crates/sift_mcp/src/service/url/test.rs
+++ b/rust/crates/sift_mcp/src/service/url/test.rs
@@ -1,9 +1,9 @@
 use super::*;
 
-const REST_URI: &str = "https://api.siftstack.com";
+const APP_URI: &str = "https://app.siftstack.com";
 
 fn service() -> UrlService {
-    UrlService::new(REST_URI.to_string())
+    UrlService::new(Some(APP_URI.to_string()))
 }
 
 #[test]
@@ -94,11 +94,50 @@ fn empty_vecs_are_treated_as_missing() {
 }
 
 #[test]
-fn host_derivation_strips_rest_uri_path() {
-    let svc = UrlService::new(String::from("https://api.siftstack.com/v1"));
+fn configured_app_uri_trims_a_trailing_slash() {
+    let svc = UrlService::new(Some(String::from("https://sift.example.net/")));
     let url = svc
         .build_explore_url(ExploreUrlRequest {
             assets: Some(vec![String::from("a")]),
+            ..Default::default()
+        })
+        .unwrap();
+    assert!(
+        url.starts_with("https://sift.example.net/explore?"),
+        "got {url}"
+    );
+}
+
+#[test]
+fn slash_only_app_uri_is_treated_as_missing() {
+    let svc = UrlService::new(Some(String::from(" / ")));
+    let err = svc.build_report_url("rep-123").unwrap_err();
+    assert_eq!(err.code.0, -32602);
+}
+
+#[test]
+fn missing_app_uri_without_explore_host_errors() {
+    let svc = UrlService::new(None);
+    let err = svc
+        .build_explore_url(ExploreUrlRequest {
+            assets: Some(vec![String::from("a")]),
+            ..Default::default()
+        })
+        .unwrap_err();
+    assert_eq!(err.code.0, -32602);
+    assert!(
+        err.message.contains("app_uri") && err.message.contains("explore_host"),
+        "expected profile and request guidance, got `{}`",
+        err.message
+    );
+}
+
+#[test]
+fn slash_only_explore_host_uses_configured_app_uri() {
+    let url = service()
+        .build_explore_url(ExploreUrlRequest {
+            assets: Some(vec![String::from("a")]),
+            explore_host: Some(String::from(" / ")),
             ..Default::default()
         })
         .unwrap();
@@ -109,44 +148,42 @@ fn host_derivation_strips_rest_uri_path() {
 }
 
 #[test]
-fn unsupported_rest_uri_without_explore_host_errors() {
-    let svc = UrlService::new(String::from("https://my-self-hosted.example"));
-    let err = svc
+fn explore_host_takes_priority_over_configured_app_uri() {
+    let url = service()
         .build_explore_url(ExploreUrlRequest {
             assets: Some(vec![String::from("a")]),
+            explore_host: Some(String::from("https://override.example.net/")),
             ..Default::default()
         })
-        .unwrap_err();
-    assert_eq!(err.code.0, -32602);
+        .unwrap();
     assert!(
-        err.message.contains("explore_host"),
-        "expected guidance to point at explore_host, got `{}`",
-        err.message
+        url.starts_with("https://override.example.net/explore?"),
+        "got {url}"
     );
 }
 
 #[test]
-fn report_url_uses_derived_web_host() {
+fn report_url_uses_configured_app_uri() {
     let url = service().build_report_url("rep-123").unwrap();
     assert_eq!(url, "https://app.siftstack.com/reports/rep-123");
 }
 
 #[test]
-fn report_url_errors_when_host_cannot_be_derived() {
-    let svc = UrlService::new(String::from("https://my-self-hosted.example"));
+fn report_url_errors_without_app_uri() {
+    let svc = UrlService::new(None);
     let err = svc.build_report_url("rep-123").unwrap_err();
     assert_eq!(err.code.0, -32602);
 }
 
 #[test]
-fn rule_url_uses_derived_web_host() {
+fn rule_url_uses_configured_app_uri() {
     let url = service().build_rule_url("rule-123").unwrap();
     assert_eq!(url, "https://app.siftstack.com/rules/rule-123");
 }
 
 #[test]
-fn rule_url_errors_when_host_cannot_be_derived() {
-    let svc = UrlService::new(String::from("https://my-self-hosted.example"));
+fn rule_url_errors_without_app_uri() {
+    let svc = UrlService::new(None);
     let err = svc.build_rule_url("rule-123").unwrap_err();
     assert_eq!(err.code.0, -32602);
 }
@@ -169,8 +206,8 @@ fn annotation_asset_run_urls_use_singular_path_segments() {
 }
 
 #[test]
-fn annotation_asset_run_urls_error_when_host_cannot_be_derived() {
-    let svc = UrlService::new(String::from("https://my-self-hosted.example"));
+fn annotation_asset_run_urls_error_without_app_uri() {
+    let svc = UrlService::new(None);
     assert_eq!(
         svc.build_annotation_url("ann-1").unwrap_err().code.0,
         -32602

--- a/rust/crates/sift_mcp/src/service/url/test.rs
+++ b/rust/crates/sift_mcp/src/service/url/test.rs
@@ -3,7 +3,7 @@ use super::*;
 const APP_URI: &str = "https://app.siftstack.com";
 
 fn service() -> UrlService {
-    UrlService::new(Some(APP_URI.to_string()))
+    UrlService::new(APP_URI.to_string())
 }
 
 #[test]
@@ -16,7 +16,6 @@ fn full_url_with_all_params() {
             panel_type: Some(String::from("scatter-plot")),
             start_time_unix_nanos: Some(0),
             end_time_unix_nanos: Some(1_700_000_000_000_000_000),
-            explore_host: None,
         })
         .unwrap();
     assert_eq!(
@@ -95,7 +94,7 @@ fn empty_vecs_are_treated_as_missing() {
 
 #[test]
 fn configured_app_uri_trims_a_trailing_slash() {
-    let svc = UrlService::new(Some(String::from("https://sift.example.net/")));
+    let svc = UrlService::new(String::from("https://sift.example.net/"));
     let url = svc
         .build_explore_url(ExploreUrlRequest {
             assets: Some(vec![String::from("a")]),
@@ -110,56 +109,9 @@ fn configured_app_uri_trims_a_trailing_slash() {
 
 #[test]
 fn slash_only_app_uri_is_treated_as_missing() {
-    let svc = UrlService::new(Some(String::from(" / ")));
+    let svc = UrlService::new(String::from(" / "));
     let err = svc.build_report_url("rep-123").unwrap_err();
     assert_eq!(err.code.0, -32602);
-}
-
-#[test]
-fn missing_app_uri_without_explore_host_errors() {
-    let svc = UrlService::new(None);
-    let err = svc
-        .build_explore_url(ExploreUrlRequest {
-            assets: Some(vec![String::from("a")]),
-            ..Default::default()
-        })
-        .unwrap_err();
-    assert_eq!(err.code.0, -32602);
-    assert!(
-        err.message.contains("app_uri") && err.message.contains("explore_host"),
-        "expected profile and request guidance, got `{}`",
-        err.message
-    );
-}
-
-#[test]
-fn slash_only_explore_host_uses_configured_app_uri() {
-    let url = service()
-        .build_explore_url(ExploreUrlRequest {
-            assets: Some(vec![String::from("a")]),
-            explore_host: Some(String::from(" / ")),
-            ..Default::default()
-        })
-        .unwrap();
-    assert!(
-        url.starts_with("https://app.siftstack.com/explore?"),
-        "got {url}"
-    );
-}
-
-#[test]
-fn explore_host_takes_priority_over_configured_app_uri() {
-    let url = service()
-        .build_explore_url(ExploreUrlRequest {
-            assets: Some(vec![String::from("a")]),
-            explore_host: Some(String::from("https://override.example.net/")),
-            ..Default::default()
-        })
-        .unwrap();
-    assert!(
-        url.starts_with("https://override.example.net/explore?"),
-        "got {url}"
-    );
 }
 
 #[test]
@@ -169,23 +121,9 @@ fn report_url_uses_configured_app_uri() {
 }
 
 #[test]
-fn report_url_errors_without_app_uri() {
-    let svc = UrlService::new(None);
-    let err = svc.build_report_url("rep-123").unwrap_err();
-    assert_eq!(err.code.0, -32602);
-}
-
-#[test]
 fn rule_url_uses_configured_app_uri() {
     let url = service().build_rule_url("rule-123").unwrap();
     assert_eq!(url, "https://app.siftstack.com/rules/rule-123");
-}
-
-#[test]
-fn rule_url_errors_without_app_uri() {
-    let svc = UrlService::new(None);
-    let err = svc.build_rule_url("rule-123").unwrap_err();
-    assert_eq!(err.code.0, -32602);
 }
 
 #[test]
@@ -203,15 +141,4 @@ fn annotation_asset_run_urls_use_singular_path_segments() {
         svc.build_run_url("run-1").unwrap(),
         "https://app.siftstack.com/run/run-1"
     );
-}
-
-#[test]
-fn annotation_asset_run_urls_error_without_app_uri() {
-    let svc = UrlService::new(None);
-    assert_eq!(
-        svc.build_annotation_url("ann-1").unwrap_err().code.0,
-        -32602
-    );
-    assert_eq!(svc.build_asset_url("asset-1").unwrap_err().code.0, -32602);
-    assert_eq!(svc.build_run_url("run-1").unwrap_err().code.0, -32602);
 }

--- a/rust/crates/sift_mcp/src/startup.rs
+++ b/rust/crates/sift_mcp/src/startup.rs
@@ -1,0 +1,123 @@
+use std::future::{self, Future};
+
+use anyhow::{Context, Result};
+use rmcp::{
+    ErrorData, RoleServer, ServerHandler, ServiceExt,
+    model::{ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo},
+    service::{MaybeSendFuture, RequestContext},
+    transport::stdio,
+};
+
+struct StartupErrorServer {
+    message: String,
+}
+
+impl StartupErrorServer {
+    fn new(message: String) -> Self {
+        Self { message }
+    }
+
+    fn error(&self) -> ErrorData {
+        ErrorData::internal_error(
+            self.message.clone(),
+            Some(serde_json::json!({
+                "status": "stopped",
+                "reason": "AppUriRequired",
+                "diagnostic_command": "sift-cli agent doctor",
+            })),
+        )
+    }
+}
+
+impl ServerHandler for StartupErrorServer {
+    fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> impl Future<Output = std::result::Result<ListToolsResult, ErrorData>> + MaybeSendFuture + '_
+    {
+        future::ready(Err(self.error()))
+    }
+
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_instructions(self.message.clone())
+    }
+}
+
+pub async fn report_startup_error(message: String) -> Result<()> {
+    let service = StartupErrorServer::new(message)
+        .serve(stdio())
+        .await
+        .context("failed to start the MCP profile error server")?;
+    service
+        .waiting()
+        .await
+        .context("the MCP profile error server stopped unexpectedly")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rmcp::ServiceExt;
+    use serde_json::Value;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    use super::StartupErrorServer;
+
+    #[tokio::test]
+    async fn returns_the_reason_when_the_client_lists_tools() {
+        let (server_transport, client_transport) = tokio::io::duplex(4096);
+        let server = tokio::spawn(async move {
+            let service = StartupErrorServer::new("profile needs app_uri".to_string())
+                .serve(server_transport)
+                .await
+                .unwrap();
+            service.waiting().await.unwrap()
+        });
+        let (reader, mut writer) = tokio::io::split(client_transport);
+        let mut reader = BufReader::new(reader);
+
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": { "name": "test-client", "version": "0.0.1" }
+            }
+        });
+        writer
+            .write_all(format!("{request}\n").as_bytes())
+            .await
+            .unwrap();
+
+        let mut response = String::new();
+        reader.read_line(&mut response).await.unwrap();
+        let init_response: Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(
+            init_response["result"]["instructions"],
+            "profile needs app_uri"
+        );
+
+        writer
+            .write_all(b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n")
+            .await
+            .unwrap();
+        writer
+            .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}\n")
+            .await
+            .unwrap();
+
+        response.clear();
+        reader.read_line(&mut response).await.unwrap();
+        let tool_response: Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(tool_response["error"]["message"], "profile needs app_uri");
+        assert_eq!(tool_response["error"]["data"]["reason"], "AppUriRequired");
+
+        drop(writer);
+        drop(reader);
+        server.await.unwrap();
+    }
+}

--- a/rust/crates/sift_mcp/src/tool/annotations/test.rs
+++ b/rust/crates/sift_mcp/src/tool/annotations/test.rs
@@ -23,7 +23,7 @@ async fn server_with_mock(mock: MockAnnotationServiceImpl) -> (SiftMcpServer, Jo
     });
 
     (
-        SiftMcpServer::new(channel, Some(String::from("https://app.test.local")), true),
+        SiftMcpServer::new(channel, String::from("https://app.test.local"), true),
         handle,
     )
 }

--- a/rust/crates/sift_mcp/src/tool/annotations/test.rs
+++ b/rust/crates/sift_mcp/src/tool/annotations/test.rs
@@ -23,7 +23,7 @@ async fn server_with_mock(mock: MockAnnotationServiceImpl) -> (SiftMcpServer, Jo
     });
 
     (
-        SiftMcpServer::new(channel, String::from("https://api.test.local"), true),
+        SiftMcpServer::new(channel, Some(String::from("https://app.test.local")), true),
         handle,
     )
 }

--- a/rust/crates/sift_mcp/src/tool/assets/test.rs
+++ b/rust/crates/sift_mcp/src/tool/assets/test.rs
@@ -35,7 +35,7 @@ async fn server_with_mock_and_flag(
     (
         SiftMcpServer::new(
             channel,
-            Some(String::from("https://app.test.local")),
+            String::from("https://app.test.local"),
             allow_destructive,
         ),
         handle,

--- a/rust/crates/sift_mcp/src/tool/assets/test.rs
+++ b/rust/crates/sift_mcp/src/tool/assets/test.rs
@@ -35,7 +35,7 @@ async fn server_with_mock_and_flag(
     (
         SiftMcpServer::new(
             channel,
-            String::from("https://api.test.local"),
+            Some(String::from("https://app.test.local")),
             allow_destructive,
         ),
         handle,

--- a/rust/crates/sift_mcp/src/tool/channels/test.rs
+++ b/rust/crates/sift_mcp/src/tool/channels/test.rs
@@ -25,7 +25,7 @@ async fn server_with_mock(mock: MockChannelServiceImpl) -> (SiftMcpServer, JoinH
     });
 
     (
-        SiftMcpServer::new(channel, String::from("https://api.test.local"), true),
+        SiftMcpServer::new(channel, Some(String::from("https://app.test.local")), true),
         handle,
     )
 }

--- a/rust/crates/sift_mcp/src/tool/channels/test.rs
+++ b/rust/crates/sift_mcp/src/tool/channels/test.rs
@@ -25,7 +25,7 @@ async fn server_with_mock(mock: MockChannelServiceImpl) -> (SiftMcpServer, JoinH
     });
 
     (
-        SiftMcpServer::new(channel, Some(String::from("https://app.test.local")), true),
+        SiftMcpServer::new(channel, String::from("https://app.test.local"), true),
         handle,
     )
 }

--- a/rust/crates/sift_mcp/src/tool/docs/test.rs
+++ b/rust/crates/sift_mcp/src/tool/docs/test.rs
@@ -24,7 +24,7 @@ async fn server_with_mock(mock: MockDocsServiceImpl) -> (SiftMcpServer, JoinHand
             .unwrap();
     });
 
-    let server = SiftMcpServer::new(channel, Some("https://app.test.local".into()), true);
+    let server = SiftMcpServer::new(channel, "https://app.test.local".into(), true);
     (server, handle)
 }
 

--- a/rust/crates/sift_mcp/src/tool/docs/test.rs
+++ b/rust/crates/sift_mcp/src/tool/docs/test.rs
@@ -24,7 +24,7 @@ async fn server_with_mock(mock: MockDocsServiceImpl) -> (SiftMcpServer, JoinHand
             .unwrap();
     });
 
-    let server = SiftMcpServer::new(channel, "https://api.test.local".into(), true);
+    let server = SiftMcpServer::new(channel, Some("https://app.test.local".into()), true);
     (server, handle)
 }
 

--- a/rust/crates/sift_mcp/src/tool/explore/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/explore/mod.rs
@@ -19,7 +19,6 @@ pub struct ExploreUrlParams {
     panel_type: Option<String>,
     start_time_unix_nanos: Option<i64>,
     end_time_unix_nanos: Option<i64>,
-    explore_host: Option<String>,
 }
 
 #[tool_router(router = explore_router, vis = "pub(crate)")]
@@ -46,13 +45,9 @@ impl SiftMcpServer {
                 rejected with `INVALID_PARAMS`; the error message enumerates the accepted set.
               - `start_time_unix_nanos`, `end_time_unix_nanos`: optional time window. Provided as Unix nanoseconds
                 for parity with `get_data`; the tool converts to ISO 8601 UTC for the URL.
-              - `explore_host`: optional override for the Sift web host (e.g. `https://sift.example.net`). When
-                omitted the tool uses `app_uri` from the selected sift-cli profile.
-
             Errors:
               - `INVALID_PARAMS` if no selection or time parameter is set (the URL would be useless), if
-                `panel_type` is not in the known set, if `end_time_unix_nanos < start_time_unix_nanos`, or if the
-                selected sift-cli profile has no `app_uri` and `explore_host` is unset.
+                `panel_type` is not in the known set, or if `end_time_unix_nanos < start_time_unix_nanos`.
 
             Guidance:
               - Reach for this tool when the user asks to \"see\", \"view\", \"graph\", \"plot\", \"visualize\", or
@@ -71,7 +66,6 @@ impl SiftMcpServer {
             panel_type,
             start_time_unix_nanos,
             end_time_unix_nanos,
-            explore_host,
         }) = params;
 
         let url = self.url_service.build_explore_url(ExploreUrlRequest {
@@ -81,7 +75,6 @@ impl SiftMcpServer {
             panel_type,
             start_time_unix_nanos,
             end_time_unix_nanos,
-            explore_host,
         })?;
 
         let next_step = format!(

--- a/rust/crates/sift_mcp/src/tool/explore/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/explore/mod.rs
@@ -46,13 +46,13 @@ impl SiftMcpServer {
                 rejected with `INVALID_PARAMS`; the error message enumerates the accepted set.
               - `start_time_unix_nanos`, `end_time_unix_nanos`: optional time window. Provided as Unix nanoseconds
                 for parity with `get_data`; the tool converts to ISO 8601 UTC for the URL.
-              - `explore_host`: optional override for the Sift web host (e.g. `https://app.staging.siftstack.com`).
-                When omitted the host is derived from the server's configured `rest_uri`.
+              - `explore_host`: optional override for the Sift web host (e.g. `https://sift.example.net`). When
+                omitted the tool uses `app_uri` from the selected sift-cli profile.
 
             Errors:
               - `INVALID_PARAMS` if no selection or time parameter is set (the URL would be useless), if
                 `panel_type` is not in the known set, if `end_time_unix_nanos < start_time_unix_nanos`, or if the
-                Sift web host cannot be derived from `rest_uri` and `explore_host` is unset.
+                selected sift-cli profile has no `app_uri` and `explore_host` is unset.
 
             Guidance:
               - Reach for this tool when the user asks to \"see\", \"view\", \"graph\", \"plot\", \"visualize\", or

--- a/rust/crates/sift_mcp/src/tool/explore/test.rs
+++ b/rust/crates/sift_mcp/src/tool/explore/test.rs
@@ -10,7 +10,7 @@ const APP_URI: &str = "https://app.siftstack.com";
 async fn server_for_explore(app_uri: &str) -> SiftMcpServer {
     let (client, _server) = tokio::io::duplex(1024);
     let channel = memory_sift_channel(client).await;
-    SiftMcpServer::new(channel, Some(app_uri.to_string()), true)
+    SiftMcpServer::new(channel, app_uri.to_string(), true)
 }
 
 fn structured_field(result: rmcp::model::CallToolResult, key: &str) -> Value {
@@ -33,7 +33,6 @@ async fn handler_returns_structured_url_and_text_content() {
         panel_type: None,
         start_time_unix_nanos: None,
         end_time_unix_nanos: None,
-        explore_host: None,
     };
 
     let result = server.explore_url(Parameters(params)).await.unwrap();

--- a/rust/crates/sift_mcp/src/tool/explore/test.rs
+++ b/rust/crates/sift_mcp/src/tool/explore/test.rs
@@ -5,12 +5,12 @@ use sift_test_util::grpc::memory_sift_channel;
 use super::*;
 use crate::server::SiftMcpServer;
 
-const REST_URI: &str = "https://api.siftstack.com";
+const APP_URI: &str = "https://app.siftstack.com";
 
-async fn server_for_explore(rest_uri: &str) -> SiftMcpServer {
+async fn server_for_explore(app_uri: &str) -> SiftMcpServer {
     let (client, _server) = tokio::io::duplex(1024);
     let channel = memory_sift_channel(client).await;
-    SiftMcpServer::new(channel, rest_uri.to_string(), true)
+    SiftMcpServer::new(channel, Some(app_uri.to_string()), true)
 }
 
 fn structured_field(result: rmcp::model::CallToolResult, key: &str) -> Value {
@@ -25,7 +25,7 @@ fn structured_field(result: rmcp::model::CallToolResult, key: &str) -> Value {
 
 #[tokio::test]
 async fn handler_returns_structured_url_and_text_content() {
-    let server = server_for_explore(REST_URI).await;
+    let server = server_for_explore(APP_URI).await;
     let params = ExploreUrlParams {
         assets: Some(vec![String::from("Engine-7")]),
         runs: None,

--- a/rust/crates/sift_mcp/src/tool/reports/test.rs
+++ b/rust/crates/sift_mcp/src/tool/reports/test.rs
@@ -40,7 +40,7 @@ async fn server_with_mock(mock: MockReportServiceImpl) -> (SiftMcpServer, JoinHa
     });
 
     (
-        SiftMcpServer::new(channel, String::from("https://api.test.local"), true),
+        SiftMcpServer::new(channel, Some(String::from("https://app.test.local")), true),
         handle,
     )
 }

--- a/rust/crates/sift_mcp/src/tool/reports/test.rs
+++ b/rust/crates/sift_mcp/src/tool/reports/test.rs
@@ -40,7 +40,7 @@ async fn server_with_mock(mock: MockReportServiceImpl) -> (SiftMcpServer, JoinHa
     });
 
     (
-        SiftMcpServer::new(channel, Some(String::from("https://app.test.local")), true),
+        SiftMcpServer::new(channel, String::from("https://app.test.local"), true),
         handle,
     )
 }

--- a/rust/crates/sift_mcp/src/tool/runs/test.rs
+++ b/rust/crates/sift_mcp/src/tool/runs/test.rs
@@ -39,7 +39,7 @@ async fn server_with_mock(mock: MockRunServiceImpl) -> (SiftMcpServer, JoinHandl
     });
 
     (
-        SiftMcpServer::new(channel, String::from("https://api.test.local"), true),
+        SiftMcpServer::new(channel, Some(String::from("https://app.test.local")), true),
         handle,
     )
 }

--- a/rust/crates/sift_mcp/src/tool/runs/test.rs
+++ b/rust/crates/sift_mcp/src/tool/runs/test.rs
@@ -39,7 +39,7 @@ async fn server_with_mock(mock: MockRunServiceImpl) -> (SiftMcpServer, JoinHandl
     });
 
     (
-        SiftMcpServer::new(channel, Some(String::from("https://app.test.local")), true),
+        SiftMcpServer::new(channel, String::from("https://app.test.local"), true),
         handle,
     )
 }

--- a/rust/crates/sift_mcp/src/tool/test_reports/test.rs
+++ b/rust/crates/sift_mcp/src/tool/test_reports/test.rs
@@ -25,7 +25,7 @@ async fn server_with_mock(mock: MockTestReportServiceImpl) -> (SiftMcpServer, Jo
     });
 
     (
-        SiftMcpServer::new(channel, Some(String::from("https://app.test.local")), true),
+        SiftMcpServer::new(channel, String::from("https://app.test.local"), true),
         handle,
     )
 }

--- a/rust/crates/sift_mcp/src/tool/test_reports/test.rs
+++ b/rust/crates/sift_mcp/src/tool/test_reports/test.rs
@@ -25,7 +25,7 @@ async fn server_with_mock(mock: MockTestReportServiceImpl) -> (SiftMcpServer, Jo
     });
 
     (
-        SiftMcpServer::new(channel, String::from("https://api.test.local"), true),
+        SiftMcpServer::new(channel, Some(String::from("https://app.test.local")), true),
         handle,
     )
 }

--- a/rust/crates/sift_mcp/src/tool/users/test.rs
+++ b/rust/crates/sift_mcp/src/tool/users/test.rs
@@ -64,7 +64,7 @@ async fn server_with_mocks(
     });
 
     (
-        SiftMcpServer::new(channel, String::from("https://api.test.local"), false),
+        SiftMcpServer::new(channel, Some(String::from("https://app.test.local")), false),
         handle,
     )
 }

--- a/rust/crates/sift_mcp/src/tool/users/test.rs
+++ b/rust/crates/sift_mcp/src/tool/users/test.rs
@@ -64,7 +64,7 @@ async fn server_with_mocks(
     });
 
     (
-        SiftMcpServer::new(channel, Some(String::from("https://app.test.local")), false),
+        SiftMcpServer::new(channel, String::from("https://app.test.local"), false),
         handle,
     )
 }


### PR DESCRIPTION
- enforce `app_uri` is set in `sift-cli` profiles. includes pathways to warn, set, and educate the using on fixing them -- including a MCP startup path that denotes what the issue is if it is not set
- removes `explore_host `and replaces it with `app_uri`
- removes the places where we inferred / calculated `app_uri` by doing string manipulation against the `rest_uri`