### PR TITLE
feat: MCP check for updates

### DIFF
--- a/rust/crates/sift_cli/assets/skills/sift/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/sift/SKILL.md
@@ -69,8 +69,9 @@ exists.
 
 ## Workflows that span tools
 
-- **Start a Sift session.** If `check_for_updates` is available, call it once
-  before the first other Sift tool. If it reports `update_available`, relay its
+- **Start a Sift session.** If `check_for_updates` is available, call it once at
+  the start of each session. Call it before any other Sift tool. If it reports
+  `update_available`, relay its
   `message` and exact `install_command`. If it reports `unavailable`, continue
   with the requested Sift task.
 - **Search a list.** Filter with a pattern rather than an exact match. Each

--- a/rust/crates/sift_cli/assets/skills/sift/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/sift/SKILL.md
@@ -46,6 +46,9 @@ Each tool's own description carries its parameters, filters, defaults, and
 errors. Read the tool schema instead of guessing. This map only tells you what
 exists.
 
+- **Setup:** When available, `check_for_updates` reports the installed sift-cli
+  version, the latest stable version, and the exact installer command. Servers
+  started with `--disable-update-check` omit this tool.
 - **Discovery:** `list_assets`, `list_runs`, `list_channels`, `list_reports`,
   `list_report_templates`, `list_rules`, `list_rule_versions`, `list_annotations`.
 - **People:** `list_users`.
@@ -66,6 +69,10 @@ exists.
 
 ## Workflows that span tools
 
+- **Start a Sift session.** If `check_for_updates` is available, call it once
+  before the first other Sift tool. If it reports `update_available`, relay its
+  `message` and exact `install_command`. If it reports `unavailable`, continue
+  with the requested Sift task.
 - **Search a list.** Filter with a pattern rather than an exact match. Each
   tool's description names its own filterable fields. When the request is too
   vague to filter on, sample with a small `limit` and ask the user to narrow

--- a/rust/crates/sift_cli/assets/skills/sift/references/agent-setup.md
+++ b/rust/crates/sift_cli/assets/skills/sift/references/agent-setup.md
@@ -4,7 +4,7 @@ Use the CLI lifecycle instead of editing one client's MCP configuration or
 skill:
 
 - Run `sift-cli agent doctor` to diagnose setup. It checks the installed
-  profile, access mode, and profile `app_uri` without a change.
+  profile, access mode, update-check setting, and profile `app_uri`.
 - Treat `app_uri` as a required profile field. Doctor treats a missing or
   unusable value as an error. The `mcp` command returns the same reason when the
   client lists its tools. For PubCloud or GovCloud, relay the exact config
@@ -21,11 +21,12 @@ skill:
   release-matched skill and read-only MCP registration for every detected
   client using the default Sift profile. If the user selected a named profile,
   pass it as `sift-cli agent install --profile <name>`. Run the command when the
-  user asks you to install or approves the change.
+  user asks you to install or approves the change. Add
+  `--disable-update-check` only when the user requests it.
 - Run `sift-cli agent update` to refresh every detected client together. It
-  preserves the existing profile and access mode. Switch every client to another
-  named profile with `sift-cli agent update --profile <name>`, or return them to
-  the default with `sift-cli agent update --default-profile`.
+  preserves the existing profile, access mode, and update-check setting. Use
+  `--disable-update-check` or `--enable-update-check` to change the setting for
+  every client.
 - If the CLI is outdated, relay the exact curl or PowerShell installer printed
   by `agent doctor` or `agent update`. After the user updates `sift-cli`, rerun
   `sift-cli agent update`.
@@ -33,7 +34,8 @@ skill:
   access modes, ask the user to choose `sift-cli agent update --read-only`,
   `--allow-create`, or `--allow-destructive`. If it reports mixed profiles,
   ask for the intended profile and use `sift-cli agent update --profile <name>`
-  or `sift-cli agent update --default-profile`.
+  or `sift-cli agent update --default-profile`. For mixed update-check settings,
+  use `--enable-update-check` or `--disable-update-check`.
 
 ## Access modes
 

--- a/rust/crates/sift_cli/src/cli/mod.rs
+++ b/rust/crates/sift_cli/src/cli/mod.rs
@@ -85,6 +85,10 @@ pub struct McpArgs {
     /// relaunch the server with this flag. Also enables create tools.
     #[arg(long)]
     pub allow_destructive: bool,
+
+    /// Disable the MCP update tool and all automatic release checks
+    #[arg(long)]
+    pub disable_update_check: bool,
 }
 
 /// Serve the bundled Sift CLI user documentation over HTTP.

--- a/rust/crates/sift_cli/src/cli/mod.rs
+++ b/rust/crates/sift_cli/src/cli/mod.rs
@@ -113,10 +113,10 @@ pub enum AgentCmd {
     /// Install every detected client in safe mode using the default profile unless selected
     Install(AgentInstallArgs),
 
-    /// Refresh every detected client while preserving its profile and access mode
+    /// Refresh every client while preserving its profile, access, and update-check settings
     Update(AgentUpdateArgs),
 
-    /// Check the CLI version, skill files, MCP profiles, and access modes
+    /// Check the CLI version, skill files, MCP profiles, access, and update-check settings
     Doctor,
 
     /// Remove Sift-owned agent files and registrations
@@ -133,6 +133,10 @@ pub struct AgentInstallArgs {
     /// Also enables create tools.
     #[arg(long)]
     pub allow_destructive: bool,
+
+    /// Disable release checks in every installed MCP server
+    #[arg(long)]
+    pub disable_update_check: bool,
 }
 
 #[derive(clap::Args)]
@@ -153,6 +157,14 @@ pub struct AgentUpdateArgs {
     /// Switch every detected MCP client back to the default profile
     #[arg(long, conflicts_with = "profile")]
     pub default_profile: bool,
+
+    /// Disable release checks in every detected MCP server
+    #[arg(long, conflicts_with = "enable_update_check")]
+    pub disable_update_check: bool,
+
+    /// Enable release checks in every detected MCP server
+    #[arg(long, conflicts_with = "disable_update_check")]
+    pub enable_update_check: bool,
 }
 
 #[derive(Subcommand)]

--- a/rust/crates/sift_cli/src/cmd/agent/config.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/config.rs
@@ -423,6 +423,9 @@ fn mcp_args(registration: &Registration) -> Vec<String> {
         AccessMode::Create => args.push("--allow-create".to_string()),
         AccessMode::Destructive => args.push("--allow-destructive".to_string()),
     }
+    if registration.disable_update_check {
+        args.push("--disable-update-check".to_string());
+    }
     args
 }
 
@@ -582,7 +585,11 @@ fn classify_command(command: &str, args: &[String], environment: &Environment) -
 }
 
 fn registration_from_args(args: &[String]) -> Option<Registration> {
-    match args {
+    let (base_args, disable_update_check) = match args.split_last() {
+        Some((flag, base_args)) if flag == "--disable-update-check" => (base_args, true),
+        _ => (args, false),
+    };
+    let registration = match base_args {
         [mcp] if mcp == "mcp" => Some(Registration::new(AccessMode::ReadOnly, Profile::Default)),
         [mcp, access] if mcp == "mcp" => {
             access_from_flag(access).map(|a| Registration::new(a, Profile::Default))
@@ -601,7 +608,8 @@ fn registration_from_args(args: &[String]) -> Option<Registration> {
             access_from_flag(access).map(|a| Registration::new(a, Profile::Named(profile.clone())))
         }
         _ => None,
-    }
+    }?;
+    Some(registration.with_update_check_disabled(disable_update_check))
 }
 
 fn access_from_flag(flag: &str) -> Option<AccessMode> {
@@ -960,6 +968,21 @@ mod tests {
             ]))
             .is_some()
         );
+        assert!(registration_from_args(&args(&["mcp", "--disable-update-check"])).is_some());
+        assert!(
+            registration_from_args(&args(&["mcp", "--allow-create", "--disable-update-check",]))
+                .is_some()
+        );
+        assert!(
+            registration_from_args(&args(&[
+                "mcp",
+                "--profile",
+                "localdev",
+                "--allow-destructive",
+                "--disable-update-check",
+            ]))
+            .is_some()
+        );
 
         for custom in [
             args(&["mcp", "--custom"]),
@@ -971,6 +994,17 @@ mod tests {
         ] {
             assert_eq!(registration_from_args(&custom), None);
         }
+    }
+
+    #[test]
+    fn disabled_update_check_round_trips_through_managed_args() {
+        let registration = Registration::new(AccessMode::Create, Profile::Default)
+            .with_update_check_disabled(true);
+
+        let args = mcp_args(&registration);
+
+        assert_eq!(args, ["mcp", "--allow-create", "--disable-update-check"]);
+        assert_eq!(registration_from_args(&args), Some(registration));
     }
 
     #[test]

--- a/rust/crates/sift_cli/src/cmd/agent/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/mod.rs
@@ -236,7 +236,7 @@ async fn print_install_update_notice() {
         Ok(current) => current,
         Err(_) => return,
     };
-    let Ok(Some(latest)) = version::latest_with_cache(&current).await else {
+    let Ok(Some(latest)) = version::latest_with_cache().await else {
         return;
     };
     if let Some(message) = version::outdated_warning(&current, &latest) {
@@ -944,7 +944,7 @@ async fn check_release() -> bool {
             "{} for a newer sift-cli release...",
             "Checking".green()
         ));
-        version::latest_with_cache(&current).await
+        version::latest_with_cache().await
     };
     match latest {
         Ok(Some(latest)) if latest > current => {

--- a/rust/crates/sift_cli/src/cmd/agent/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/mod.rs
@@ -200,7 +200,7 @@ impl Environment {
     }
 }
 
-pub fn install(profile: Option<String>, args: AgentInstallArgs) -> Result<ExitCode> {
+pub async fn install(profile: Option<String>, args: AgentInstallArgs) -> Result<ExitCode> {
     let access = if args.allow_destructive {
         AccessMode::Destructive
     } else if args.allow_create {
@@ -209,7 +209,24 @@ pub fn install(profile: Option<String>, args: AgentInstallArgs) -> Result<ExitCo
         AccessMode::ReadOnly
     };
     let registration = Registration::new(access, Profile::from_option(profile));
-    install_environment(&Environment::discover()?, "Installed", &registration)
+    let result = install_environment(&Environment::discover()?, "Installed", &registration)?;
+    if result == ExitCode::SUCCESS {
+        print_install_update_notice().await;
+    }
+    Ok(result)
+}
+
+async fn print_install_update_notice() {
+    let current = match Version::parse(env!("CARGO_PKG_VERSION")) {
+        Ok(current) => current,
+        Err(_) => return,
+    };
+    let Ok(Some(latest)) = version::latest_with_cache(&current).await else {
+        return;
+    };
+    if let Some(message) = version::outdated_warning(&current, &latest) {
+        println!("\n{message}\n");
+    }
 }
 
 pub async fn update(profile: Option<String>, args: AgentUpdateArgs) -> Result<ExitCode> {
@@ -842,7 +859,7 @@ async fn check_release() -> bool {
             "{} for a newer sift-cli release...",
             "Checking".green()
         ));
-        version::fetch_latest().await
+        version::latest_with_cache(&current).await
     };
     match latest {
         Ok(Some(latest)) if latest > current => {

--- a/rust/crates/sift_cli/src/cmd/agent/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/mod.rs
@@ -91,15 +91,29 @@ impl Profile {
 pub(super) struct Registration {
     access: AccessMode,
     profile: Profile,
+    disable_update_check: bool,
 }
 
 impl Registration {
     fn new(access: AccessMode, profile: Profile) -> Self {
-        Self { access, profile }
+        Self {
+            access,
+            profile,
+            disable_update_check: false,
+        }
+    }
+
+    fn with_update_check_disabled(mut self, disabled: bool) -> Self {
+        self.disable_update_check = disabled;
+        self
     }
 
     fn label(&self) -> String {
-        format!("{}, {}", self.access.label(), self.profile.label())
+        let mut label = format!("{}, {}", self.access.label(), self.profile.label());
+        if self.disable_update_check {
+            label.push_str(", update check disabled");
+        }
+        label
     }
 }
 
@@ -208,7 +222,8 @@ pub async fn install(profile: Option<String>, args: AgentInstallArgs) -> Result<
     } else {
         AccessMode::ReadOnly
     };
-    let registration = Registration::new(access, Profile::from_option(profile));
+    let registration = Registration::new(access, Profile::from_option(profile))
+        .with_update_check_disabled(args.disable_update_check);
     let result = install_environment(&Environment::discover()?, "Installed", &registration)?;
     if result == ExitCode::SUCCESS {
         print_install_update_notice().await;
@@ -264,12 +279,21 @@ pub async fn update(profile: Option<String>, args: AgentUpdateArgs) -> Result<Ex
     } else {
         profile.map(Profile::Named)
     };
+    let requested_update_check = if args.disable_update_check {
+        Some(true)
+    } else if args.enable_update_check {
+        Some(false)
+    } else {
+        None
+    };
 
     let unresolved_access =
         requested_access.is_none() && matches!(&inference.access, AccessInference::Mixed);
     let unresolved_profile =
         requested_profile.is_none() && matches!(&inference.profile, ProfileInference::Mixed);
-    if unresolved_access || unresolved_profile {
+    let unresolved_update_check = requested_update_check.is_none()
+        && matches!(&inference.update_check, UpdateCheckInference::Mixed);
+    if unresolved_access || unresolved_profile || unresolved_update_check {
         println!("No changes were made because detected MCP clients are not configured uniformly.");
         if unresolved_access {
             println!(
@@ -278,6 +302,11 @@ pub async fn update(profile: Option<String>, args: AgentUpdateArgs) -> Result<Ex
         }
         if unresolved_profile {
             println!("- Profiles are mixed. Choose `--profile <name>` or `--default-profile`.");
+        }
+        if unresolved_update_check {
+            println!(
+                "- Update checks are mixed. Choose `--enable-update-check` or `--disable-update-check`."
+            );
         }
         return Ok(ExitCode::FAILURE);
     }
@@ -290,7 +319,13 @@ pub async fn update(profile: Option<String>, args: AgentUpdateArgs) -> Result<Ex
         ProfileInference::Resolved(profile) => profile,
         ProfileInference::Mixed => unreachable!("mixed profiles were handled above"),
     });
-    let registration = Registration::new(access, profile);
+    let disable_update_check =
+        requested_update_check.unwrap_or_else(|| match inference.update_check {
+            UpdateCheckInference::Resolved(disabled) => disabled,
+            UpdateCheckInference::Mixed => unreachable!("mixed update checks were handled above"),
+        });
+    let registration =
+        Registration::new(access, profile).with_update_check_disabled(disable_update_check);
 
     install_environment(&environment, "Updated", &registration)
 }
@@ -422,6 +457,10 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
         .iter()
         .map(|registration| registration.profile.clone())
         .collect::<Vec<_>>();
+    let update_checks = registrations
+        .iter()
+        .map(|registration| registration.disable_update_check)
+        .collect::<Vec<_>>();
     let mixed_access = has_mixed_access_modes(&access_modes);
     if mixed_access {
         println!(
@@ -434,6 +473,14 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
     if mixed_profiles {
         println!(
             "{} Detected MCP clients use mixed profiles.",
+            error_status()
+        );
+        unhealthy = true;
+    }
+    let mixed_update_checks = has_mixed_update_checks(&update_checks);
+    if mixed_update_checks {
+        println!(
+            "{} Detected MCP clients use mixed update-check settings.",
             error_status()
         );
         unhealthy = true;
@@ -533,6 +580,12 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
                 }
             }
         }
+        if mixed_update_checks {
+            println!(
+                "Choose one explicitly with `sift-cli agent update --enable-update-check` or \
+                 `sift-cli agent update --disable-update-check`."
+            );
+        }
         if unexpected_profile && !mixed_profiles {
             println!(
                 "Run `sift-cli agent update --profile {}` to switch every detected integration.",
@@ -542,7 +595,12 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
                 }
             );
         }
-        if blocked && !mixed_access && !mixed_profiles && !unexpected_profile {
+        if blocked
+            && !mixed_access
+            && !mixed_profiles
+            && !mixed_update_checks
+            && !unexpected_profile
+        {
             println!(
                 "Then run `sift-cli agent update` to repair all detected integrations together."
             );
@@ -551,6 +609,7 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
             && !blocked
             && !mixed_access
             && !mixed_profiles
+            && !mixed_update_checks
             && !unexpected_profile
         {
             println!("Run `sift-cli agent update` to repair the detected integrations.");
@@ -780,9 +839,16 @@ enum ProfileInference {
     Mixed,
 }
 
+#[derive(Debug, Eq, PartialEq)]
+enum UpdateCheckInference {
+    Resolved(bool),
+    Mixed,
+}
+
 struct RegistrationInference {
     access: AccessInference,
     profile: ProfileInference,
+    update_check: UpdateCheckInference,
 }
 
 fn infer_registration(environment: &Environment) -> Result<RegistrationInference> {
@@ -800,12 +866,17 @@ fn infer_registration(environment: &Environment) -> Result<RegistrationInference
         .map(|registration| registration.access)
         .collect::<Vec<_>>();
     let profiles = registrations
-        .into_iter()
-        .map(|registration| registration.profile)
+        .iter()
+        .map(|registration| registration.profile.clone())
+        .collect::<Vec<_>>();
+    let update_checks = registrations
+        .iter()
+        .map(|registration| registration.disable_update_check)
         .collect::<Vec<_>>();
     Ok(RegistrationInference {
         access: infer_access_modes(&access_modes),
         profile: infer_profiles(&profiles),
+        update_check: infer_update_checks(&update_checks),
     })
 }
 
@@ -840,6 +911,20 @@ fn has_mixed_profiles(profiles: &[Profile]) -> bool {
     profiles
         .first()
         .is_some_and(|first| profiles.iter().any(|profile| profile != first))
+}
+
+fn infer_update_checks(disabled: &[bool]) -> UpdateCheckInference {
+    if has_mixed_update_checks(disabled) {
+        UpdateCheckInference::Mixed
+    } else {
+        UpdateCheckInference::Resolved(disabled.first().copied().unwrap_or(false))
+    }
+}
+
+fn has_mixed_update_checks(disabled: &[bool]) -> bool {
+    disabled
+        .first()
+        .is_some_and(|first| disabled.iter().any(|value| value != first))
 }
 
 async fn check_release() -> bool {

--- a/rust/crates/sift_cli/src/cmd/agent/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/tests.rs
@@ -7,7 +7,7 @@ use tempdir::TempDir;
 
 use super::{
     AccessInference, AccessMode, Environment, Harness, Profile, ProfileInference, Registration,
-    config, skill,
+    UpdateCheckInference, config, skill,
 };
 
 fn environment(harnesses: Vec<Harness>) -> (TempDir, Environment) {
@@ -451,6 +451,36 @@ fn update_profile_inference_preserves_one_profile_and_rejects_mixed_profiles() {
     assert_eq!(
         super::infer_profiles(&[Profile::Default, Profile::Named("localdev".to_string()),]),
         ProfileInference::Mixed
+    );
+}
+
+#[test]
+fn update_check_inference_preserves_one_mode_and_rejects_mixed_modes() {
+    assert_eq!(
+        super::infer_update_checks(&[]),
+        UpdateCheckInference::Resolved(false)
+    );
+    assert_eq!(
+        super::infer_update_checks(&[true, true]),
+        UpdateCheckInference::Resolved(true)
+    );
+    assert_eq!(
+        super::infer_update_checks(&[false, true]),
+        UpdateCheckInference::Mixed
+    );
+}
+
+#[test]
+fn update_check_flags_are_mutually_exclusive() {
+    assert!(
+        crate::cli::Args::try_parse_from([
+            "sift-cli",
+            "agent",
+            "update",
+            "--disable-update-check",
+            "--enable-update-check",
+        ])
+        .is_err()
     );
 }
 

--- a/rust/crates/sift_cli/src/cmd/mcp.rs
+++ b/rust/crates/sift_cli/src/cmd/mcp.rs
@@ -4,11 +4,13 @@ use std::{
 };
 
 use anyhow::{Error, Result};
+use semver::Version;
 use sift_rs::Credentials;
+use tokio::sync::watch;
 use tracing_subscriber::EnvFilter;
 
 use crate::cli::McpArgs;
-use crate::cmd::Context;
+use crate::cmd::{Context, version};
 use crate::util::tty::Output;
 
 pub async fn report_startup_error(error: Error) -> Result<ExitCode> {
@@ -38,6 +40,12 @@ pub async fn run(ctx: Context, args: McpArgs, app_uri: String) -> Result<ExitCod
         "starting Sift MCP server"
     );
 
+    let update_check = if args.disable_update_check {
+        None
+    } else {
+        Some(start_update_check())
+    };
+
     let credentials = Credentials::Config {
         uri: ctx.grpc_uri,
         apikey: ctx.api_key,
@@ -48,6 +56,8 @@ pub async fn run(ctx: Context, args: McpArgs, app_uri: String) -> Result<ExitCod
         app_uri,
         args.allow_create,
         args.allow_destructive,
+        env!("CARGO_PKG_VERSION").to_string(),
+        update_check,
     )
     .await
     {
@@ -59,5 +69,141 @@ pub async fn run(ctx: Context, args: McpArgs, app_uri: String) -> Result<ExitCod
             tracing::error!(error = ?err, "Sift MCP server terminated");
             Err(err)
         }
+    }
+}
+
+fn start_update_check() -> sift_mcp::UpdateCheckReceiver {
+    let current_version = env!("CARGO_PKG_VERSION").to_string();
+    let current = match Version::parse(&current_version) {
+        Ok(current) => current,
+        Err(error) => {
+            tracing::debug!(%error, "could not parse the installed sift-cli version");
+            return ready_update_check(sift_mcp::UpdateCheck::Unavailable {
+                current_version,
+                message: "Could not parse the installed sift-cli version. Run `sift-cli --version` for details."
+                    .to_string(),
+            });
+        }
+    };
+
+    if let Some(cached) = version::read_release_cache(&current) {
+        let update_check = if cached.is_outdated {
+            update_check_from_versions(&current, &cached.latest_version)
+        } else {
+            sift_mcp::UpdateCheck::Current {
+                current_version,
+                latest_version: cached.latest_version.to_string(),
+            }
+        };
+        log_update_notice(&update_check);
+        return ready_update_check(update_check);
+    }
+
+    let (sender, receiver) = watch::channel(sift_mcp::UpdateCheck::Checking {
+        current_version: current_version.clone(),
+    });
+    tokio::spawn(async move {
+        let update_check = match version::fetch_latest().await {
+            Ok(Some(latest)) => update_check_from_versions(&current, &latest),
+            Ok(None) => sift_mcp::UpdateCheck::Unavailable {
+                current_version,
+                message:
+                    "No stable sift-cli release was found. Run `sift-cli --version` for details."
+                        .to_string(),
+            },
+            Err(error) => {
+                tracing::debug!(%error, "could not check for a newer sift-cli release");
+                sift_mcp::UpdateCheck::Unavailable {
+                    current_version,
+                    message: "Could not check for a newer sift-cli release. Run `sift-cli --version` for details."
+                        .to_string(),
+                }
+            }
+        };
+        log_update_notice(&update_check);
+        if sender.send(update_check).is_err() {
+            tracing::debug!("the MCP server closed before the update check completed");
+        }
+    });
+    receiver
+}
+
+fn update_check_from_versions(current: &Version, latest: &Version) -> sift_mcp::UpdateCheck {
+    match version::outdated_warning(current, latest) {
+        Some(message) => sift_mcp::UpdateCheck::UpdateAvailable {
+            current_version: current.to_string(),
+            latest_version: latest.to_string(),
+            install_command: version::install_command(latest),
+            message,
+        },
+        None => sift_mcp::UpdateCheck::Current {
+            current_version: current.to_string(),
+            latest_version: latest.to_string(),
+        },
+    }
+}
+
+fn log_update_notice(update_check: &sift_mcp::UpdateCheck) {
+    if let sift_mcp::UpdateCheck::UpdateAvailable { message, .. } = update_check {
+        tracing::warn!("{message}");
+    }
+}
+
+fn ready_update_check(update_check: sift_mcp::UpdateCheck) -> sift_mcp::UpdateCheckReceiver {
+    watch::channel(update_check).1
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+    use semver::Version;
+
+    use super::update_check_from_versions;
+
+    #[test]
+    fn disable_update_check_flag_is_accepted() {
+        let args = crate::cli::Args::try_parse_from(["sift-cli", "mcp", "--disable-update-check"])
+            .unwrap();
+        let Some(crate::cli::Cmd::Mcp(args)) = args.cmd else {
+            panic!("expected the MCP command");
+        };
+
+        assert!(args.disable_update_check);
+    }
+
+    #[test]
+    fn update_check_contains_the_exact_install_command() {
+        let current = Version::parse("0.3.0").unwrap();
+        let latest = Version::parse("0.4.0").unwrap();
+
+        let update_check = update_check_from_versions(&current, &latest);
+
+        match update_check {
+            sift_mcp::UpdateCheck::UpdateAvailable {
+                current_version,
+                latest_version,
+                install_command,
+                message,
+            } => {
+                assert_eq!(current_version, "0.3.0");
+                assert_eq!(latest_version, "0.4.0");
+                assert!(message.ends_with(&format!("  {install_command}")));
+                assert!(install_command.contains("sift_cli-v0.4.0/sift_cli-installer"));
+            }
+            update_check => panic!("expected an available update, got {update_check:?}"),
+        }
+    }
+
+    #[test]
+    fn update_check_reports_a_current_binary() {
+        let current = Version::parse("0.4.0").unwrap();
+        let latest = Version::parse("0.4.0").unwrap();
+
+        let update_check = update_check_from_versions(&current, &latest);
+
+        assert!(matches!(
+            update_check,
+            sift_mcp::UpdateCheck::Current { .. }
+        ));
     }
 }

--- a/rust/crates/sift_cli/src/cmd/mcp.rs
+++ b/rust/crates/sift_cli/src/cmd/mcp.rs
@@ -92,14 +92,16 @@ fn start_update_check() -> sift_mcp::UpdateCheckReceiver {
         }
     };
 
-    if let Some(cached) = version::read_release_cache(&current) {
-        let update_check = if cached.is_outdated {
-            update_check_from_versions(&current, &cached.latest_version)
-        } else {
-            sift_mcp::UpdateCheck::Current {
-                current_version,
-                latest_version: cached.latest_version.to_string(),
+    if let Some(cached) = version::read_release_cache() {
+        let update_check = match cached {
+            version::CachedRelease::Latest(latest) => {
+                update_check_from_versions(&current, &latest)
             }
+            version::CachedRelease::Unavailable => sift_mcp::UpdateCheck::Unavailable {
+                current_version,
+                message: "Could not check for a newer sift-cli release. Run `sift-cli --version` for details."
+                    .to_string(),
+            },
         };
         log_update_notice(&update_check);
         return ready_update_check(update_check);

--- a/rust/crates/sift_cli/src/cmd/mcp.rs
+++ b/rust/crates/sift_cli/src/cmd/mcp.rs
@@ -40,17 +40,13 @@ pub async fn run(ctx: Context, args: McpArgs, app_uri: String) -> Result<ExitCod
         "starting Sift MCP server"
     );
 
-    let update_check = if args.disable_update_check {
-        None
-    } else {
-        Some(start_update_check())
-    };
+    let update_check = select_update_check(args.disable_update_check, start_update_check);
 
     let credentials = Credentials::Config {
         uri: ctx.grpc_uri,
         apikey: ctx.api_key,
     };
-    match sift_mcp::run(
+    match sift_mcp::run_with_update_check(
         credentials,
         !ctx.disable_tls,
         app_uri,
@@ -70,6 +66,16 @@ pub async fn run(ctx: Context, args: McpArgs, app_uri: String) -> Result<ExitCod
             Err(err)
         }
     }
+}
+
+fn select_update_check<F>(
+    disable_update_check: bool,
+    start: F,
+) -> Option<sift_mcp::UpdateCheckReceiver>
+where
+    F: FnOnce() -> sift_mcp::UpdateCheckReceiver,
+{
+    (!disable_update_check).then(start)
 }
 
 fn start_update_check() -> sift_mcp::UpdateCheckReceiver {
@@ -155,10 +161,13 @@ fn ready_update_check(update_check: sift_mcp::UpdateCheck) -> sift_mcp::UpdateCh
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+
     use clap::Parser;
     use semver::Version;
+    use tokio::sync::watch;
 
-    use super::update_check_from_versions;
+    use super::{select_update_check, update_check_from_versions};
 
     #[test]
     fn disable_update_check_flag_is_accepted() {
@@ -169,6 +178,22 @@ mod tests {
         };
 
         assert!(args.disable_update_check);
+    }
+
+    #[test]
+    fn disabled_update_check_does_not_start_the_check() {
+        let called = Cell::new(false);
+
+        let update_check = select_update_check(true, || {
+            called.set(true);
+            watch::channel(sift_mcp::UpdateCheck::Checking {
+                current_version: "0.4.0".to_string(),
+            })
+            .1
+        });
+
+        assert!(update_check.is_none());
+        assert!(!called.get());
     }
 
     #[test]

--- a/rust/crates/sift_cli/src/cmd/version.rs
+++ b/rust/crates/sift_cli/src/cmd/version.rs
@@ -1,16 +1,35 @@
-use std::{process::ExitCode, time::Duration};
+use std::{
+    fs,
+    future::Future,
+    path::{Path, PathBuf},
+    process::ExitCode,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
-use anyhow::Result;
+use anyhow::{Context, Result, anyhow};
 use crossterm::style::Stylize;
 use reqwest::ClientBuilder;
 use semver::Version;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::util::tty::Output;
 
 const RELEASES_URL: &str = "https://api.github.com/repos/sift-stack/sift/releases?per_page=100";
 const TAG_PREFIX: &str = "sift_cli-v";
 const USER_AGENT: &str = concat!("sift-cli/", env!("CARGO_PKG_VERSION"));
+const RELEASE_CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+#[derive(Debug)]
+pub(crate) struct CachedRelease {
+    pub(crate) latest_version: Version,
+    pub(crate) is_outdated: bool,
+}
+
+#[derive(Deserialize, Serialize)]
+struct ReleaseCache {
+    latest_version: String,
+    checked_at: u64,
+}
 
 #[derive(Deserialize)]
 struct GithubRelease {
@@ -28,7 +47,7 @@ pub async fn run() -> Result<ExitCode> {
     let mut out = Output::new();
     out.line(format!("sift-cli {}", current_str.bold()));
 
-    match fetch_latest().await {
+    match latest_with_cache(&current).await {
         Ok(Some(latest)) => {
             out.line(format!("Latest release: {}", latest.to_string().bold()));
             if latest > current {
@@ -78,7 +97,79 @@ pub(crate) async fn fetch_latest() -> Result<Option<Version>> {
         .json()
         .await?;
 
-    Ok(latest_stable(releases))
+    let latest = latest_stable(releases);
+    if let Some(latest) = &latest
+        && let Err(error) = write_release_cache(latest)
+    {
+        tracing::debug!(%error, "could not update the sift-cli release cache");
+    }
+
+    Ok(latest)
+}
+
+pub(crate) async fn latest_with_cache(current: &Version) -> Result<Option<Version>> {
+    let path = release_cache_path();
+    cached_or_fetch_latest_at(path.as_deref(), current, SystemTime::now(), fetch_latest).await
+}
+
+async fn cached_or_fetch_latest_at<F, Fut>(
+    path: Option<&Path>,
+    current: &Version,
+    now: SystemTime,
+    refresh: F,
+) -> Result<Option<Version>>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<Option<Version>>>,
+{
+    if let Some(cached) = path.and_then(|path| read_release_cache_at(path, current, now)) {
+        return Ok(Some(cached.latest_version));
+    }
+    refresh().await
+}
+
+pub(crate) fn read_release_cache(current: &Version) -> Option<CachedRelease> {
+    let path = release_cache_path()?;
+    read_release_cache_at(&path, current, SystemTime::now())
+}
+
+fn release_cache_path() -> Option<PathBuf> {
+    dirs::cache_dir().map(|path| path.join("sift-cli").join("latest-release.json"))
+}
+
+fn read_release_cache_at(path: &Path, current: &Version, now: SystemTime) -> Option<CachedRelease> {
+    let cache: ReleaseCache = serde_json::from_slice(&fs::read(path).ok()?).ok()?;
+    let checked_at = UNIX_EPOCH.checked_add(Duration::from_secs(cache.checked_at))?;
+    let age = now.duration_since(checked_at).ok()?;
+    if age > RELEASE_CACHE_TTL {
+        return None;
+    }
+
+    let latest_version = Version::parse(&cache.latest_version).ok()?;
+    let is_outdated = latest_version > *current;
+    Some(CachedRelease {
+        latest_version,
+        is_outdated,
+    })
+}
+
+fn write_release_cache(latest: &Version) -> Result<()> {
+    let path =
+        release_cache_path().ok_or_else(|| anyhow!("the platform has no cache directory"))?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("the release cache path has no parent"))?;
+    fs::create_dir_all(parent).context("failed to create the sift-cli cache directory")?;
+    let checked_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("the system clock is before the Unix epoch")?
+        .as_secs();
+    let cache = ReleaseCache {
+        latest_version: latest.to_string(),
+        checked_at,
+    };
+    let contents = serde_json::to_vec(&cache).context("failed to serialize the release cache")?;
+    fs::write(path, contents).context("failed to write the release cache")
 }
 
 fn latest_stable(releases: Vec<GithubRelease>) -> Option<Version> {
@@ -110,10 +201,44 @@ pub(crate) fn install_command(latest: &Version) -> String {
     cmd_tmpl.replace("{url}", &url)
 }
 
+pub(crate) fn outdated_warning(current: &Version, latest: &Version) -> Option<String> {
+    (latest > current).then(|| {
+        format!(
+            "sift-cli {current} is outdated; latest is {latest}\nUpdate with:\n\n  {}",
+            install_command(latest)
+        )
+    })
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{GithubRelease, latest_stable};
+    use std::cell::Cell;
+    use std::{
+        fs,
+        time::{Duration, SystemTime, UNIX_EPOCH},
+    };
+
     use semver::Version;
+    use serde_json::json;
+    use tempdir::TempDir;
+
+    use super::{
+        GithubRelease, RELEASE_CACHE_TTL, cached_or_fetch_latest_at, install_command,
+        latest_stable, outdated_warning, read_release_cache_at,
+    };
+
+    fn write_cache(path: &std::path::Path, latest_version: &str, checked_at: SystemTime) {
+        let checked_at = checked_at.duration_since(UNIX_EPOCH).unwrap().as_secs();
+        fs::write(
+            path,
+            json!({
+                "latest_version": latest_version,
+                "checked_at": checked_at,
+            })
+            .to_string(),
+        )
+        .unwrap();
+    }
 
     #[test]
     fn latest_release_excludes_drafts_and_prereleases() {
@@ -139,5 +264,129 @@ mod tests {
             latest_stable(releases),
             Some(Version::parse("0.3.0").unwrap())
         );
+    }
+
+    #[test]
+    fn fresh_release_cache_reports_an_outdated_binary() {
+        let dir = TempDir::new("sift-release-cache").unwrap();
+        let path = dir.path().join("latest-release.json");
+        let now = SystemTime::now();
+        write_cache(&path, "0.4.0", now - Duration::from_secs(60));
+
+        let cached = read_release_cache_at(&path, &Version::parse("0.3.0").unwrap(), now).unwrap();
+
+        assert_eq!(cached.latest_version, Version::parse("0.4.0").unwrap());
+        assert!(cached.is_outdated);
+    }
+
+    #[tokio::test]
+    async fn fresh_release_cache_skips_the_refresh() {
+        let dir = TempDir::new("sift-release-cache").unwrap();
+        let path = dir.path().join("latest-release.json");
+        let now = SystemTime::now();
+        write_cache(&path, "0.4.0", now - Duration::from_secs(60));
+        let refreshed = Cell::new(false);
+
+        let latest = cached_or_fetch_latest_at(
+            Some(&path),
+            &Version::parse("0.3.0").unwrap(),
+            now,
+            || async {
+                refreshed.set(true);
+                Ok(None)
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(latest, Some(Version::parse("0.4.0").unwrap()));
+        assert!(!refreshed.get());
+    }
+
+    #[tokio::test]
+    async fn expired_release_cache_runs_the_refresh() {
+        let dir = TempDir::new("sift-release-cache").unwrap();
+        let path = dir.path().join("latest-release.json");
+        let now = SystemTime::now();
+        write_cache(
+            &path,
+            "0.3.0",
+            now - RELEASE_CACHE_TTL - Duration::from_secs(1),
+        );
+        let refreshed = Cell::new(false);
+
+        let latest = cached_or_fetch_latest_at(
+            Some(&path),
+            &Version::parse("0.3.0").unwrap(),
+            now,
+            || async {
+                refreshed.set(true);
+                Ok(Some(Version::parse("0.4.0").unwrap()))
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(latest, Some(Version::parse("0.4.0").unwrap()));
+        assert!(refreshed.get());
+    }
+
+    #[test]
+    fn expired_release_cache_is_unknown() {
+        let dir = TempDir::new("sift-release-cache").unwrap();
+        let path = dir.path().join("latest-release.json");
+        let now = SystemTime::now();
+        write_cache(
+            &path,
+            "0.4.0",
+            now - RELEASE_CACHE_TTL - Duration::from_secs(1),
+        );
+
+        assert!(read_release_cache_at(&path, &Version::parse("0.3.0").unwrap(), now,).is_none());
+    }
+
+    #[test]
+    fn corrupt_release_cache_is_unknown() {
+        let dir = TempDir::new("sift-release-cache").unwrap();
+        let path = dir.path().join("latest-release.json");
+        fs::write(&path, "not json").unwrap();
+
+        assert!(
+            read_release_cache_at(&path, &Version::parse("0.3.0").unwrap(), SystemTime::now(),)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn older_cached_release_does_not_mark_the_binary_outdated() {
+        let dir = TempDir::new("sift-release-cache").unwrap();
+        let path = dir.path().join("latest-release.json");
+        let now = SystemTime::now();
+        write_cache(&path, "0.3.0", now);
+
+        let cached = read_release_cache_at(&path, &Version::parse("0.4.0").unwrap(), now).unwrap();
+
+        assert!(!cached.is_outdated);
+    }
+
+    #[test]
+    fn outdated_warning_includes_the_shared_install_command() {
+        let current = Version::parse("0.3.0").unwrap();
+        let latest = Version::parse("0.4.0").unwrap();
+
+        let warning = outdated_warning(&current, &latest).unwrap();
+        let command = install_command(&latest);
+
+        assert!(warning.contains("sift-cli 0.3.0 is outdated; latest is 0.4.0"));
+        assert!(warning.ends_with(&format!("  {command}")));
+        assert!(warning[..warning.len().min(512)].contains(&command));
+    }
+
+    #[test]
+    fn outdated_warning_is_absent_for_the_latest_release() {
+        let current = Version::parse("0.4.0").unwrap();
+        let latest = Version::parse("0.4.0").unwrap();
+
+        assert_eq!(outdated_warning(&current, &latest), None);
     }
 }

--- a/rust/crates/sift_cli/src/cmd/version.rs
+++ b/rust/crates/sift_cli/src/cmd/version.rs
@@ -18,16 +18,17 @@ const RELEASES_URL: &str = "https://api.github.com/repos/sift-stack/sift/release
 const TAG_PREFIX: &str = "sift_cli-v";
 const USER_AGENT: &str = concat!("sift-cli/", env!("CARGO_PKG_VERSION"));
 const RELEASE_CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+const RELEASE_FAILURE_CACHE_TTL: Duration = Duration::from_secs(15 * 60);
 
-#[derive(Debug)]
-pub(crate) struct CachedRelease {
-    pub(crate) latest_version: Version,
-    pub(crate) is_outdated: bool,
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum CachedRelease {
+    Latest(Version),
+    Unavailable,
 }
 
 #[derive(Deserialize, Serialize)]
 struct ReleaseCache {
-    latest_version: String,
+    latest_version: Option<String>,
     checked_at: u64,
 }
 
@@ -47,7 +48,7 @@ pub async fn run() -> Result<ExitCode> {
     let mut out = Output::new();
     out.line(format!("sift-cli {}", current_str.bold()));
 
-    match latest_with_cache(&current).await {
+    match latest_with_cache().await {
         Ok(Some(latest)) => {
             out.line(format!("Latest release: {}", latest.to_string().bold()));
             if latest > current {
@@ -84,37 +85,39 @@ pub async fn run() -> Result<ExitCode> {
 }
 
 pub(crate) async fn fetch_latest() -> Result<Option<Version>> {
-    let client = ClientBuilder::new()
-        .user_agent(USER_AGENT)
-        .timeout(Duration::from_secs(5))
-        .build()?;
+    let result = async {
+        let client = ClientBuilder::new()
+            .user_agent(USER_AGENT)
+            .timeout(Duration::from_secs(5))
+            .build()?;
 
-    let releases: Vec<GithubRelease> = client
-        .get(RELEASES_URL)
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
+        let releases: Vec<GithubRelease> = client
+            .get(RELEASES_URL)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
 
-    let latest = latest_stable(releases);
-    if let Some(latest) = &latest
-        && let Err(error) = write_release_cache(latest)
-    {
+        Ok(latest_stable(releases))
+    }
+    .await;
+
+    let latest = result.as_ref().ok().and_then(|latest| latest.as_ref());
+    if let Err(error) = write_release_cache(latest) {
         tracing::debug!(%error, "could not update the sift-cli release cache");
     }
 
-    Ok(latest)
+    result
 }
 
-pub(crate) async fn latest_with_cache(current: &Version) -> Result<Option<Version>> {
+pub(crate) async fn latest_with_cache() -> Result<Option<Version>> {
     let path = release_cache_path();
-    cached_or_fetch_latest_at(path.as_deref(), current, SystemTime::now(), fetch_latest).await
+    cached_or_fetch_latest_at(path.as_deref(), SystemTime::now(), fetch_latest).await
 }
 
 async fn cached_or_fetch_latest_at<F, Fut>(
     path: Option<&Path>,
-    current: &Version,
     now: SystemTime,
     refresh: F,
 ) -> Result<Option<Version>>
@@ -122,38 +125,47 @@ where
     F: FnOnce() -> Fut,
     Fut: Future<Output = Result<Option<Version>>>,
 {
-    if let Some(cached) = path.and_then(|path| read_release_cache_at(path, current, now)) {
-        return Ok(Some(cached.latest_version));
+    match path.and_then(|path| read_release_cache_at(path, now)) {
+        Some(CachedRelease::Latest(latest)) => return Ok(Some(latest)),
+        Some(CachedRelease::Unavailable) => {
+            return Err(anyhow!("a recent release check failed"));
+        }
+        None => {}
     }
     refresh().await
 }
 
-pub(crate) fn read_release_cache(current: &Version) -> Option<CachedRelease> {
+pub(crate) fn read_release_cache() -> Option<CachedRelease> {
     let path = release_cache_path()?;
-    read_release_cache_at(&path, current, SystemTime::now())
+    read_release_cache_at(&path, SystemTime::now())
 }
 
 fn release_cache_path() -> Option<PathBuf> {
     dirs::cache_dir().map(|path| path.join("sift-cli").join("latest-release.json"))
 }
 
-fn read_release_cache_at(path: &Path, current: &Version, now: SystemTime) -> Option<CachedRelease> {
+fn read_release_cache_at(path: &Path, now: SystemTime) -> Option<CachedRelease> {
     let cache: ReleaseCache = serde_json::from_slice(&fs::read(path).ok()?).ok()?;
     let checked_at = UNIX_EPOCH.checked_add(Duration::from_secs(cache.checked_at))?;
     let age = now.duration_since(checked_at).ok()?;
-    if age > RELEASE_CACHE_TTL {
+    let ttl = if cache.latest_version.is_some() {
+        RELEASE_CACHE_TTL
+    } else {
+        RELEASE_FAILURE_CACHE_TTL
+    };
+    if age > ttl {
         return None;
     }
 
-    let latest_version = Version::parse(&cache.latest_version).ok()?;
-    let is_outdated = latest_version > *current;
-    Some(CachedRelease {
-        latest_version,
-        is_outdated,
-    })
+    match cache.latest_version {
+        Some(latest_version) => Version::parse(&latest_version)
+            .ok()
+            .map(CachedRelease::Latest),
+        None => Some(CachedRelease::Unavailable),
+    }
 }
 
-fn write_release_cache(latest: &Version) -> Result<()> {
+fn write_release_cache(latest: Option<&Version>) -> Result<()> {
     let path =
         release_cache_path().ok_or_else(|| anyhow!("the platform has no cache directory"))?;
     let parent = path
@@ -165,7 +177,7 @@ fn write_release_cache(latest: &Version) -> Result<()> {
         .context("the system clock is before the Unix epoch")?
         .as_secs();
     let cache = ReleaseCache {
-        latest_version: latest.to_string(),
+        latest_version: latest.map(ToString::to_string),
         checked_at,
     };
     let contents = serde_json::to_vec(&cache).context("failed to serialize the release cache")?;
@@ -223,11 +235,12 @@ mod tests {
     use tempdir::TempDir;
 
     use super::{
-        GithubRelease, RELEASE_CACHE_TTL, cached_or_fetch_latest_at, install_command,
-        latest_stable, outdated_warning, read_release_cache_at,
+        CachedRelease, GithubRelease, RELEASE_CACHE_TTL, RELEASE_FAILURE_CACHE_TTL,
+        cached_or_fetch_latest_at, install_command, latest_stable, outdated_warning,
+        read_release_cache_at,
     };
 
-    fn write_cache(path: &std::path::Path, latest_version: &str, checked_at: SystemTime) {
+    fn write_cache(path: &std::path::Path, latest_version: Option<&str>, checked_at: SystemTime) {
         let checked_at = checked_at.duration_since(UNIX_EPOCH).unwrap().as_secs();
         fs::write(
             path,
@@ -267,16 +280,18 @@ mod tests {
     }
 
     #[test]
-    fn fresh_release_cache_reports_an_outdated_binary() {
+    fn fresh_release_cache_returns_the_latest_release() {
         let dir = TempDir::new("sift-release-cache").unwrap();
         let path = dir.path().join("latest-release.json");
         let now = SystemTime::now();
-        write_cache(&path, "0.4.0", now - Duration::from_secs(60));
+        write_cache(&path, Some("0.4.0"), now - Duration::from_secs(60));
 
-        let cached = read_release_cache_at(&path, &Version::parse("0.3.0").unwrap(), now).unwrap();
+        let cached = read_release_cache_at(&path, now).unwrap();
 
-        assert_eq!(cached.latest_version, Version::parse("0.4.0").unwrap());
-        assert!(cached.is_outdated);
+        assert_eq!(
+            cached,
+            CachedRelease::Latest(Version::parse("0.4.0").unwrap())
+        );
     }
 
     #[tokio::test]
@@ -284,18 +299,13 @@ mod tests {
         let dir = TempDir::new("sift-release-cache").unwrap();
         let path = dir.path().join("latest-release.json");
         let now = SystemTime::now();
-        write_cache(&path, "0.4.0", now - Duration::from_secs(60));
+        write_cache(&path, Some("0.4.0"), now - Duration::from_secs(60));
         let refreshed = Cell::new(false);
 
-        let latest = cached_or_fetch_latest_at(
-            Some(&path),
-            &Version::parse("0.3.0").unwrap(),
-            now,
-            || async {
-                refreshed.set(true);
-                Ok(None)
-            },
-        )
+        let latest = cached_or_fetch_latest_at(Some(&path), now, || async {
+            refreshed.set(true);
+            Ok(None)
+        })
         .await
         .unwrap();
 
@@ -310,20 +320,15 @@ mod tests {
         let now = SystemTime::now();
         write_cache(
             &path,
-            "0.3.0",
+            Some("0.3.0"),
             now - RELEASE_CACHE_TTL - Duration::from_secs(1),
         );
         let refreshed = Cell::new(false);
 
-        let latest = cached_or_fetch_latest_at(
-            Some(&path),
-            &Version::parse("0.3.0").unwrap(),
-            now,
-            || async {
-                refreshed.set(true);
-                Ok(Some(Version::parse("0.4.0").unwrap()))
-            },
-        )
+        let latest = cached_or_fetch_latest_at(Some(&path), now, || async {
+            refreshed.set(true);
+            Ok(Some(Version::parse("0.4.0").unwrap()))
+        })
         .await
         .unwrap();
 
@@ -338,11 +343,11 @@ mod tests {
         let now = SystemTime::now();
         write_cache(
             &path,
-            "0.4.0",
+            Some("0.4.0"),
             now - RELEASE_CACHE_TTL - Duration::from_secs(1),
         );
 
-        assert!(read_release_cache_at(&path, &Version::parse("0.3.0").unwrap(), now,).is_none());
+        assert!(read_release_cache_at(&path, now).is_none());
     }
 
     #[test]
@@ -351,22 +356,76 @@ mod tests {
         let path = dir.path().join("latest-release.json");
         fs::write(&path, "not json").unwrap();
 
-        assert!(
-            read_release_cache_at(&path, &Version::parse("0.3.0").unwrap(), SystemTime::now(),)
-                .is_none()
+        assert!(read_release_cache_at(&path, SystemTime::now()).is_none());
+    }
+
+    #[test]
+    fn fresh_release_cache_returns_an_older_release() {
+        let dir = TempDir::new("sift-release-cache").unwrap();
+        let path = dir.path().join("latest-release.json");
+        let now = SystemTime::now();
+        write_cache(&path, Some("0.3.0"), now);
+
+        let cached = read_release_cache_at(&path, now).unwrap();
+
+        assert_eq!(
+            cached,
+            CachedRelease::Latest(Version::parse("0.3.0").unwrap())
         );
     }
 
     #[test]
-    fn older_cached_release_does_not_mark_the_binary_outdated() {
+    fn fresh_failure_cache_is_unavailable() {
         let dir = TempDir::new("sift-release-cache").unwrap();
         let path = dir.path().join("latest-release.json");
         let now = SystemTime::now();
-        write_cache(&path, "0.3.0", now);
+        write_cache(&path, None, now - Duration::from_secs(60));
 
-        let cached = read_release_cache_at(&path, &Version::parse("0.4.0").unwrap(), now).unwrap();
+        assert_eq!(
+            read_release_cache_at(&path, now),
+            Some(CachedRelease::Unavailable)
+        );
+    }
 
-        assert!(!cached.is_outdated);
+    #[tokio::test]
+    async fn fresh_failure_cache_skips_the_refresh() {
+        let dir = TempDir::new("sift-release-cache").unwrap();
+        let path = dir.path().join("latest-release.json");
+        let now = SystemTime::now();
+        write_cache(&path, None, now - Duration::from_secs(60));
+        let refreshed = Cell::new(false);
+
+        let result = cached_or_fetch_latest_at(Some(&path), now, || async {
+            refreshed.set(true);
+            Ok(Some(Version::parse("0.4.0").unwrap()))
+        })
+        .await;
+
+        assert!(result.is_err());
+        assert!(!refreshed.get());
+    }
+
+    #[tokio::test]
+    async fn expired_failure_cache_runs_the_refresh() {
+        let dir = TempDir::new("sift-release-cache").unwrap();
+        let path = dir.path().join("latest-release.json");
+        let now = SystemTime::now();
+        write_cache(
+            &path,
+            None,
+            now - RELEASE_FAILURE_CACHE_TTL - Duration::from_secs(1),
+        );
+        let refreshed = Cell::new(false);
+
+        let latest = cached_or_fetch_latest_at(Some(&path), now, || async {
+            refreshed.set(true);
+            Ok(Some(Version::parse("0.4.0").unwrap()))
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(latest, Some(Version::parse("0.4.0").unwrap()));
+        assert!(refreshed.get());
     }
 
     #[test]

--- a/rust/crates/sift_cli/src/main.rs
+++ b/rust/crates/sift_cli/src/main.rs
@@ -80,7 +80,9 @@ fn run(clargs: cli::Args) -> Result<ExitCode> {
             },
         },
         Cmd::Agent(cmd) => match cmd {
-            AgentCmd::Install(args) => return cmd::agent::install(clargs.profile, args),
+            AgentCmd::Install(args) => {
+                return run_future(cmd::agent::install(clargs.profile, args));
+            }
             AgentCmd::Update(args) => {
                 return run_future(cmd::agent::update(clargs.profile, args));
             }

--- a/rust/crates/sift_mcp/src/lib.rs
+++ b/rust/crates/sift_mcp/src/lib.rs
@@ -1,7 +1,9 @@
 use anyhow::{Context, Result};
 use clap::{crate_name, crate_version};
 use rmcp::{ServiceExt, transport::stdio};
+use serde::Serialize;
 use sift_rs::{Credentials, SiftChannelBuilder};
+use tokio::sync::watch;
 
 mod server;
 use server::SiftMcpServer;
@@ -15,12 +17,66 @@ mod prompt;
 mod service;
 mod tool;
 
+#[derive(Clone, Debug, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum UpdateCheck {
+    Checking {
+        current_version: String,
+    },
+    Current {
+        current_version: String,
+        latest_version: String,
+    },
+    UpdateAvailable {
+        current_version: String,
+        latest_version: String,
+        install_command: String,
+        message: String,
+    },
+    Unavailable {
+        current_version: String,
+        message: String,
+    },
+}
+
+impl UpdateCheck {
+    pub fn message(&self) -> String {
+        match self {
+            Self::Checking { current_version } => {
+                format!("The update check for sift-cli {current_version} is not complete.")
+            }
+            Self::Current {
+                current_version,
+                latest_version,
+            } => format!("sift-cli {current_version} is current; latest is {latest_version}."),
+            Self::UpdateAvailable { message, .. } | Self::Unavailable { message, .. } => {
+                message.clone()
+            }
+        }
+    }
+
+    pub(crate) fn is_checking(&self) -> bool {
+        matches!(self, Self::Checking { .. })
+    }
+
+    pub(crate) fn update_message(&self) -> Option<&str> {
+        match self {
+            Self::UpdateAvailable { message, .. } => Some(message),
+            _ => None,
+        }
+    }
+}
+
+pub type UpdateCheckReceiver = watch::Receiver<UpdateCheck>;
+
 pub async fn run(
     credentials: Credentials,
     use_tls: bool,
     app_uri: String,
     allow_create: bool,
     allow_destructive: bool,
+    cli_version: String,
+    update_check: Option<UpdateCheckReceiver>,
 ) -> Result<()> {
     let channel = SiftChannelBuilder::new(credentials)
         .use_tls(use_tls)
@@ -28,10 +84,17 @@ pub async fn run(
         .build()
         .context("failed to build gRPC channel to connect to Sift")?;
 
-    let service = SiftMcpServer::new(channel, app_uri, allow_create, allow_destructive)
-        .serve(stdio())
-        .await
-        .context("failed to start MCP server")?;
+    let service = SiftMcpServer::new_with_update_check(
+        channel,
+        app_uri,
+        allow_create,
+        allow_destructive,
+        cli_version,
+        update_check,
+    )
+    .serve(stdio())
+    .await
+    .context("failed to start MCP server")?;
 
     service
         .waiting()

--- a/rust/crates/sift_mcp/src/lib.rs
+++ b/rust/crates/sift_mcp/src/lib.rs
@@ -75,6 +75,25 @@ pub async fn run(
     app_uri: String,
     allow_create: bool,
     allow_destructive: bool,
+) -> Result<()> {
+    run_with_update_check(
+        credentials,
+        use_tls,
+        app_uri,
+        allow_create,
+        allow_destructive,
+        crate_version!().to_string(),
+        None,
+    )
+    .await
+}
+
+pub async fn run_with_update_check(
+    credentials: Credentials,
+    use_tls: bool,
+    app_uri: String,
+    allow_create: bool,
+    allow_destructive: bool,
     cli_version: String,
     update_check: Option<UpdateCheckReceiver>,
 ) -> Result<()> {
@@ -102,4 +121,23 @@ pub async fn run(
         .context("MCP server terminated unexpectedly")?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+
+    use sift_rs::Credentials;
+
+    fn accepts_legacy_run<F, Fut>(_run: F)
+    where
+        F: Fn(Credentials, bool, String, bool, bool) -> Fut,
+        Fut: Future<Output = anyhow::Result<()>>,
+    {
+    }
+
+    #[test]
+    fn public_run_keeps_its_legacy_signature() {
+        accepts_legacy_run(super::run);
+    }
 }

--- a/rust/crates/sift_mcp/src/server/mod.rs
+++ b/rust/crates/sift_mcp/src/server/mod.rs
@@ -2,14 +2,39 @@ use rmcp::{
     ErrorData, RoleServer, ServerHandler,
     handler::server::router::prompt::PromptRouter,
     handler::server::tool::ToolRouter,
-    model::{ListToolsResult, PaginatedRequestParams},
+    model::{
+        Implementation, ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo,
+    },
     prompt_handler,
     service::RequestContext,
     tool_handler,
 };
 use sift_rs::SiftChannel;
+#[cfg(test)]
+use tokio::sync::watch;
 
-use crate::policy::RetryPolicy;
+#[cfg(test)]
+use crate::UpdateCheck;
+use crate::{UpdateCheckReceiver, policy::RetryPolicy};
+
+#[cfg(test)]
+mod test;
+
+const UPDATE_CHECK_INSTRUCTIONS: &str = concat!(
+    "Call `check_for_updates` once before the first other Sift tool in each session. ",
+    "If it reports `update_available`, relay its `message` and exact ",
+    "`install_command` to the user. If the check is unavailable, continue with ",
+    "the requested Sift task. "
+);
+pub(crate) const BASE_INSTRUCTIONS: &str = concat!(
+    "Use Sift tools for telemetry discovery, analysis, ",
+    "and ingestion. Run `sift-cli agent doctor` for read-only integration ",
+    "diagnosis, `sift-cli agent install` for first setup, and `sift-cli agent ",
+    "update` to refresh every detected client together. Never enable destructive ",
+    "tools without explicit user approval. Result objects follow proto3 JSON ",
+    "rules: fields at their default value (false, 0, empty string/list) are ",
+    "omitted, so a missing boolean key means false, not unknown."
+);
 #[cfg(feature = "test-reports")]
 use crate::service::test_reports::TestReportService;
 use crate::service::{
@@ -42,22 +67,11 @@ pub struct SiftMcpServer {
 
     pub allow_create: bool,
     pub allow_destructive: bool,
+    cli_version: String,
+    pub update_check: Option<UpdateCheckReceiver>,
 }
 
-#[tool_handler(
-    router = self.tool_router,
-    name = "SiftMcp",
-    version = "0.1.0",
-    instructions = "Use Sift tools for telemetry discovery, analysis, and \
-    ingestion. Run `sift-cli agent doctor` for read-only integration \
-    diagnosis, `sift-cli agent install` for first setup, and \
-    `sift-cli agent update` to refresh every detected client together. If the \
-    CLI is outdated, relay the exact curl or PowerShell installer it prints. \
-    Never enable destructive tools without explicit user approval. Result \
-    objects follow proto3 JSON rules: fields at their default value (false, \
-    0, empty string/list) are omitted, so a missing boolean key means false, \
-    not unknown.",
-)]
+#[tool_handler(router = self.tool_router)]
 #[prompt_handler(router = self.prompt_router)]
 impl ServerHandler for SiftMcpServer {
     async fn list_tools(
@@ -81,14 +95,62 @@ impl ServerHandler for SiftMcpServer {
         });
         Ok(ListToolsResult::with_all_items(tools))
     }
+
+    fn get_info(&self) -> ServerInfo {
+        let instructions = match &self.update_check {
+            Some(receiver) => {
+                let update_check = receiver.borrow();
+                let base = format!("{UPDATE_CHECK_INSTRUCTIONS}{BASE_INSTRUCTIONS}");
+                match update_check.update_message() {
+                    Some(message) => format!("{message}\n\n{base}"),
+                    None => base,
+                }
+            }
+            None => BASE_INSTRUCTIONS.to_string(),
+        };
+
+        ServerInfo::new(
+            ServerCapabilities::builder()
+                .enable_tools()
+                .enable_prompts()
+                .build(),
+        )
+        .with_server_info(Implementation::new("SiftMcp", self.cli_version.clone()))
+        .with_instructions(instructions)
+    }
 }
 
 impl SiftMcpServer {
+    #[cfg(test)]
     pub fn new(
         channel: SiftChannel,
         app_uri: String,
         allow_create: bool,
         allow_destructive: bool,
+    ) -> Self {
+        let version = env!("CARGO_PKG_VERSION").to_string();
+        let update_check = watch::channel(UpdateCheck::Current {
+            current_version: version.clone(),
+            latest_version: version.clone(),
+        })
+        .1;
+        Self::new_with_update_check(
+            channel,
+            app_uri,
+            allow_create,
+            allow_destructive,
+            version,
+            Some(update_check),
+        )
+    }
+
+    pub fn new_with_update_check(
+        channel: SiftChannel,
+        app_uri: String,
+        allow_create: bool,
+        allow_destructive: bool,
+        cli_version: String,
+        update_check: Option<UpdateCheckReceiver>,
     ) -> Self {
         // Add more routers here as new tool groups are introduced, e.g.
         //   tool_router.merge(Self::ingestion_router())
@@ -106,6 +168,9 @@ impl SiftMcpServer {
         tool_router.merge(Self::test_reports_router());
         tool_router.merge(Self::docs_router());
         tool_router.merge(Self::users_router());
+        if update_check.is_some() {
+            tool_router.merge(Self::update_router());
+        }
 
         let prompt_router = Self::prompt_router();
 
@@ -148,6 +213,8 @@ impl SiftMcpServer {
             prompt_router,
             allow_create,
             allow_destructive,
+            cli_version,
+            update_check,
         }
     }
 

--- a/rust/crates/sift_mcp/src/server/mod.rs
+++ b/rust/crates/sift_mcp/src/server/mod.rs
@@ -21,7 +21,7 @@ use crate::{UpdateCheckReceiver, policy::RetryPolicy};
 mod test;
 
 const UPDATE_CHECK_INSTRUCTIONS: &str = concat!(
-    "Call `check_for_updates` once before the first other Sift tool in each session. ",
+    "Call `check_for_updates` once at the start of each session, before you call any other Sift tool. ",
     "If it reports `update_available`, relay its `message` and exact ",
     "`install_command` to the user. If the check is unavailable, continue with ",
     "the requested Sift task. "

--- a/rust/crates/sift_mcp/src/server/test.rs
+++ b/rust/crates/sift_mcp/src/server/test.rs
@@ -19,7 +19,7 @@ const CLI_VERSION: &str = "7.8.9";
 const INSTALL_COMMAND: &str =
     "curl --proto '=https' --tlsv1.2 -LsSf https://example.test/sift_cli-installer.sh | sh";
 const EXPECTED_BASE_INSTRUCTIONS: &str = concat!(
-    "Call `check_for_updates` once before the first other Sift tool in each session. ",
+    "Call `check_for_updates` once at the start of each session, before you call any other Sift tool. ",
     "If it reports `update_available`, relay its `message` and exact ",
     "`install_command` to the user. If the check is unavailable, continue with ",
     "the requested Sift task. Use Sift tools for telemetry discovery, analysis, ",

--- a/rust/crates/sift_mcp/src/server/test.rs
+++ b/rust/crates/sift_mcp/src/server/test.rs
@@ -224,6 +224,50 @@ async fn update_tool_waits_for_the_background_check_and_returns_the_install_comm
 }
 
 #[tokio::test]
+async fn update_tool_fails_open_when_the_background_check_closes() {
+    let (sender, update_check) = watch::channel(UpdateCheck::Checking {
+        current_version: "0.3.0".to_string(),
+    });
+    let (mut reader, mut writer, server) = initialized_client(Some(update_check), 1).await;
+    let _initialize = read_json(&mut reader).await;
+    writer
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n")
+        .await
+        .unwrap();
+    drop(sender);
+    writer
+        .write_all(
+            b"{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"check_for_updates\",\"arguments\":{}}}\n",
+        )
+        .await
+        .unwrap();
+
+    let response = read_json(&mut reader).await;
+    assert_eq!(
+        response["result"]["structuredContent"]["status"],
+        "unavailable"
+    );
+    assert_eq!(
+        response["result"]["structuredContent"]["current_version"],
+        "0.3.0"
+    );
+
+    writer
+        .write_all(
+            b"{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"list_assets\",\"arguments\":{\"filter\":\"\"}}}\n",
+        )
+        .await
+        .unwrap();
+    let assets = read_json(&mut reader).await;
+    assert_eq!(
+        assets["result"]["structuredContent"],
+        serde_json::json!({ "assets": [] })
+    );
+
+    finish(reader, writer, server).await;
+}
+
+#[tokio::test]
 async fn update_notice_does_not_change_unrelated_tool_results() {
     let (mut reader, mut writer, server) =
         initialized_client(Some(receiver(update_available())), 1).await;

--- a/rust/crates/sift_mcp/src/server/test.rs
+++ b/rust/crates/sift_mcp/src/server/test.rs
@@ -1,0 +1,278 @@
+use std::time::Duration;
+
+use rmcp::{ServerHandler, ServiceExt};
+use serde_json::Value;
+use sift_rs::assets::v1::{ListAssetsResponse, asset_service_server::AssetServiceServer};
+use sift_test_util::{grpc::memory_sift_channel, mock::assets::v1::MockAssetServiceImpl};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader, DuplexStream},
+    sync::watch,
+    task::JoinHandle,
+};
+use tonic::{Response, transport::Server};
+
+use crate::UpdateCheck;
+
+use super::SiftMcpServer;
+
+const CLI_VERSION: &str = "7.8.9";
+const INSTALL_COMMAND: &str =
+    "curl --proto '=https' --tlsv1.2 -LsSf https://example.test/sift_cli-installer.sh | sh";
+const EXPECTED_BASE_INSTRUCTIONS: &str = concat!(
+    "Call `check_for_updates` once before the first other Sift tool in each session. ",
+    "If it reports `update_available`, relay its `message` and exact ",
+    "`install_command` to the user. If the check is unavailable, continue with ",
+    "the requested Sift task. Use Sift tools for telemetry discovery, analysis, ",
+    "and ingestion. Run `sift-cli agent doctor` for read-only integration ",
+    "diagnosis, `sift-cli agent install` for first setup, and `sift-cli agent ",
+    "update` to refresh every detected client together. Never enable destructive ",
+    "tools without explicit user approval. Result objects follow proto3 JSON ",
+    "rules: fields at their default value (false, 0, empty string/list) are ",
+    "omitted, so a missing boolean key means false, not unknown."
+);
+
+fn update_available() -> UpdateCheck {
+    UpdateCheck::UpdateAvailable {
+        current_version: "0.3.0".to_string(),
+        latest_version: "0.4.0".to_string(),
+        install_command: INSTALL_COMMAND.to_string(),
+        message: format!(
+            "sift-cli 0.3.0 is outdated; latest is 0.4.0\nUpdate with:\n\n  {INSTALL_COMMAND}"
+        ),
+    }
+}
+
+fn receiver(status: UpdateCheck) -> watch::Receiver<UpdateCheck> {
+    watch::channel(status).1
+}
+
+async fn server_with_update_check(
+    update_check: Option<watch::Receiver<UpdateCheck>>,
+    asset_tool_calls: usize,
+) -> (SiftMcpServer, JoinHandle<()>) {
+    let mut mock = MockAssetServiceImpl::new();
+    mock.expect_list_assets()
+        .times(asset_tool_calls)
+        .returning(|_| Ok(Response::new(ListAssetsResponse::default())));
+
+    let (client, server) = tokio::io::duplex(1024);
+    let channel = memory_sift_channel(client).await;
+    let handle = tokio::spawn(async move {
+        Server::builder()
+            .add_service(AssetServiceServer::new(mock))
+            .serve_with_incoming(tokio_stream::once(Ok::<_, std::io::Error>(server)))
+            .await
+            .unwrap();
+    });
+
+    (
+        SiftMcpServer::new_with_update_check(
+            channel,
+            "https://app.test.local".to_string(),
+            false,
+            false,
+            CLI_VERSION.to_string(),
+            update_check,
+        ),
+        handle,
+    )
+}
+
+async fn initialized_client(
+    update_check: Option<watch::Receiver<UpdateCheck>>,
+    asset_tool_calls: usize,
+) -> (
+    BufReader<tokio::io::ReadHalf<DuplexStream>>,
+    tokio::io::WriteHalf<DuplexStream>,
+    JoinHandle<()>,
+) {
+    let (server, grpc_handle) = server_with_update_check(update_check, asset_tool_calls).await;
+    let (server_transport, client_transport) = tokio::io::duplex(8192);
+    let mcp_handle = tokio::spawn(async move {
+        let service = server.serve(server_transport).await.unwrap();
+        service.waiting().await.unwrap();
+        grpc_handle.abort();
+    });
+    let (reader, mut writer) = tokio::io::split(client_transport);
+    let reader = BufReader::new(reader);
+
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": { "name": "test-client", "version": "0.0.1" }
+        }
+    });
+    writer
+        .write_all(format!("{request}\n").as_bytes())
+        .await
+        .unwrap();
+
+    (reader, writer, mcp_handle)
+}
+
+async fn read_json(reader: &mut BufReader<tokio::io::ReadHalf<DuplexStream>>) -> Value {
+    let mut response = String::new();
+    reader.read_line(&mut response).await.unwrap();
+    serde_json::from_str(&response).unwrap()
+}
+
+async fn finish(
+    reader: BufReader<tokio::io::ReadHalf<DuplexStream>>,
+    writer: tokio::io::WriteHalf<DuplexStream>,
+    server: JoinHandle<()>,
+) {
+    drop(writer);
+    drop(reader);
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn initialize_prepends_a_cached_update_notice() {
+    let expected = update_available();
+    let expected_message = expected.message();
+    let (mut reader, writer, server) = initialized_client(Some(receiver(expected)), 0).await;
+
+    let response = read_json(&mut reader).await;
+    let instructions = response["result"]["instructions"].as_str().unwrap();
+
+    assert!(instructions.starts_with(&expected_message));
+    assert!(instructions[..instructions.len().min(512)].contains(INSTALL_COMMAND));
+    assert!(instructions.ends_with(EXPECTED_BASE_INSTRUCTIONS));
+    assert!(instructions.len() < 2048);
+
+    finish(reader, writer, server).await;
+}
+
+#[tokio::test]
+async fn initialize_instructs_the_agent_to_check_once() {
+    let current = UpdateCheck::Current {
+        current_version: "0.4.0".to_string(),
+        latest_version: "0.4.0".to_string(),
+    };
+    let (mut reader, writer, server) = initialized_client(Some(receiver(current)), 0).await;
+
+    let response = read_json(&mut reader).await;
+
+    assert_eq!(
+        response["result"]["instructions"],
+        EXPECTED_BASE_INSTRUCTIONS
+    );
+
+    finish(reader, writer, server).await;
+}
+
+#[tokio::test]
+async fn get_info_reports_the_injected_cli_version() {
+    let current = UpdateCheck::Current {
+        current_version: "0.4.0".to_string(),
+        latest_version: "0.4.0".to_string(),
+    };
+    let (server, grpc_handle) = server_with_update_check(Some(receiver(current)), 0).await;
+
+    assert_eq!(
+        ServerHandler::get_info(&server).server_info.version,
+        CLI_VERSION
+    );
+
+    grpc_handle.abort();
+}
+
+#[tokio::test]
+async fn update_tool_waits_for_the_background_check_and_returns_the_install_command() {
+    let (sender, update_check) = watch::channel(UpdateCheck::Checking {
+        current_version: "0.3.0".to_string(),
+    });
+    let (mut reader, mut writer, server) = initialized_client(Some(update_check), 0).await;
+    let _initialize = read_json(&mut reader).await;
+    writer
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n")
+        .await
+        .unwrap();
+    writer
+        .write_all(
+            b"{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"check_for_updates\",\"arguments\":{}}}\n",
+        )
+        .await
+        .unwrap();
+
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        sender.send(update_available()).unwrap();
+    });
+    let response = read_json(&mut reader).await;
+
+    assert_eq!(
+        response["result"]["structuredContent"]["status"],
+        "update_available"
+    );
+    assert_eq!(
+        response["result"]["structuredContent"]["install_command"],
+        INSTALL_COMMAND
+    );
+    assert!(
+        response["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains(INSTALL_COMMAND)
+    );
+
+    finish(reader, writer, server).await;
+}
+
+#[tokio::test]
+async fn update_notice_does_not_change_unrelated_tool_results() {
+    let (mut reader, mut writer, server) =
+        initialized_client(Some(receiver(update_available())), 1).await;
+    let _initialize = read_json(&mut reader).await;
+    writer
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n")
+        .await
+        .unwrap();
+    writer
+        .write_all(
+            b"{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"list_assets\",\"arguments\":{\"filter\":\"\"}}}\n",
+        )
+        .await
+        .unwrap();
+
+    let response = read_json(&mut reader).await;
+
+    assert_eq!(
+        response["result"]["structuredContent"],
+        serde_json::json!({ "assets": [] })
+    );
+    assert_eq!(response["result"]["content"].as_array().unwrap().len(), 1);
+
+    finish(reader, writer, server).await;
+}
+
+#[tokio::test]
+async fn disabled_update_check_is_not_advertised() {
+    let (mut reader, mut writer, server) = initialized_client(None, 0).await;
+    let initialize = read_json(&mut reader).await;
+    let instructions = initialize["result"]["instructions"].as_str().unwrap();
+    assert!(!instructions.contains("check_for_updates"));
+
+    writer
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n")
+        .await
+        .unwrap();
+    writer
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}\n")
+        .await
+        .unwrap();
+    let tools = read_json(&mut reader).await;
+    assert!(
+        tools["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|tool| tool["name"] != "check_for_updates")
+    );
+
+    finish(reader, writer, server).await;
+}

--- a/rust/crates/sift_mcp/src/tool/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/mod.rs
@@ -12,4 +12,5 @@ pub mod rules;
 pub mod runs;
 #[cfg(feature = "test-reports")]
 pub mod test_reports;
+pub mod update;
 pub mod users;

--- a/rust/crates/sift_mcp/src/tool/update/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/update/mod.rs
@@ -1,0 +1,74 @@
+use rmcp::{
+    handler::server::wrapper::Parameters,
+    model::{CallToolResult, ContentBlock},
+    schemars::{self, JsonSchema},
+    tool, tool_router,
+};
+use serde::Deserialize;
+
+use crate::{error, server::SiftMcpServer};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CheckForUpdatesParams {}
+
+#[tool_router(router = update_router, vis = "pub(crate)")]
+impl SiftMcpServer {
+    #[tool(
+        name = "check_for_updates",
+        description = "
+            Check whether this sift-cli and its embedded MCP server are current.
+
+            Output:
+              - `status`: `current`, `update_available`, or `unavailable`.
+              - `current_version`: version of the sift-cli process that hosts this MCP server.
+              - `latest_version`: latest stable release, when known.
+              - `install_command`: exact curl or PowerShell installer command when an update exists.
+              - `message`: text to relay to the user.
+
+            Parameters:
+              - None.
+
+            Errors:
+              - Network and release lookup failures return `status = unavailable`; they do not block other Sift tools.
+
+            Guidance:
+              - Call once before the first other Sift tool in each session.
+              - If `status = update_available`, relay `message` and `install_command` exactly.
+              - If `status = unavailable`, continue with the user's requested Sift task.
+        ",
+        annotations(title = "system/check_for_updates", read_only_hint = true)
+    )]
+    pub async fn check_for_updates(
+        &self,
+        _params: Parameters<CheckForUpdatesParams>,
+    ) -> error::McpResult {
+        let Some(mut receiver) = self.update_check.clone() else {
+            return Err(rmcp::ErrorData::invalid_request(
+                "The update check is disabled for this MCP server.",
+                None,
+            ));
+        };
+        let is_checking = receiver.borrow().is_checking();
+        let update_check = if is_checking && receiver.changed().await.is_err() {
+            let current_version = match &*receiver.borrow() {
+                crate::UpdateCheck::Checking { current_version } => current_version.clone(),
+                update_check => return Ok(update_result(update_check.clone())),
+            };
+            crate::UpdateCheck::Unavailable {
+                current_version,
+                message: "Could not check for a newer sift-cli release. Run `sift-cli --version` for details."
+                    .to_string(),
+            }
+        } else {
+            receiver.borrow().clone()
+        };
+        Ok(update_result(update_check))
+    }
+}
+
+fn update_result(update_check: crate::UpdateCheck) -> CallToolResult {
+    let message = update_check.message();
+    let mut result = CallToolResult::structured(serde_json::json!(update_check));
+    result.content = vec![ContentBlock::text(message)];
+    result
+}

--- a/rust/crates/sift_mcp/src/tool/update/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/update/mod.rs
@@ -26,7 +26,7 @@ impl SiftMcpServer {
               - `message`: text to relay to the user.
 
             Guidance:
-              - Call once before the first other Sift tool in each session.
+              - Call once at the start of each session, before any other Sift tool.
               - If `status = update_available`, relay `message` and `install_command` exactly.
               - If `status = unavailable`, continue with the user's requested Sift task.
         ",

--- a/rust/crates/sift_mcp/src/tool/update/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/update/mod.rs
@@ -25,12 +25,6 @@ impl SiftMcpServer {
               - `install_command`: exact curl or PowerShell installer command when an update exists.
               - `message`: text to relay to the user.
 
-            Parameters:
-              - None.
-
-            Errors:
-              - Network and release lookup failures return `status = unavailable`; they do not block other Sift tools.
-
             Guidance:
               - Call once before the first other Sift tool in each session.
               - If `status = update_available`, relay `message` and `install_command` exactly.


### PR DESCRIPTION
- automatically check for sift-cli updates on first tool use
- flags for enabling / disabling update checker
- provides helpful scripts to run to update to the latest version when out of date

<img width="3020" height="1752" alt="codex update" src="https://github.com/user-attachments/assets/8ee0e783-c88c-4b3b-af45-902cd744f826" />
<img width="2196" height="702" alt="claude update" src="https://github.com/user-attachments/assets/08c39a56-9eda-442d-9465-a9a70254e0b5" />
