### PR TITLE
rust(feat): sift cli get assets

### DIFF
--- a/rust/crates/sift_cli/src/cli/mod.rs
+++ b/rust/crates/sift_cli/src/cli/mod.rs
@@ -51,6 +51,10 @@ pub enum Cmd {
     #[command(subcommand)]
     Export(ExportCmd),
 
+    /// Get commands to discover and pull data from Sift
+    #[command(subcommand)]
+    Get(GetCmd),
+
     /// Ping the Sift API to verify credentials and connectivity
     Ping,
 
@@ -309,6 +313,12 @@ pub enum ImportCmd {
     /// Run without a subcommand to import; use `ls` to list files without importing.
     #[command(name = "backups")]
     Backup(BackupArgs),
+}
+
+#[derive(Subcommand)]
+pub enum GetCmd {
+    /// Get assets
+    Asset(GetAssetArgs),
 }
 
 #[derive(Subcommand)]
@@ -867,4 +877,11 @@ impl DocArgs {
     fn default_addr() -> SocketAddr {
         "0.0.0.0:3000".parse().unwrap()
     }
+}
+
+#[derive(clap::Args)]
+pub struct GetAssetArgs {
+    /// Filter option for filtering search
+    #[arg(long)]
+    pub filter: Option<String>,
 }

--- a/rust/crates/sift_cli/src/cli/mod.rs
+++ b/rust/crates/sift_cli/src/cli/mod.rs
@@ -881,7 +881,11 @@ impl DocArgs {
 
 #[derive(clap::Args)]
 pub struct GetAssetArgs {
-    /// Filter option for filtering search
+    /// Filter option for filtering search with CEL expression
     #[arg(long)]
     pub filter: Option<String>,
+
+    /// Caps returned results to set number
+    #[arg(long, default_value = "50")]
+    pub limit: Option<u32>,
 }

--- a/rust/crates/sift_cli/src/cli/mod.rs
+++ b/rust/crates/sift_cli/src/cli/mod.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand, crate_version};
+use clap::{Parser, Subcommand, ValueEnum, crate_version};
 use clap_complete::Shell;
 use parquet::{ChannelMode, ComplexTypesMode};
 pub mod hdf5;
@@ -879,6 +879,13 @@ impl DocArgs {
     }
 }
 
+#[derive(Clone, Copy, ValueEnum, Debug, PartialEq, Eq)]
+#[value(rename_all = "lowercase")]
+pub enum OutputFormats {
+    Text,
+    Json,
+}
+
 #[derive(clap::Args)]
 pub struct GetAssetArgs {
     /// Filter option for filtering search with CEL expression
@@ -888,4 +895,8 @@ pub struct GetAssetArgs {
     /// Caps returned results to set number
     #[arg(long, default_value = "50")]
     pub limit: Option<u32>,
+
+    /// Determines the output format
+    #[arg(long, value_enum)]
+    pub output_format: Option<OutputFormats>,
 }

--- a/rust/crates/sift_cli/src/cmd/get/assets.rs
+++ b/rust/crates/sift_cli/src/cmd/get/assets.rs
@@ -6,9 +6,15 @@ use sift_rs::assets::v1::{
 };
 
 use crate::{
+    BIN_NAME,
     cli::GetAssetArgs,
     cmd::Context,
-    util::{api::create_grpc_channel, tty::Output},
+    util::{
+        api::create_grpc_channel,
+        app_uri::normalize_app_uri,
+        explore_url::build_explore_url,
+        tty::{Output, hyperlink, link_style, stdout_is_tty},
+    },
 };
 
 const ASSET_ID_CHAR_LENGTH_WHITESPACE_LENGTH: usize = 38;
@@ -26,10 +32,13 @@ pub async fn run(ctx: Context, args: GetAssetArgs) -> Result<ExitCode> {
         .await
         .context("failed to list assets")?
         .into_inner();
+    let app_uri = ctx.app_uri.as_deref().and_then(normalize_app_uri);
     let mut output = Output::new();
     if assets.is_empty() {
         output.line("no assets found");
     } else {
+        let linkify = stdout_is_tty();
+
         output.line(format_args!(
             "{:<width$}{}",
             "ID",
@@ -37,13 +46,24 @@ pub async fn run(ctx: Context, args: GetAssetArgs) -> Result<ExitCode> {
             width = ASSET_ID_CHAR_LENGTH_WHITESPACE_LENGTH,
         ));
         for asset in &assets {
+            let name = match build_explore_url(app_uri, &asset.name, None) {
+                Some(url) if linkify => hyperlink(&link_style(&asset.name), &url),
+                _ => asset.name.clone(),
+            };
             output.line(format_args!(
-                "{:<width$}{}",
+                "{:<width$}{name}",
                 asset.asset_id,
-                asset.name,
                 width = ASSET_ID_CHAR_LENGTH_WHITESPACE_LENGTH,
             ));
         }
+        output.tip(match app_uri {
+            Some(host) => {
+                format!("View an asset in Explore at {host}/explore?method=single&assets=<NAME>")
+            }
+            None => format!(
+                "Run `{BIN_NAME} config update --app-uri <SIFT_WEB_ORIGIN>` for Explore links."
+            ),
+        });
     }
     output.print();
 

--- a/rust/crates/sift_cli/src/cmd/get/assets.rs
+++ b/rust/crates/sift_cli/src/cmd/get/assets.rs
@@ -20,7 +20,7 @@ pub async fn run(ctx: Context, args: GetAssetArgs) -> Result<ExitCode> {
         .list_assets(ListAssetsRequest {
             filter: args.filter.unwrap_or_default(),
             order_by: "modified_date desc".to_string(),
-            page_size: 50,
+            page_size: args.limit.unwrap_or_default(),
             ..Default::default()
         })
         .await

--- a/rust/crates/sift_cli/src/cmd/get/assets.rs
+++ b/rust/crates/sift_cli/src/cmd/get/assets.rs
@@ -1,0 +1,51 @@
+use std::process::ExitCode;
+
+use anyhow::{Context as AnyhowContext, Result};
+use sift_rs::assets::v1::{
+    ListAssetsRequest, ListAssetsResponse, asset_service_client::AssetServiceClient,
+};
+
+use crate::{
+    cli::GetAssetArgs,
+    cmd::Context,
+    util::{api::create_grpc_channel, tty::Output},
+};
+
+const ASSET_ID_CHAR_LENGTH_WHITESPACE_LENGTH: usize = 38;
+
+pub async fn run(ctx: Context, args: GetAssetArgs) -> Result<ExitCode> {
+    let grpc_channel = create_grpc_channel(&ctx)?;
+
+    let ListAssetsResponse { assets, .. } = AssetServiceClient::new(grpc_channel)
+        .list_assets(ListAssetsRequest {
+            filter: args.filter.unwrap_or_default(),
+            order_by: "modified_date desc".to_string(),
+            page_size: 50,
+            ..Default::default()
+        })
+        .await
+        .context("failed to list assets")?
+        .into_inner();
+    let mut output = Output::new();
+    if assets.is_empty() {
+        output.line("no assets found");
+    } else {
+        output.line(format_args!(
+            "{:<width$}{}",
+            "ID",
+            "Name",
+            width = ASSET_ID_CHAR_LENGTH_WHITESPACE_LENGTH,
+        ));
+        for asset in &assets {
+            output.line(format_args!(
+                "{:<width$}{}",
+                asset.asset_id,
+                asset.name,
+                width = ASSET_ID_CHAR_LENGTH_WHITESPACE_LENGTH,
+            ));
+        }
+    }
+    output.print();
+
+    Ok(ExitCode::SUCCESS)
+}

--- a/rust/crates/sift_cli/src/cmd/get/assets.rs
+++ b/rust/crates/sift_cli/src/cmd/get/assets.rs
@@ -7,7 +7,7 @@ use sift_rs::assets::v1::{
 
 use crate::{
     BIN_NAME,
-    cli::GetAssetArgs,
+    cli::{GetAssetArgs, OutputFormats},
     cmd::Context,
     util::{
         api::create_grpc_channel,
@@ -34,36 +34,44 @@ pub async fn run(ctx: Context, args: GetAssetArgs) -> Result<ExitCode> {
         .into_inner();
     let app_uri = ctx.app_uri.as_deref().and_then(normalize_app_uri);
     let mut output = Output::new();
-    if assets.is_empty() {
-        output.line("no assets found");
-    } else {
-        let linkify = stdout_is_tty();
-
-        output.line(format_args!(
-            "{:<width$}{}",
-            "ID",
-            "Name",
-            width = ASSET_ID_CHAR_LENGTH_WHITESPACE_LENGTH,
-        ));
-        for asset in &assets {
-            let name = match build_explore_url(app_uri, &asset.name, None) {
-                Some(url) if linkify => hyperlink(&link_style(&asset.name), &url),
-                _ => asset.name.clone(),
-            };
-            output.line(format_args!(
-                "{:<width$}{name}",
-                asset.asset_id,
-                width = ASSET_ID_CHAR_LENGTH_WHITESPACE_LENGTH,
-            ));
+    match args.output_format {
+        Some(OutputFormats::Json) => {
+            output.line(serde_json::to_string_pretty(&assets).context("failed to encode assets")?);
         }
-        output.tip(match app_uri {
-            Some(host) => {
-                format!("View an asset in Explore at {host}/explore?method=single&assets=<NAME>")
+        Some(OutputFormats::Text) | None => {
+            if assets.is_empty() {
+                output.line("no assets found");
+            } else {
+                let linkify = stdout_is_tty();
+
+                output.line(format_args!(
+                    "{:<width$}{}",
+                    "ID",
+                    "Name",
+                    width = ASSET_ID_CHAR_LENGTH_WHITESPACE_LENGTH,
+                ));
+                for asset in &assets {
+                    let name = match build_explore_url(app_uri, &asset.name, None) {
+                        Some(url) if linkify => hyperlink(&link_style(&asset.name), &url),
+                        _ => asset.name.clone(),
+                    };
+                    output.line(format_args!(
+                        "{:<width$}{name}",
+                        asset.asset_id,
+                        width = ASSET_ID_CHAR_LENGTH_WHITESPACE_LENGTH,
+                    ));
+                }
+                output.tip(match app_uri {
+                    Some(host) => format!(
+                        "View an asset in Explore at {host}/explore?method=single&assets=<NAME>"
+                    ),
+                    None => format!(
+                        "Run `{BIN_NAME} config update --app-uri <SIFT_WEB_ORIGIN>` for Explore \
+                         links."
+                    ),
+                });
             }
-            None => format!(
-                "Run `{BIN_NAME} config update --app-uri <SIFT_WEB_ORIGIN>` for Explore links."
-            ),
-        });
+        }
     }
     output.print();
 

--- a/rust/crates/sift_cli/src/cmd/get/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/get/mod.rs
@@ -1,0 +1,1 @@
+pub mod assets;

--- a/rust/crates/sift_cli/src/cmd/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/mod.rs
@@ -9,6 +9,7 @@ pub mod agent;
 pub mod config;
 pub mod doc;
 pub mod export;
+pub mod get;
 pub mod import;
 pub mod install;
 pub mod mcp;

--- a/rust/crates/sift_cli/src/main.rs
+++ b/rust/crates/sift_cli/src/main.rs
@@ -154,6 +154,9 @@ fn run(clargs: cli::Args) -> Result<ExitCode> {
             cli::ExportCmd::Run(args) => run_future(cmd::export::run(ctx, args)),
             cli::ExportCmd::Asset(args) => run_future(cmd::export::asset(ctx, args)),
         },
+        Cmd::Get(cmd) => match cmd {
+            cli::GetCmd::Asset(args) => run_future(cmd::get::assets::run(ctx, args)),
+        },
         Cmd::Ping => run_future(cmd::ping::run(ctx)),
         _ => Ok(ExitCode::SUCCESS),
     }

--- a/rust/crates/sift_cli/src/util/explore_url.rs
+++ b/rust/crates/sift_cli/src/util/explore_url.rs
@@ -72,7 +72,6 @@ pub fn build_explore_url(
 mod tests {
     use super::{build_explore_url, import_target};
 
-
     #[test]
     fn import_target_uses_the_configured_app_uri() {
         let target = import_target(

--- a/rust/crates/sift_cli/src/util/explore_url.rs
+++ b/rust/crates/sift_cli/src/util/explore_url.rs
@@ -72,6 +72,7 @@ pub fn build_explore_url(
 mod tests {
     use super::{build_explore_url, import_target};
 
+
     #[test]
     fn import_target_uses_the_configured_app_uri() {
         let target = import_target(

--- a/rust/crates/sift_cli/src/util/tty.rs
+++ b/rust/crates/sift_cli/src/util/tty.rs
@@ -1,4 +1,7 @@
-use std::io::{self, Write};
+use std::{
+    fmt::Display,
+    io::{self, Write},
+};
 
 use anyhow::Result;
 use crossterm::style::Stylize;
@@ -67,8 +70,8 @@ impl Output {
         Self::default()
     }
 
-    pub fn line<S: Into<String>>(&mut self, txt: S) -> &mut Self {
-        self.lines.push(txt.into());
+    pub fn line<S: Display>(&mut self, txt: S) -> &mut Self {
+        self.lines.push(txt.to_string());
         self
     }
 

--- a/rust/crates/sift_cli/src/util/tty.rs
+++ b/rust/crates/sift_cli/src/util/tty.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt::Display,
-    io::{self, Write},
+    io::{self, IsTerminal, Write},
 };
 
 use anyhow::Result;
@@ -59,6 +59,18 @@ impl PromptUser {
     }
 }
 
+pub fn stdout_is_tty() -> bool {
+    io::stdout().is_terminal()
+}
+
+pub fn hyperlink(text: &str, url: &str) -> String {
+    format!("\x1b]8;;{url}\x1b\\{text}\x1b]8;;\x1b\\")
+}
+
+pub fn link_style(text: &str) -> String {
+    text.cyan().underlined().to_string()
+}
+
 #[derive(Default)]
 pub struct Output {
     lines: Vec<String>,
@@ -102,5 +114,26 @@ impl Output {
             return;
         }
         eprintln!("{}: {out}", "error".red())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::hyperlink;
+
+    #[test]
+    fn hyperlink_wraps_text_in_an_osc_8_sequence() {
+        assert_eq!(
+            hyperlink("engine", "https://app.siftstack.com/explore?assets=engine"),
+            "\x1b]8;;https://app.siftstack.com/explore?assets=engine\x1b\\engine\x1b]8;;\x1b\\"
+        );
+    }
+
+    #[test]
+    fn hyperlink_leaves_the_visible_width_unchanged() {
+        let link = hyperlink("engine", "https://app.siftstack.com");
+        assert!(link.contains("engine"));
+        assert!(link.starts_with("\x1b]8;;"));
+        assert!(link.ends_with("\x1b]8;;\x1b\\"));
     }
 }


### PR DESCRIPTION
# Description
Adds `sift-cli get asset` for listing assets. Returns in a table by default with hyperlinks to the asset in explore. By default we list out the most recent 50 assets by `modified_on` date
It has a few flags:
    - `--filter` takes a CEL expression
    - `--limit` lets you edit how many rows you get back
    - `--output-format` lets you determine the output format, current flags are text and json
   

# Verification
- Unit tests
- Manual testing