### PR TITLE
rust(feat): Don't proceed with an empty list tool call

### DIFF
--- a/rust/crates/sift_cli/assets/skills/sift/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/sift/SKILL.md
@@ -79,6 +79,9 @@ exists.
 
 ## Rules that always apply
 
+- **Stop on empty list results.** If any `list_*` tool returns no items, tell
+  the user that nothing matched and ask how to proceed. Do not make subsequent
+  tool calls using an empty or placeholder name or id from the missing result.
 - **Surface URLs as plain text, in full.** The link from `explore_url` and the
   `View in Sift:` line from `sift-cli import` are deliverables. Never invent a
   URL that a tool did not return.

--- a/rust/crates/sift_mcp/CLAUDE.md
+++ b/rust/crates/sift_mcp/CLAUDE.md
@@ -508,8 +508,7 @@ against a value the caller only half knows. Every tool that takes a `filter` the
 ```
                 When filtering or searching, use `name.matches(\"(?i)rover\")`, not `==`. Use `==` only for an
                 exact value from a prior result. `contains`/`startsWith`/`endsWith` are case-SENSITIVE:
-                `contains(\"Rover\")` silently misses `rover-01`. An empty result is not proof of absence — retry
-                once with a shorter fragment.
+                `contains(\"Rover\")` silently misses `rover-01`.
 ```
 
 Write it as a direct instruction, and name the failure. "Prefer a pattern" states a preference the
@@ -528,8 +527,6 @@ Adapt it per resource; they are not uniform:
 - **`list_channels`** adds a line pointing at `contains` for a full literal name, because channel
   names embed `.` (`motor_d.current`), which is a regex wildcard. `list_users` adds the same line
   for `.` and `+` in email addresses.
-- **`count_test_steps`** and **`count_test_measurements`** return a number, not rows, so they say
-  "a count of 0 is not proof of absence".
 
 This guidance is not proto-sourced, so Step 5's "fix the proto first" rule does not apply. The
 string functions are behavior of the shared CEL filter engine, not of any one proto.

--- a/rust/crates/sift_mcp/src/tool/annotations/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/annotations/mod.rs
@@ -106,8 +106,7 @@ impl SiftMcpServer {
                 `metadata.{key}` (e.g. `metadata.severity == \"high\"`).
                 When filtering or searching, use `name.matches(\"(?i)vibration\")`, not `==`. Use `==` only for an
                 exact value from a prior result. `contains`/`startsWith`/`endsWith` are case-SENSITIVE:
-                `contains(\"Vibration\")` silently misses `vibration-check`. An empty result is not proof of
-                absence — retry once with a shorter fragment.
+                `contains(\"Vibration\")` silently misses `vibration-check`.
               - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `created_date`,
                 `modified_date`, `start_time`, `end_time`, `name`, `description`. Default sort is `created_date desc`
                 (newest first). Example: `\"start_time desc,name\"`.

--- a/rust/crates/sift_mcp/src/tool/assets/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/assets/mod.rs
@@ -45,8 +45,7 @@ impl SiftMcpServer {
                 When searching by name, use `name_lower.contains(\"rover\")`: `name_lower` is an indexed lowercase
                 copy of `name` and exists only on assets. On any other text field use `name.matches(\"(?i)rover\")`.
                 Use `==` only for an exact value from a prior result. `contains`/`startsWith`/`endsWith` are
-                case-SENSITIVE: `contains(\"Rover\")` silently misses `rover-01`. An empty result is not proof of
-                absence — retry once with a shorter fragment.
+                case-SENSITIVE: `contains(\"Rover\")` silently misses `rover-01`.
               - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `name`,
                 `created_date`, `modified_date`, `archived_date`. Default sort is `created_date desc` (newest first).
                 Example: `\"created_date desc,modified_date\"`.

--- a/rust/crates/sift_mcp/src/tool/channels/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/channels/mod.rs
@@ -27,9 +27,8 @@ impl SiftMcpServer {
                 `created_date`, `modified_date`, `created_by_user_id`, `modified_by_user_id`.
                 When filtering or searching, use `name.matches(\"(?i)motor\")`, not `==`. Use `==` only for an
                 exact value from a prior result. `contains`/`startsWith`/`endsWith` are case-SENSITIVE:
-                `contains(\"Motor\")` silently misses `motor_d.current`. An empty result is not proof of absence —
-                retry once with a shorter fragment. Channel names embed `.`, a regex wildcard, so match a full
-                literal name with `contains`, not `matches`.
+                `contains(\"Motor\")` silently misses `motor_d.current`. Channel names embed `.`, a regex wildcard,
+                so match a full literal name with `contains`, not `matches`.
               - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `name`,
                 `created_date`, `modified_date`, `active`. Default sort is `created_date` ascending (oldest first) —
                 note this differs from `list_assets` and `list_runs`. Example: `\"name,created_date desc\"`.

--- a/rust/crates/sift_mcp/src/tool/reports/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/reports/mod.rs
@@ -76,8 +76,7 @@ impl SiftMcpServer {
                 Reference metadata entries as `metadata.{key}` (e.g. `metadata.batch == \"nightly\"`).
                 When filtering or searching, use `name.matches(\"(?i)nightly\")`, not `==`. Use `==` only for an
                 exact value from a prior result. `contains`/`startsWith`/`endsWith` are case-SENSITIVE:
-                `contains(\"Nightly\")` silently misses `nightly-regression`. An empty result is not proof of
-                absence — retry once with a shorter fragment.
+                `contains(\"Nightly\")` silently misses `nightly-regression`.
               - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `name`,
                 `created_date`, `modified_date`. Default sort is `created_date desc` (newest first).
                 Example: `\"created_date desc,modified_date\"`.

--- a/rust/crates/sift_mcp/src/tool/rules/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/rules/mod.rs
@@ -75,8 +75,7 @@ impl SiftMcpServer {
                 Reference metadata entries as `metadata.{key}` (e.g. `metadata.severity == \"high\"`).
                 When filtering or searching, use `name.matches(\"(?i)avionics\")`, not `==`. Use `==` only for an
                 exact value from a prior result. `contains`/`startsWith`/`endsWith` are case-SENSITIVE:
-                `contains(\"Avionics\")` silently misses `avionics-power-limit`. An empty result is not proof of
-                absence — retry once with a shorter fragment.
+                `contains(\"Avionics\")` silently misses `avionics-power-limit`.
                 Folder membership is filterable via `folders` and `activeFolders` (folder-id lists;
                 `activeFolders` excludes archived folders): `\"<folder_id>\" in folders` returns rules in a
                 folder, `size(activeFolders) == 0` returns uncategorized rules.
@@ -137,8 +136,7 @@ impl SiftMcpServer {
                 `user_notes` and `change_message` are the text fields. When filtering or searching them, use
                 `change_message.matches(\"(?i)asset\")`, not `==`. Use `==` only for an exact value from a prior
                 result. `contains`/`startsWith`/`endsWith` are case-SENSITIVE: `contains(\"Asset\")` silently
-                misses `asset renamed`. An empty result is not proof of absence — retry once with a shorter
-                fragment.
+                misses `asset renamed`.
               - `limit`: max items to return. Start at 50 and only raise it if the result is capped
                 and you still need more. Values are clamped to `1..=200`; omitting it defaults to 50.
 

--- a/rust/crates/sift_mcp/src/tool/runs/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/runs/mod.rs
@@ -54,8 +54,7 @@ impl SiftMcpServer {
                 `duration(...)` helper, e.g. `duration_string > duration('10h')`.
                 When filtering or searching, use `name.matches(\"(?i)rover\")`, not `==`. Use `==` only for an
                 exact value from a prior result. `contains`/`startsWith`/`endsWith` are case-SENSITIVE:
-                `contains(\"Rover\")` silently misses `rover-01`. An empty result is not proof of absence — retry
-                once with a shorter fragment.
+                `contains(\"Rover\")` silently misses `rover-01`.
               - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `name`,
                 `description`, `created_date`, `modified_date`, `start_time`, `stop_time`. Default sort is
                 `created_date desc` (newest first). Example: `\"created_date desc,modified_date\"`.

--- a/rust/crates/sift_mcp/src/tool/test_reports/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/test_reports/mod.rs
@@ -69,7 +69,7 @@ impl SiftMcpServer {
                 When filtering or searching the text fields (`name`, `test_case`, `serial_number`), use
                 `name.matches(\"(?i)vibe\")`, not `==`. Use `==` only for an exact value from a prior result.
                 `contains`/`startsWith`/`endsWith` are case-SENSITIVE: `contains(\"Vibe\")` silently misses
-                `vibe-test-2`. An empty result is not proof of absence — retry once with a shorter fragment.
+                `vibe-test-2`.
               - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `test_report_id`,
                 `name`, `test_system_name`, `test_case`, `start_time`, `end_time`, `created_date`, `modified_date`.
                 Default sort is `start_time desc` (newest first). Example: `\"start_time desc,name\"`.
@@ -127,7 +127,7 @@ impl SiftMcpServer {
                 When filtering or searching `name`, `description`, or `error_message`, use
                 `name.matches(\"(?i)power\")`, not `==`. Use `==` only for an exact value from a prior result.
                 `contains`/`startsWith`/`endsWith` are case-SENSITIVE: `contains(\"Power\")` silently misses
-                `power-on`. An empty result is not proof of absence — retry once with a shorter fragment.
+                `power-on`.
               - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `test_step_id`,
                 `name`, `step_type`, `step_path`, `status`, `start_time`, `end_time`, `created_date`,
                 `modified_date`. Default sort is `step_path` ascending (tree order). Example:
@@ -187,8 +187,7 @@ impl SiftMcpServer {
                 `TEST_MEASUREMENT_TYPE_BOOLEAN`, `TEST_MEASUREMENT_TYPE_LIMIT`.
                 When filtering or searching `name`, use `name.matches(\"(?i)voltage\")`, not `==`. Use `==` only
                 for an exact value from a prior result. `contains`/`startsWith`/`endsWith` are case-SENSITIVE:
-                `contains(\"Voltage\")` silently misses `voltage_bus_a`. An empty result is not proof of absence —
-                retry once with a shorter fragment.
+                `contains(\"Voltage\")` silently misses `voltage_bus_a`.
               - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `measurement_id`,
                 `name`, `measurement_type`, `test_step_id`, `test_report_id`, `passed`, `timestamp`,
                 `created_date`, `modified_date`. Default sort is `timestamp` ascending. Example:
@@ -241,8 +240,7 @@ impl SiftMcpServer {
                 `created_date`, `modified_date`, `metadata`. When filtering `name`, `description`, or
                 `error_message`, use `name.matches(\"(?i)power\")`, not `==`. Use `==` only for an exact value from
                 a prior result. `contains`/`startsWith`/`endsWith` are case-SENSITIVE: `contains(\"Power\")`
-                silently misses `power-on`. A count of 0 is not proof of absence — retry once with a shorter
-                fragment.
+                silently misses `power-on`.
 
             Errors:
               - `INVALID_PARAMS` if `filter` is not a valid CEL expression.
@@ -280,7 +278,7 @@ impl SiftMcpServer {
                 `timestamp`, `created_date`, `modified_date`, `metadata`. When filtering `name`, use
                 `name.matches(\"(?i)voltage\")`, not `==`. Use `==` only for an exact value from a prior result.
                 `contains`/`startsWith`/`endsWith` are case-SENSITIVE: `contains(\"Voltage\")` silently misses
-                `voltage_bus_a`. A count of 0 is not proof of absence — retry once with a shorter fragment.
+                `voltage_bus_a`.
 
             Errors:
               - `INVALID_PARAMS` if `filter` is not a valid CEL expression.

--- a/rust/crates/sift_mcp/src/tool/users/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/users/mod.rs
@@ -42,9 +42,9 @@ impl SiftMcpServer {
               - `filter`: CEL expression over `user_id` and `name` (`name` is the user's `user_name`). Pass an empty
                 string to list everyone. When searching for a person, use `name.matches(\"(?i)jane\")`, not `==`.
                 Use `==` only for an exact address from a prior result. `contains`/`startsWith`/`endsWith` are
-                case-SENSITIVE: `contains(\"Jane\")` silently misses `jane@siftstack.com`. An empty result is not
-                proof of absence — retry once with a shorter fragment. `name.matches(\"(?i)^(jane|john)@\")`
-                resolves several people at once; `user_id in [\"<uuid>\"]` maps ids back to names. Addresses
+                case-SENSITIVE: `contains(\"Jane\")` silently misses `jane@siftstack.com`.
+                `name.matches(\"(?i)^(jane|john)@\")` resolves several people at once;
+                `user_id in [\"<uuid>\"]` maps ids back to names. Addresses
                 contain `.` and `+`, both regex metacharacters, so use `contains` to match one literally.
               - `order_by`: optional comma-separated `FIELD_NAME[ desc]` list. Orderable fields: `name`,
                 `created_date`, `modified_date`; with `include_inactive` set, only `created_date` and


### PR DESCRIPTION
Guides the sift-cli to not proceed with an empty list tool result. When a tool call receives an empty result, it would sometimes attempt to make a subsequent tool call using an empty string as a result of a previous empty response.