### PR TITLE
chore: change ci runners to reduce x86_64 macOS build time

### DIFF
--- a/.github/workflows/sift_cli-v-release.yml
+++ b/.github/workflows/sift_cli-v-release.yml
@@ -135,10 +135,6 @@ jobs:
         if: "runner.os == 'Windows'"
         run: "echo \"CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded\" >> \"$GITHUB_ENV\""
         shell: "bash"
-      - uses: swatinem/rust-cache@v2
-        with:
-          key: ${{ join(matrix.targets, '-') }}
-          cache-provider: ${{ matrix.cache_provider }}
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/.github/workflows/sift_cli-v-release.yml
+++ b/.github/workflows/sift_cli-v-release.yml
@@ -135,6 +135,10 @@ jobs:
         if: "runner.os == 'Windows'"
         run: "echo \"CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded\" >> \"$GITHUB_ENV\""
         shell: "bash"
+      - uses: swatinem/rust-cache@v2
+        with:
+          key: ${{ join(matrix.targets, '-') }}
+          cache-provider: ${{ matrix.cache_provider }}
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -33,7 +33,7 @@ github-build-setup = "includes/build-setup.yml"
 # Windows stays on the default GitHub runner: the RunsOn stack in this org does
 # not serve Windows jobs (verified on PR #726, the job was never picked up).
 [dist.github-custom-runners]
-x86_64-unknown-linux-gnu = "runs-on,runner=8cpu-linux-x64,image=ubuntu22-full-x64"
+x86_64-unknown-linux-gnu = "runs-on,runner=8cpu-linux-x64,image=ubuntu22-full-x64,spot=false"
 
 # Build the Intel macOS binary on an arm64 runner. The M-series runners are
 # much faster than the Intel `macos-*-intel` pool, and Rosetta 2 runs any

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -17,6 +17,9 @@ targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-
 install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = false
+# TEMPORARY: run the full build matrix on this PR to verify the new runners.
+# Revert this commit before merge.
+pr-run-mode = "upload"
 # Build only sift_cli with `--package` instead of the whole workspace. The
 # workspace build compiles sift_stream_bindings (pyo3), which is not part of
 # the CLI release and fails to link when the apple target is cross-compiled.

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -25,13 +25,6 @@ precise-builds = true
 # sift_cli's build.rs invokes `mdbook build`, so mdbook must be on PATH.
 github-build-setup = "includes/build-setup.yml"
 
-# Faster runners for the build matrix. The RunsOn label is static because the
-# matrix comes from the `dist plan` JSON output, where `${{ }}` does not expand.
-# Windows stays on the default GitHub runner: the RunsOn stack in this org does
-# not serve Windows jobs (verified on PR #726, the job was never picked up).
-[dist.github-custom-runners]
-x86_64-unknown-linux-gnu = "runs-on,runner=8cpu-linux-x64,image=ubuntu22-full-x64,spot=false"
-
 # Build the Intel macOS binary on an arm64 runner. The M-series runners are
 # much faster than the Intel `macos-*-intel` pool, and Rosetta 2 runs any
 # x86_64 build-time helper binaries.

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -28,11 +28,12 @@ precise-builds = true
 # sift_cli's build.rs invokes `mdbook build`, so mdbook must be on PATH.
 github-build-setup = "includes/build-setup.yml"
 
-# Faster runners for the build matrix. The RunsOn labels are static because the
+# Faster runners for the build matrix. The RunsOn label is static because the
 # matrix comes from the `dist plan` JSON output, where `${{ }}` does not expand.
+# Windows stays on the default GitHub runner: the RunsOn stack in this org does
+# not serve Windows jobs (verified on PR #726, the job was never picked up).
 [dist.github-custom-runners]
 x86_64-unknown-linux-gnu = "runs-on,runner=8cpu-linux-x64,image=ubuntu22-full-x64"
-x86_64-pc-windows-msvc = "runs-on,image=windows22-full-x64,family=m7i,cpu=8"
 
 # Build the Intel macOS binary on an arm64 runner. The M-series runners are
 # much faster than the Intel `macos-*-intel` pool, and Rosetta 2 runs any

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -17,6 +17,23 @@ targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-
 install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = false
+# Build only sift_cli with `--package` instead of the whole workspace. The
+# workspace build compiles sift_stream_bindings (pyo3), which is not part of
+# the CLI release and fails to link when the apple target is cross-compiled.
+precise-builds = true
 # Extra CI steps injected into the build job before `dist build`.
 # sift_cli's build.rs invokes `mdbook build`, so mdbook must be on PATH.
 github-build-setup = "includes/build-setup.yml"
+
+# Faster runners for the build matrix. The RunsOn labels are static because the
+# matrix comes from the `dist plan` JSON output, where `${{ }}` does not expand.
+[dist.github-custom-runners]
+x86_64-unknown-linux-gnu = "runs-on,runner=8cpu-linux-x64,image=ubuntu22-full-x64"
+x86_64-pc-windows-msvc = "runs-on,image=windows22-full-x64,family=m7i,cpu=8"
+
+# Build the Intel macOS binary on an arm64 runner. The M-series runners are
+# much faster than the Intel `macos-*-intel` pool, and Rosetta 2 runs any
+# x86_64 build-time helper binaries.
+[dist.github-custom-runners.x86_64-apple-darwin]
+runner = "macos-15"
+host = "aarch64-apple-darwin"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -17,9 +17,6 @@ targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-
 install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = false
-# TEMPORARY: run the full build matrix on this PR to verify the new runners.
-# Revert this commit before merge.
-pr-run-mode = "upload"
 # Build only sift_cli with `--package` instead of the whole workspace. The
 # workspace build compiles sift_stream_bindings (pyo3), which is not part of
 # the CLI release and fails to link when the apple target is cross-compiled.


### PR DESCRIPTION
when updating ALL runners to be better, here are the rough diffs:

```
┌────────────────────────────────┬──────────┬─────────┐
│              Job               │   Old    │  Final  │
├────────────────────────────────┼──────────┼─────────┤
│ Linux (RunsOn 8cpu, on-demand) │ 16.5 min │ 6m08s   │
├────────────────────────────────┼──────────┼─────────┤
│ arm64 macOS                    │ 16 min   │ 8m37s   │
├────────────────────────────────┼──────────┼─────────┤
│ x86_64 macOS (arm64 cross)     │ 41 min   │ 11m26s  │
├────────────────────────────────┼──────────┼─────────┤
│ Windows (unchanged runner)     │ 30 min   │ 28m10s  │
├────────────────────────────────┼──────────┼─────────┤
│ Release wall clock             │ ~42 min  │ ~29 min │
└────────────────────────────────┴──────────┴─────────┘
```

so I think if we just update the `x86_64 macOS (arm64 cross)` runner, that will be sufficient, since now we're bottlenecked by windows. reverted the changes I had for Linux and `arm64 macOS`  since the ~16m fall within the 30m bounds now