### PR TITLE
rust(feature): surface stream API error upon stream completion

### DIFF
--- a/rust/crates/sift_stream/src/stream/mode/live_only.rs
+++ b/rust/crates/sift_stream/src/stream/mode/live_only.rs
@@ -164,14 +164,22 @@ impl Transport for LiveStreamingOnly {
     /// Closes the ingestion channel, sends the shutdown signal, and awaits task completion.
     ///
     /// The ingestion task drains any messages already queued before acting on the shutdown
-    /// signal, so all messages sent before `finish` is called will be delivered.
+    /// signal, so all messages sent before `finish` is called are delivered. A returned `Ok`
+    /// is an acknowledgment that every message reached Sift; an `Err` means delivery of some
+    /// data may have failed.
     async fn finish(self, stream_id: &Uuid) -> Result<()> {
         self.ingestion_tx.close();
         let _ = self.control_tx.send(ControlMessage::Shutdown);
-        let _ = self.ingestion_task.await;
+        let joined = self.ingestion_task.await;
         if let Some(t) = self.metrics_streaming {
             let _ = t.await;
         }
+        joined.map_err(|e| {
+            Error::new_msg(
+                ErrorKind::StreamError,
+                format!("ingestion task panicked: {e}"),
+            )
+        })??;
 
         #[cfg(feature = "tracing")]
         tracing::info!(
@@ -383,6 +391,47 @@ mod tests {
 
         let stream_id = uuid::Uuid::new_v4();
         transport.finish(&stream_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_finish_propagates_ingestion_task_error() {
+        let (control_tx, _) = broadcast::channel(10);
+        let (ingestion_tx, _ingestion_rx) = async_channel::bounded::<DataMessage>(10);
+
+        let transport = LiveStreamingOnly {
+            message_id_counter: 0,
+            ingestion_tx,
+            control_tx,
+            ingestion_task: tokio::spawn(async {
+                Err(Error::new_msg(ErrorKind::StreamError, "delivery failed"))
+            }),
+            metrics_streaming: None,
+            flows_seen: HashSet::new(),
+            metrics: Arc::new(crate::metrics::SiftStreamMetrics::default()),
+        };
+
+        let stream_id = uuid::Uuid::new_v4();
+        let err = transport.finish(&stream_id).await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::StreamError);
+    }
+
+    #[tokio::test]
+    async fn test_finish_propagates_ingestion_task_panic() {
+        let (control_tx, _) = broadcast::channel(10);
+        let (ingestion_tx, _ingestion_rx) = async_channel::bounded::<DataMessage>(10);
+
+        let transport = LiveStreamingOnly {
+            message_id_counter: 0,
+            ingestion_tx,
+            control_tx,
+            ingestion_task: tokio::spawn(async { panic!("boom") }),
+            metrics_streaming: None,
+            flows_seen: HashSet::new(),
+            metrics: Arc::new(crate::metrics::SiftStreamMetrics::default()),
+        };
+
+        let stream_id = uuid::Uuid::new_v4();
+        assert!(transport.finish(&stream_id).await.is_err());
     }
 
     #[tokio::test]

--- a/rust/crates/sift_stream/src/stream/mode/live_only.rs
+++ b/rust/crates/sift_stream/src/stream/mode/live_only.rs
@@ -164,9 +164,11 @@ impl Transport for LiveStreamingOnly {
     /// Closes the ingestion channel, sends the shutdown signal, and awaits task completion.
     ///
     /// The ingestion task drains any messages already queued before acting on the shutdown
-    /// signal, so all messages sent before `finish` is called are delivered. A returned `Ok`
-    /// is an acknowledgment that every message reached Sift; an `Err` means delivery of some
-    /// data may have failed.
+    /// signal, so all messages sent before `finish` is called are delivered. An `Err` means the
+    /// stream carrying that tail-end data failed and Sift never acknowledged it; since live-only
+    /// mode keeps no disk backup, that data is unrecoverable. An `Ok` means shutdown completed
+    /// with an acknowledged stream. Note that `Ok` does not account for data lost to earlier
+    /// mid-stream failures that the retry loop recovered from.
     async fn finish(self, stream_id: &Uuid) -> Result<()> {
         self.ingestion_tx.close();
         let _ = self.control_tx.send(ControlMessage::Shutdown);

--- a/rust/crates/sift_stream/src/stream/mode/live_with_backups.rs
+++ b/rust/crates/sift_stream/src/stream/mode/live_with_backups.rs
@@ -296,7 +296,11 @@ impl Transport for LiveStreamingWithBackups {
     /// delivery confirmation from Sift for all data up to this point.
     ///
     /// Always call `finish` when done sending — dropping a [`SiftStream`](crate::SiftStream)
-    /// without calling it may result in tail-end data not reaching Sift.
+    /// without calling it may result in tail-end data not reaching Sift. A returned `Ok` means
+    /// every message was either delivered to Sift or durably written to a disk backup for later
+    /// reingestion; it is not a synchronous receipt that all data reached Sift, since
+    /// reingestion from backups happens in the background. An `Err` means a shutdown or backup
+    /// task failed.
     async fn finish(self, stream_id: &Uuid) -> Result<()> {
         drop(self.ingestion_tx);
         drop(self.backup_tx);
@@ -306,7 +310,10 @@ impl Transport for LiveStreamingWithBackups {
             .map_err(|e| Error::new(ErrorKind::StreamError, e))
             .context("failed to send shutdown signal to task-based architecture")?;
 
-        let _ = tokio::try_join!(
+        // try_join! short-circuits if any task panics, so a panic surfaces as an error
+        // instead of leaving finish() blocked on a sibling task that can no longer make
+        // progress. On success it yields each task's own Result for propagation below.
+        let joined = tokio::try_join!(
             self.ingestion_task,
             self.backup_manager,
             self.reingestion_task,
@@ -315,6 +322,16 @@ impl Transport for LiveStreamingWithBackups {
         if let Some(metrics_streaming) = self.metrics_streaming {
             let _ = metrics_streaming.await;
         }
+
+        let (ingestion_res, backup_res, reingestion_res) = joined.map_err(|e| {
+            Error::new_msg(
+                ErrorKind::StreamError,
+                format!("streaming task panicked: {e}"),
+            )
+        })?;
+        ingestion_res?;
+        backup_res?;
+        reingestion_res?;
 
         #[cfg(feature = "tracing")]
         tracing::info!(
@@ -698,5 +715,54 @@ mod tests {
             3,
             "finish() must await all three internal tasks before returning"
         );
+    }
+
+    #[tokio::test]
+    async fn test_finish_propagates_ingestion_task_error() {
+        let (control_tx, _ctrl_rx) = broadcast::channel::<ControlMessage>(10);
+        let (ingestion_tx, _) = async_channel::bounded::<DataMessage>(10);
+        let (backup_tx, _) = async_channel::bounded::<DataMessage>(10);
+
+        let transport = LiveStreamingWithBackups {
+            message_id_counter: 0,
+            backup_tx,
+            ingestion_tx,
+            control_tx,
+            ingestion_task: tokio::spawn(async {
+                Err(Error::new_msg(ErrorKind::StreamError, "delivery failed"))
+            }),
+            backup_manager: tokio::spawn(async { Ok(()) }),
+            reingestion_task: tokio::spawn(async { Ok(()) }),
+            metrics_streaming: None,
+            flows_seen: std::collections::HashSet::new(),
+            metrics: Arc::new(crate::metrics::SiftStreamMetrics::default()),
+        };
+
+        let stream_id = uuid::Uuid::new_v4();
+        let err = transport.finish(&stream_id).await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::StreamError);
+    }
+
+    #[tokio::test]
+    async fn test_finish_propagates_ingestion_task_panic() {
+        let (control_tx, _ctrl_rx) = broadcast::channel::<ControlMessage>(10);
+        let (ingestion_tx, _) = async_channel::bounded::<DataMessage>(10);
+        let (backup_tx, _) = async_channel::bounded::<DataMessage>(10);
+
+        let transport = LiveStreamingWithBackups {
+            message_id_counter: 0,
+            backup_tx,
+            ingestion_tx,
+            control_tx,
+            ingestion_task: tokio::spawn(async { panic!("boom") }),
+            backup_manager: tokio::spawn(async { Ok(()) }),
+            reingestion_task: tokio::spawn(async { Ok(()) }),
+            metrics_streaming: None,
+            flows_seen: std::collections::HashSet::new(),
+            metrics: Arc::new(crate::metrics::SiftStreamMetrics::default()),
+        };
+
+        let stream_id = uuid::Uuid::new_v4();
+        assert!(transport.finish(&stream_id).await.is_err());
     }
 }

--- a/rust/crates/sift_stream/src/stream/tasks/ingestion.rs
+++ b/rust/crates/sift_stream/src/stream/tasks/ingestion.rs
@@ -167,6 +167,24 @@ impl IngestionTask {
                             // be consumed by a later non-overlapping CheckpointComplete, causing
                             // backup files from the failed stream to be deleted without re-ingestion.
                             self.control_tx.send(ControlMessage::CheckpointComplete { first_message_id: first_message_id.load(Ordering::Relaxed), last_message_id: last_message_id.load(Ordering::Relaxed) }).map_err(|e| Error::new(ErrorKind::StreamError, e))?;
+
+                            // A closed data channel means `finish` was called, so no further
+                            // stream will be created to carry what this one was holding. In
+                            // live-only mode there is no backup or reingestion path either, so
+                            // the data is unrecoverable. Surface it here rather than breaking
+                            // into a clean shutdown; otherwise whether the loss is reported
+                            // depends on which `select!` branch observes the shutdown first.
+                            if self.config.checkpoint_interval.is_none() && self.data_rx.is_closed() {
+                                #[cfg(feature = "tracing")]
+                                tracing::error!(
+                                    sift_stream_id = %self.config.sift_stream_id,
+                                    error = %e,
+                                    "stream failed after shutdown began; not retrying"
+                                );
+
+                                return Err(Error::new(ErrorKind::StreamError, e))
+                                    .context("stream to Sift failed during shutdown");
+                            }
                         }
                     }
 
@@ -1034,5 +1052,46 @@ mod tests {
             saw_reingest,
             "backups mode should emit CheckpointNeedsReingestion for the failed final flush"
         );
+    }
+
+    /// Regression test for the shutdown race: the run loop can observe the closed data channel
+    /// from the failed-stream arm instead of the `Shutdown` control message, which used to break
+    /// into a clean shutdown and report `Ok` for data that never reached Sift. Closing the data
+    /// channel without sending `Shutdown` forces that arm deterministically.
+    #[tokio::test]
+    async fn test_live_only_stream_failure_after_close_errors() {
+        let (ingestion_channel, mock_service) =
+            crate::test::create_mock_grpc_channel_with_service().await;
+        let (control_tx, _control_rx) = broadcast::channel(1024);
+        let (data_tx, data_rx) = async_channel::bounded(1024);
+        let metrics = Arc::new(SiftStreamMetrics::default());
+        let mut config = make_live_only_ingestion_task_config(ingestion_channel, metrics);
+        config.retry_policy = RetryPolicy {
+            max_attempts: 3,
+            initial_backoff: Duration::from_millis(1),
+            max_backoff: Duration::from_millis(10),
+            backoff_multiplier: 2,
+        };
+
+        // Every stream attempt fails, so nothing is ever acknowledged by Sift.
+        mock_service.set_num_errors_to_return(usize::MAX);
+
+        let control_rx_task = control_tx.subscribe();
+        let mut ingestion_task = IngestionTask::new(control_tx, control_rx_task, data_rx, config);
+
+        let handle = tokio::spawn(async move { ingestion_task.run().await });
+
+        send_messages_for_ingestion(&data_tx, 10).await;
+
+        // Close the channel without a Shutdown message.
+        data_tx.close();
+
+        let res = tokio::time::timeout(Duration::from_secs(10), handle)
+            .await
+            .expect("ingestion task should not hang")
+            .expect("ingestion task should not panic");
+
+        let err = res.expect_err("live-only mode must not report Ok for undelivered data");
+        assert_eq!(err.kind(), ErrorKind::StreamError);
     }
 }

--- a/rust/crates/sift_stream/src/stream/tasks/ingestion.rs
+++ b/rust/crates/sift_stream/src/stream/tasks/ingestion.rs
@@ -328,6 +328,15 @@ impl IngestionTask {
                         error = %e,
                         "final stream failed"
                     );
+
+                    // In live-only mode there is no backup or reingestion path to recover
+                    // this data, so a failed final flush is unrecoverable loss. Surface it so
+                    // finish() does not falsely acknowledge delivery.
+                    if self.config.checkpoint_interval.is_none() {
+                        return Err(Error::new(ErrorKind::StreamError, e))
+                            .context("final stream flush to Sift failed during shutdown");
+                    }
+
                     self.control_tx
                         .send(ControlMessage::CheckpointNeedsReingestion {
                             first_message_id: first_message_id.load(Ordering::Relaxed),
@@ -952,6 +961,77 @@ mod tests {
             metrics.messages_sent.get(),
             10,
             "should have sent 10 messages"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_live_only_final_flush_failure_errors() {
+        let (ingestion_channel, _mock_service) =
+            crate::test::create_mock_grpc_channel_with_service().await;
+        let (control_tx, _control_rx) = broadcast::channel(1024);
+        let (_data_tx, data_rx) = async_channel::bounded::<DataMessage>(1024);
+        let metrics = Arc::new(SiftStreamMetrics::default());
+        let config = make_live_only_ingestion_task_config(ingestion_channel, metrics);
+
+        let control_rx_task = control_tx.subscribe();
+        let mut ingestion_task = IngestionTask::new(control_tx, control_rx_task, data_rx, config);
+
+        let failing_stream = Some(Box::pin(async {
+            Err::<(), GrpcStatus>(GrpcStatus::unavailable("sift unreachable"))
+        }));
+
+        let result = ingestion_task
+            .shutdown(
+                failing_stream,
+                Arc::new(AtomicU64::new(0)),
+                Arc::new(AtomicU64::new(0)),
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "live-only shutdown must surface a failed final flush as an error"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_backups_final_flush_failure_reingests() {
+        let (ingestion_channel, _mock_service) =
+            crate::test::create_mock_grpc_channel_with_service().await;
+        let (control_tx, mut control_rx) = broadcast::channel(1024);
+        let (_data_tx, data_rx) = async_channel::bounded::<DataMessage>(1024);
+        let metrics = Arc::new(SiftStreamMetrics::default());
+        let config = make_ingestion_task_config(ingestion_channel, metrics, Duration::from_secs(60));
+
+        let control_rx_task = control_tx.subscribe();
+        let mut ingestion_task = IngestionTask::new(control_tx, control_rx_task, data_rx, config);
+
+        let failing_stream = Some(Box::pin(async {
+            Err::<(), GrpcStatus>(GrpcStatus::unavailable("sift unreachable"))
+        }));
+
+        let result = ingestion_task
+            .shutdown(
+                failing_stream,
+                Arc::new(AtomicU64::new(0)),
+                Arc::new(AtomicU64::new(0)),
+            )
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "backups mode routes a failed final flush to reingestion, not an error"
+        );
+
+        let mut saw_reingest = false;
+        while let Ok(msg) = control_rx.try_recv() {
+            if matches!(msg, ControlMessage::CheckpointNeedsReingestion { .. }) {
+                saw_reingest = true;
+            }
+        }
+        assert!(
+            saw_reingest,
+            "backups mode should emit CheckpointNeedsReingestion for the failed final flush"
         );
     }
 }

--- a/rust/crates/sift_stream/src/stream/tasks/ingestion.rs
+++ b/rust/crates/sift_stream/src/stream/tasks/ingestion.rs
@@ -1001,7 +1001,8 @@ mod tests {
         let (control_tx, mut control_rx) = broadcast::channel(1024);
         let (_data_tx, data_rx) = async_channel::bounded::<DataMessage>(1024);
         let metrics = Arc::new(SiftStreamMetrics::default());
-        let config = make_ingestion_task_config(ingestion_channel, metrics, Duration::from_secs(60));
+        let config =
+            make_ingestion_task_config(ingestion_channel, metrics, Duration::from_secs(60));
 
         let control_rx_task = control_tx.subscribe();
         let mut ingestion_task = IngestionTask::new(control_tx, control_rx_task, data_rx, config);

--- a/rust/crates/sift_stream/tests/test_live_only_streaming_retries.rs
+++ b/rust/crates/sift_stream/tests/test_live_only_streaming_retries.rs
@@ -1,4 +1,5 @@
 use chrono::Local;
+use sift_error::prelude::ErrorKind;
 use sift_rs::{
     common::r#type::v1::ChannelDataType,
     ingest::v1::{
@@ -198,7 +199,14 @@ pub async fn test_live_only_retries_exhausted() {
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 
-    assert!(sift_stream.finish().await.is_ok());
+    // The server never accepted any data, so the final flush during shutdown cannot succeed.
+    // In live-only mode there is no backup to fall back on, so `finish` must report the loss
+    // instead of acknowledging delivery.
+    let err = sift_stream
+        .finish()
+        .await
+        .expect_err("finish must surface undelivered data in live-only mode");
+    assert_eq!(err.kind(), ErrorKind::StreamError);
 
     assert!(
         server.await.is_ok(),


### PR DESCRIPTION
## Changes

Previously we would eat up the streaming API error that would get returned upon stream termination but we should return it to the user so they get final acknowledgment about whether or not their data has been received.

## Verification

- Unit testing
- Manual testing

