### PR TITLE
rust(chore): Feature Flag test_reports

### DIFF
--- a/rust/crates/sift_cli/assets/skills/sift/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/sift/SKILL.md
@@ -52,6 +52,9 @@ exists.
 - **Report detail:** `list_report_rule_summaries`.
 - **Test results:** `list_test_reports`, `list_test_steps`,
   `list_test_measurements`, `count_test_steps`, `count_test_measurements`.
+  These, along with the `create_test_report` and `append_test_measurements`
+  writes below, are gated behind the `test-reports` Cargo feature (default on).
+  A server built with `--no-default-features` will not expose them.
 - **Data:** `get_data` writes channel data to a Parquet file. `sql` queries
   Parquet files. `upload_dataset` streams a Parquet dataset into Sift.
 - **Links:** `explore_url`.

--- a/rust/crates/sift_mcp/CLAUDE.md
+++ b/rust/crates/sift_mcp/CLAUDE.md
@@ -629,6 +629,30 @@ and `derive_and_upload` are the reference implementations.
 
 ---
 
+## Reference — feature flags
+
+The crate defines Cargo features to let downstream consumers strip individual tool domains from
+the built server. Feature-gated modules follow the same rules as everything else, plus these:
+
+- **`test-reports`** (default on). Gates `service::test_reports`, `tool::test_reports`, the
+  `test_report_service` field and its construction in `server/mod.rs`, the
+  `Self::test_reports_router()` merge, and `UrlService::build_test_report_url`. Building with
+  `--no-default-features` yields a server without the `list_test_reports`, `list_test_steps`,
+  `list_test_measurements`, `count_test_steps`, `count_test_measurements`, `create_test_report`,
+  and `append_test_measurements` tools. All other tools remain available.
+
+When gating a domain behind a feature:
+
+- Wrap every declaration and reference — `pub mod`, `use`, struct field, service construction,
+  router merge, `Self { ... }` init, and any helper on a cross-domain service (see
+  `UrlService::build_test_report_url`) that only that domain calls.
+- Verify both `cargo build -p sift_mcp` and `cargo build -p sift_mcp --no-default-features`
+  build clean, with no dead-code warnings from unused helpers left behind.
+- Update the tool inventory in `rust/crates/sift_cli/assets/skills/sift/SKILL.md` to name the
+  feature next to the affected tools, so agents know why a tool they expected may be missing.
+
+---
+
 ## Pre-merge checklist
 
 Run through this before declaring the tool done:

--- a/rust/crates/sift_mcp/Cargo.toml
+++ b/rust/crates/sift_mcp/Cargo.toml
@@ -32,7 +32,6 @@ polars = { workspace = true, features = ["lazy", "parquet", "sql"] }
 tokio-stream.workspace = true
 
 [features]
-default = ["test-reports"]
 test-reports = []
 
 [dev-dependencies]

--- a/rust/crates/sift_mcp/Cargo.toml
+++ b/rust/crates/sift_mcp/Cargo.toml
@@ -31,6 +31,10 @@ parquet.workspace = true
 polars = { workspace = true, features = ["lazy", "parquet", "sql"] }
 tokio-stream.workspace = true
 
+[features]
+default = ["test-reports"]
+test-reports = []
+
 [dev-dependencies]
 sift_test_util.workspace = true
 tokio-stream.workspace = true

--- a/rust/crates/sift_mcp/src/server/mod.rs
+++ b/rust/crates/sift_mcp/src/server/mod.rs
@@ -10,14 +10,14 @@ use rmcp::{
 use sift_rs::SiftChannel;
 
 use crate::policy::RetryPolicy;
+#[cfg(feature = "test-reports")]
+use crate::service::test_reports::TestReportService;
 use crate::service::{
     annotations::AnnotationService, assets::AssetService, channels::ChannelService,
     data::DataService, docs::DocsService, ingest::IngestService, ping::PingService,
     report_templates::ReportTemplateService, reports::ReportService, rules::RuleService,
     runs::RunService, url::UrlService, users::UserService,
 };
-#[cfg(feature = "test-reports")]
-use crate::service::test_reports::TestReportService;
 
 #[derive(Clone)]
 pub struct SiftMcpServer {

--- a/rust/crates/sift_mcp/src/server/mod.rs
+++ b/rust/crates/sift_mcp/src/server/mod.rs
@@ -14,8 +14,10 @@ use crate::service::{
     annotations::AnnotationService, assets::AssetService, channels::ChannelService,
     data::DataService, docs::DocsService, ingest::IngestService, ping::PingService,
     report_templates::ReportTemplateService, reports::ReportService, rules::RuleService,
-    runs::RunService, test_reports::TestReportService, url::UrlService, users::UserService,
+    runs::RunService, url::UrlService, users::UserService,
 };
+#[cfg(feature = "test-reports")]
+use crate::service::test_reports::TestReportService;
 
 #[derive(Clone)]
 pub struct SiftMcpServer {
@@ -33,6 +35,7 @@ pub struct SiftMcpServer {
     pub report_service: ReportService,
     pub report_template_service: ReportTemplateService,
     pub rule_service: RuleService,
+    #[cfg(feature = "test-reports")]
     pub test_report_service: TestReportService,
     pub docs_service: DocsService,
     pub user_service: UserService,
@@ -93,6 +96,7 @@ impl SiftMcpServer {
         tool_router.merge(Self::ping_router());
         tool_router.merge(Self::rules_router());
         tool_router.merge(Self::annotations_router());
+        #[cfg(feature = "test-reports")]
         tool_router.merge(Self::test_reports_router());
         tool_router.merge(Self::docs_router());
         tool_router.merge(Self::users_router());
@@ -113,6 +117,7 @@ impl SiftMcpServer {
         let report_template_service =
             ReportTemplateService::new(channel.clone(), retry_policy.clone());
         let rule_service = RuleService::new(channel.clone(), retry_policy.clone());
+        #[cfg(feature = "test-reports")]
         let test_report_service = TestReportService::new(channel.clone(), retry_policy.clone());
         let docs_service = DocsService::new(channel.clone(), retry_policy.clone());
         let user_service = UserService::new(channel.clone(), retry_policy);
@@ -129,6 +134,7 @@ impl SiftMcpServer {
             report_service,
             report_template_service,
             rule_service,
+            #[cfg(feature = "test-reports")]
             test_report_service,
             docs_service,
             user_service,

--- a/rust/crates/sift_mcp/src/service/mod.rs
+++ b/rust/crates/sift_mcp/src/service/mod.rs
@@ -9,6 +9,7 @@ pub mod report_templates;
 pub mod reports;
 pub mod rules;
 pub mod runs;
+#[cfg(feature = "test-reports")]
 pub mod test_reports;
 pub mod url;
 pub mod users;

--- a/rust/crates/sift_mcp/src/service/url/mod.rs
+++ b/rust/crates/sift_mcp/src/service/url/mod.rs
@@ -127,6 +127,7 @@ impl UrlService {
         Ok(format!("{host}/reports/{}", encode_value(report_id)))
     }
 
+    #[cfg(feature = "test-reports")]
     pub fn build_test_report_url(&self, test_report_id: &str) -> Result<String, ErrorData> {
         let host = self.app_host()?;
         Ok(format!(

--- a/rust/crates/sift_mcp/src/tool/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/mod.rs
@@ -10,5 +10,6 @@ pub mod report_templates;
 pub mod reports;
 pub mod rules;
 pub mod runs;
+#[cfg(feature = "test-reports")]
 pub mod test_reports;
 pub mod users;


### PR DESCRIPTION
# Description

Feature Flags `test_reports` associated tools in MCP. Would need to be installed with:
`cargo install --path crates/sift_cli --features test-reports`

Tools that are flagged:
  - list_test_reports (read)
  - list_test_steps (read)
  - list_test_measurements (read)
  - count_test_steps (read)
  - count_test_measurements (read)
  - create_test_report (additive write)
  - append_test_measurements (additive write)

Also, updates associated documentation. When we assess how to personalize the flags based on what flags they have, we can conditionally compile the feature flagged doc pages too. For now we just tag them