### PR TITLE
rust(feat): agent install works without client binaries

### DIFF
--- a/rust/crates/sift_cli/CHANGELOG.md
+++ b/rust/crates/sift_cli/CHANGELOG.md
@@ -16,6 +16,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   a client-CLI-backed MCP registration that cannot run is skipped with a
   warning instead of failing the install. `agent doctor` reports such a
   registration as a warning rather than an error.
+- Added an optional `--path <DIR>` to `sift-cli agent install` that installs
+  the agent skill into the named directory in addition to every detected
+  client, for image builds and other environments that package the skill at a
+  fixed location. The directory receives `SKILL.md` and `references/`
+  directly; rerun with the same `--path` to refresh it.
 
 ## [v0.4.1] - August 10, 2026
 

--- a/rust/crates/sift_cli/CHANGELOG.md
+++ b/rust/crates/sift_cli/CHANGELOG.md
@@ -20,7 +20,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   the agent skill into the named directory in addition to every detected
   client, for image builds and other environments that package the skill at a
   fixed location. The directory receives `SKILL.md` and `references/`
-  directly; rerun with the same `--path` to refresh it.
+  directly; rerun with the same `--path` to refresh it. Without `--path`, the
+  skill installs only to the default locations for detected clients.
 
 ## [v0.4.1] - August 10, 2026
 

--- a/rust/crates/sift_cli/CHANGELOG.md
+++ b/rust/crates/sift_cli/CHANGELOG.md
@@ -10,6 +10,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added a `--disable-nonessential-traffic` flag to `sift-cli mcp` that stops
   the MCP server from making non-essential network requests. Release checks
   stay under `--disable-update-check`.
+- `sift-cli agent install` now works in headless environments (container
+  builds, CI). A client's config directory counts as detection even when its
+  binary is not on PATH, the skill always installs (it is plain file IO), and
+  a client-CLI-backed MCP registration that cannot run is skipped with a
+  warning instead of failing the install. `agent doctor` reports such a
+  registration as a warning rather than an error.
 
 ## [v0.4.1] - August 10, 2026
 

--- a/rust/crates/sift_cli/src/cli/mod.rs
+++ b/rust/crates/sift_cli/src/cli/mod.rs
@@ -147,9 +147,8 @@ pub struct AgentInstallArgs {
     #[arg(long)]
     pub disable_update_check: bool,
 
-    /// Also install the agent skill into this directory, in addition to every
-    /// detected client. The directory receives SKILL.md and references/
-    /// directly; rerun with the same --path to refresh it.
+    /// Install the agent skill into this directory too, even when no clients
+    /// are detected. Rerun with the same --path to refresh it.
     #[arg(long, value_name = "DIR")]
     pub path: Option<std::path::PathBuf>,
 }

--- a/rust/crates/sift_cli/src/cli/mod.rs
+++ b/rust/crates/sift_cli/src/cli/mod.rs
@@ -146,6 +146,12 @@ pub struct AgentInstallArgs {
     /// Disable release checks in every installed MCP server
     #[arg(long)]
     pub disable_update_check: bool,
+
+    /// Also install the agent skill into this directory, in addition to every
+    /// detected client. The directory receives SKILL.md and references/
+    /// directly; rerun with the same --path to refresh it.
+    #[arg(long, value_name = "DIR")]
+    pub path: Option<std::path::PathBuf>,
 }
 
 #[derive(clap::Args)]

--- a/rust/crates/sift_cli/src/cmd/agent/config.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/config.rs
@@ -70,6 +70,7 @@ pub(super) enum State {
     Current(Registration),
     ManagedDrift(Registration),
     Conflict(String),
+    Unregistrable(String),
     Unavailable(String),
 }
 
@@ -86,7 +87,9 @@ pub(super) fn snapshot(harness: Harness, environment: &Environment) -> Result<Sn
                 State::Current(_) | State::ManagedDrift(_) => {
                     SnapshotContents::Native(inspection.entry)
                 }
-                State::Conflict(detail) | State::Unavailable(detail) => {
+                State::Conflict(detail)
+                | State::Unregistrable(detail)
+                | State::Unavailable(detail) => {
                     return Err(anyhow!(
                         "{} MCP registration cannot be snapshotted: {detail}",
                         harness.label()
@@ -190,7 +193,7 @@ fn uninstall_with(
 ) -> Result<bool> {
     match inspect_with(harness, environment, runner)? {
         State::Missing => Ok(false),
-        State::Conflict(_) | State::Unavailable(_) => Ok(false),
+        State::Conflict(_) | State::Unregistrable(_) | State::Unavailable(_) => Ok(false),
         State::Current(_) | State::ManagedDrift(_) => match harness {
             Harness::Claude | Harness::Codex => {
                 remove_native(harness, runner)?;
@@ -221,7 +224,7 @@ fn inspect_native(
 fn inspect_claude(environment: &Environment, runner: &dyn Runner) -> Result<NativeInspection> {
     if !environment.command_available("claude") {
         return Ok(NativeInspection {
-            state: State::Unavailable("`claude` is not available on PATH".to_string()),
+            state: State::Unregistrable("`claude` is not available on PATH".to_string()),
             entry: None,
         });
     }
@@ -284,7 +287,7 @@ fn inspect_claude(environment: &Environment, runner: &dyn Runner) -> Result<Nati
 fn inspect_codex(environment: &Environment, runner: &dyn Runner) -> Result<NativeInspection> {
     if !environment.command_available("codex") {
         return Ok(NativeInspection {
-            state: State::Unavailable("`codex` is not available on PATH".to_string()),
+            state: State::Unregistrable("`codex` is not available on PATH".to_string()),
             entry: None,
         });
     }
@@ -345,7 +348,7 @@ fn install_native(
     let previous = match inspection.state {
         State::Missing => None,
         State::Current(_) | State::ManagedDrift(_) => inspection.entry,
-        State::Conflict(detail) | State::Unavailable(detail) => {
+        State::Conflict(detail) | State::Unregistrable(detail) | State::Unavailable(detail) => {
             return Err(anyhow!(
                 "{} MCP registration cannot be replaced: {detail}",
                 harness.label()
@@ -384,7 +387,7 @@ fn restore_native(
     let current = match inspection.state {
         State::Missing => None,
         State::Current(_) | State::ManagedDrift(_) => inspection.entry,
-        State::Conflict(detail) | State::Unavailable(detail) => {
+        State::Conflict(detail) | State::Unregistrable(detail) | State::Unavailable(detail) => {
             return Err(anyhow!(
                 "{} MCP registration cannot be restored: {detail}",
                 harness.label()

--- a/rust/crates/sift_cli/src/cmd/agent/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/mod.rs
@@ -181,10 +181,12 @@ impl Environment {
                 let command_exists = commands
                     .iter()
                     .any(|command| self.command_available(command));
-                let detected = match harness {
-                    Harness::Claude | Harness::Codex => command_exists,
-                    Harness::Cursor | Harness::OpenCode => command_exists || config_dir.exists(),
-                };
+                // A config directory counts as detection even without the
+                // client binary on PATH, so headless environments (container
+                // builds, CI) can install the skill: skill installation is
+                // plain file IO, and a registration that needs the client's
+                // own CLI is skipped with a warning instead of failing.
+                let detected = command_exists || config_dir.exists();
                 detected.then_some(harness)
             })
             .collect()
@@ -439,13 +441,15 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
                 blocked = true;
             }
             config::State::Unavailable(detail) => {
+                // The client's own CLI is missing (headless image, uninstalled
+                // client with a leftover config directory). Nothing about the
+                // Sift setup is broken, so report it without failing doctor.
                 println!(
-                    "{} {} MCP registration: {detail}",
-                    error_status(),
+                    "{} {} MCP registration not inspectable: {detail}",
+                    warning_status(),
                     harness.label()
                 );
-                unhealthy = true;
-                blocked = true;
+                warnings = true;
             }
         }
     }
@@ -730,13 +734,23 @@ fn install_environment(
             ));
         }
     }
+    // A harness whose registration is unavailable (its own CLI is not on
+    // PATH) still gets the skill: skill installation is plain file IO. Only
+    // the MCP registration is skipped, with a warning below.
+    let mut registrable = Vec::new();
+    let mut skipped = Vec::new();
     for harness in &environment.harnesses {
         let state = config::inspect(*harness, environment)?;
         match state {
-            config::State::Conflict(detail) | config::State::Unavailable(detail) => {
+            config::State::Conflict(detail) => {
                 blockers.push(format!("{} MCP registration: {detail}", harness.label()));
             }
-            _ => {}
+            config::State::Unavailable(detail) => {
+                skipped.push((*harness, detail));
+            }
+            _ => {
+                registrable.push(*harness);
+            }
         }
     }
 
@@ -749,8 +763,7 @@ fn install_environment(
         return Ok(ExitCode::FAILURE);
     }
 
-    let config_snapshots = environment
-        .harnesses
+    let config_snapshots = registrable
         .iter()
         .map(|harness| config::snapshot(*harness, environment))
         .collect::<Result<Vec<_>>>()?;
@@ -760,7 +773,7 @@ fn install_environment(
         for target in &targets {
             replacements.push(skill::begin_install(&target.path)?);
         }
-        for harness in &environment.harnesses {
+        for harness in &registrable {
             config::install(*harness, environment, registration)?;
             installed_configs += 1;
         }
@@ -810,7 +823,7 @@ fn install_environment(
             target.path.display()
         );
     }
-    for harness in &environment.harnesses {
+    for harness in &registrable {
         println!(
             "{} {verb} {} MCP registration ({})",
             ok_status(),
@@ -818,12 +831,28 @@ fn install_environment(
             registration.label()
         );
     }
+    for (harness, detail) in &skipped {
+        println!(
+            "{} Skipped {} MCP registration: {detail}. The skill is installed; rerun \
+             `{} agent install` once the client is available.",
+            warning_status(),
+            harness.label(),
+            registration.profile.command_prefix()
+        );
+    }
 
-    println!(
-        "{verb} the Sift agent bundle for: {} ({}).",
-        harness_labels(&environment.harnesses),
-        registration.label()
-    );
+    if registrable.is_empty() {
+        println!(
+            "{verb} the Sift agent skill for: {}; no MCP registrations were made.",
+            harness_labels(&environment.harnesses)
+        );
+    } else {
+        println!(
+            "{verb} the Sift agent bundle for: {} ({}).",
+            harness_labels(&registrable),
+            registration.label()
+        );
+    }
     Ok(ExitCode::SUCCESS)
 }
 

--- a/rust/crates/sift_cli/src/cmd/agent/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/mod.rs
@@ -443,7 +443,15 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
                 blocked = true;
             }
             config::State::Unavailable(detail) => {
-                // A missing client binary is not a broken Sift setup.
+                println!(
+                    "{} {} MCP registration: {detail}",
+                    error_status(),
+                    harness.label()
+                );
+                unhealthy = true;
+                blocked = true;
+            }
+            config::State::Unregistrable(detail) => {
                 println!(
                     "{} {} MCP registration not inspectable: {detail}",
                     warning_status(),
@@ -558,8 +566,8 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
     if unhealthy {
         if blocked {
             println!(
-                "Resolve the reported conflicts before repairing all detected integrations \
-                 together."
+                "Resolve the reported conflicts or inspection errors before repairing all \
+                 detected integrations together."
             );
         }
         if mixed_access {
@@ -654,6 +662,7 @@ fn uninstall_environment(environment: &Environment) -> Result<ExitCode> {
             config::State::Conflict(detail) | config::State::Unavailable(detail) => {
                 blockers.push(format!("{} MCP registration: {detail}", harness.label()));
             }
+            config::State::Unregistrable(_) => {}
             _ => {}
         }
     }
@@ -679,6 +688,7 @@ fn uninstall_environment(environment: &Environment) -> Result<ExitCode> {
         }
     }
 
+    let mut skipped_registration = false;
     for harness in &environment.harnesses {
         let state = config::inspect(*harness, environment)?;
         match &state {
@@ -694,6 +704,14 @@ fn uninstall_environment(environment: &Environment) -> Result<ExitCode> {
                     harness.label()
                 );
             }
+            config::State::Unregistrable(detail) => {
+                println!(
+                    "{} Skipped {} MCP registration: {detail}",
+                    warning_status(),
+                    harness.label()
+                );
+                skipped_registration = true;
+            }
             config::State::Current(_) | config::State::ManagedDrift(_) => {
                 config::uninstall(*harness, environment)?;
                 println!("[removed] {} MCP registration", harness.label());
@@ -701,7 +719,11 @@ fn uninstall_environment(environment: &Environment) -> Result<ExitCode> {
         }
     }
 
-    println!("Removed the Sift agent bundle from every detected client.");
+    if skipped_registration {
+        println!("Removed the Sift agent skills; inaccessible MCP registrations were unchanged.");
+    } else {
+        println!("Removed the Sift agent bundle from every detected client.");
+    }
     Ok(ExitCode::SUCCESS)
 }
 
@@ -745,17 +767,15 @@ fn install_environment(
             ));
         }
     }
-    // Unavailable means the client's own CLI is missing; the skill still
-    // installs and only the registration is skipped, with a warning below.
     let mut registrable = Vec::new();
     let mut skipped = Vec::new();
     for harness in &environment.harnesses {
         let state = config::inspect(*harness, environment)?;
         match state {
-            config::State::Conflict(detail) => {
+            config::State::Conflict(detail) | config::State::Unavailable(detail) => {
                 blockers.push(format!("{} MCP registration: {detail}", harness.label()));
             }
-            config::State::Unavailable(detail) => {
+            config::State::Unregistrable(detail) => {
                 skipped.push((*harness, detail));
             }
             _ => {

--- a/rust/crates/sift_cli/src/cmd/agent/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/mod.rs
@@ -226,7 +226,12 @@ pub async fn install(profile: Option<String>, args: AgentInstallArgs) -> Result<
     };
     let registration = Registration::new(access, Profile::from_option(profile))
         .with_update_check_disabled(args.disable_update_check);
-    let result = install_environment(&Environment::discover()?, "Installed", &registration)?;
+    let result = install_environment(
+        &Environment::discover()?,
+        "Installed",
+        &registration,
+        args.path.as_deref(),
+    )?;
     if result == ExitCode::SUCCESS {
         print_install_update_notice().await;
     }
@@ -329,7 +334,7 @@ pub async fn update(profile: Option<String>, args: AgentUpdateArgs) -> Result<Ex
     let registration =
         Registration::new(access, profile).with_update_check_disabled(disable_update_check);
 
-    install_environment(&environment, "Updated", &registration)
+    install_environment(&environment, "Updated", &registration, None)
 }
 
 pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
@@ -709,8 +714,9 @@ fn install_environment(
     environment: &Environment,
     verb: &str,
     registration: &Registration,
+    extra_skill_path: Option<&Path>,
 ) -> Result<ExitCode> {
-    if environment.harnesses.is_empty() {
+    if environment.harnesses.is_empty() && extra_skill_path.is_none() {
         println!(
             "No supported AI coding clients were detected. Supported clients: \
              Claude Code, Codex, Cursor, and OpenCode."
@@ -723,13 +729,24 @@ fn install_environment(
     let spinner = Spinner::new();
     spinner.set_message(format!("{} Sift MCP and skills...", "Installing".green()));
 
-    let targets = skill::targets(environment);
+    let mut targets = skill::targets(environment);
+    // An explicit --path receives the skill in addition to the detected
+    // clients. An empty harness list marks it as caller-requested; skip it
+    // when a detected client already installs to the same directory.
+    if let Some(path) = extra_skill_path
+        && !targets.iter().any(|target| target.path == path)
+    {
+        targets.push(skill::Target {
+            path: path.to_path_buf(),
+            harnesses: Vec::new(),
+        });
+    }
     let mut blockers = Vec::new();
     for target in &targets {
         if skill::inspect(&target.path)? == skill::State::Conflict {
             blockers.push(format!(
                 "{} has an unmanaged skill at {}",
-                harness_labels(&target.harnesses),
+                target_label(&target.harnesses),
                 target.path.display()
             ));
         }
@@ -819,7 +836,7 @@ fn install_environment(
         println!(
             "{} {verb} {} skill: {}",
             ok_status(),
-            harness_labels(&target.harnesses),
+            target_label(&target.harnesses),
             target.path.display()
         );
     }
@@ -844,7 +861,7 @@ fn install_environment(
     if registrable.is_empty() {
         println!(
             "{verb} the Sift agent skill for: {}; no MCP registrations were made.",
-            harness_labels(&environment.harnesses)
+            target_label(&environment.harnesses)
         );
     } else {
         println!(
@@ -1002,6 +1019,16 @@ async fn check_release() -> bool {
             );
             false
         }
+    }
+}
+
+/// Like `harness_labels`, but names a target with no harnesses behind it:
+/// a skill directory the caller requested explicitly via `--path`.
+fn target_label(harnesses: &[Harness]) -> String {
+    if harnesses.is_empty() {
+        "requested --path".to_string()
+    } else {
+        harness_labels(harnesses)
     }
 }
 

--- a/rust/crates/sift_cli/src/cmd/agent/mod.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/mod.rs
@@ -181,11 +181,8 @@ impl Environment {
                 let command_exists = commands
                     .iter()
                     .any(|command| self.command_available(command));
-                // A config directory counts as detection even without the
-                // client binary on PATH, so headless environments (container
-                // builds, CI) can install the skill: skill installation is
-                // plain file IO, and a registration that needs the client's
-                // own CLI is skipped with a warning instead of failing.
+                // A config directory alone counts, so headless environments
+                // without client binaries still install the skill.
                 let detected = command_exists || config_dir.exists();
                 detected.then_some(harness)
             })
@@ -446,9 +443,7 @@ pub async fn doctor(expected_profile: Option<String>) -> Result<ExitCode> {
                 blocked = true;
             }
             config::State::Unavailable(detail) => {
-                // The client's own CLI is missing (headless image, uninstalled
-                // client with a leftover config directory). Nothing about the
-                // Sift setup is broken, so report it without failing doctor.
+                // A missing client binary is not a broken Sift setup.
                 println!(
                     "{} {} MCP registration not inspectable: {detail}",
                     warning_status(),
@@ -730,9 +725,8 @@ fn install_environment(
     spinner.set_message(format!("{} Sift MCP and skills...", "Installing".green()));
 
     let mut targets = skill::targets(environment);
-    // An explicit --path receives the skill in addition to the detected
-    // clients. An empty harness list marks it as caller-requested; skip it
-    // when a detected client already installs to the same directory.
+    // Empty harnesses marks the caller-requested --path target; drop it when
+    // a detected client already installs to the same directory.
     if let Some(path) = extra_skill_path
         && !targets.iter().any(|target| target.path == path)
     {
@@ -751,9 +745,8 @@ fn install_environment(
             ));
         }
     }
-    // A harness whose registration is unavailable (its own CLI is not on
-    // PATH) still gets the skill: skill installation is plain file IO. Only
-    // the MCP registration is skipped, with a warning below.
+    // Unavailable means the client's own CLI is missing; the skill still
+    // installs and only the registration is skipped, with a warning below.
     let mut registrable = Vec::new();
     let mut skipped = Vec::new();
     for harness in &environment.harnesses {
@@ -1022,8 +1015,7 @@ async fn check_release() -> bool {
     }
 }
 
-/// Like `harness_labels`, but names a target with no harnesses behind it:
-/// a skill directory the caller requested explicitly via `--path`.
+/// `harness_labels`, with a name for the caller-requested `--path` target.
 fn target_label(harnesses: &[Harness]) -> String {
     if harnesses.is_empty() {
         "requested --path".to_string()

--- a/rust/crates/sift_cli/src/cmd/agent/skill.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/skill.rs
@@ -109,6 +109,17 @@ pub(super) fn inspect(path: &Path) -> Result<State> {
         }
     }
 
+    let mut entries =
+        fs::read_dir(path).with_context(|| format!("failed to read {}", path.display()))?;
+    if entries
+        .next()
+        .transpose()
+        .with_context(|| format!("failed to read {}", path.display()))?
+        .is_none()
+    {
+        return Ok(State::Missing);
+    }
+
     if directory_matches(&BUNDLE, path)? {
         return Ok(State::Current);
     }

--- a/rust/crates/sift_cli/src/cmd/agent/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/tests.rs
@@ -35,7 +35,10 @@ fn status_tags_use_expected_colors() {
 }
 
 #[test]
-fn stale_native_config_directories_are_not_detected_as_installed_clients() {
+fn native_config_directories_detect_clients_without_binaries() {
+    // Headless environments (container builds, CI) have a config directory
+    // but no client binary on PATH. Detection must still fire so the skill
+    // installs; the binary-dependent MCP registration degrades separately.
     let directory = TempDir::new("sift-cli-agent-detection").unwrap();
     fs::create_dir_all(directory.path().join(".claude")).unwrap();
     fs::create_dir_all(directory.path().join(".codex")).unwrap();
@@ -45,7 +48,41 @@ fn stale_native_config_directories_are_not_detected_as_installed_clients() {
         Vec::new(),
     );
 
-    assert!(environment.detect_harnesses().is_empty());
+    assert_eq!(
+        environment.detect_harnesses(),
+        vec![Harness::Claude, Harness::Codex]
+    );
+}
+
+#[test]
+fn install_without_client_binaries_installs_the_skill_and_skips_registration() {
+    // The container/CI case end to end: Claude Code detected via ~/.claude
+    // with no `claude` on PATH. The skill must install and the run must
+    // succeed; only the MCP registration is skipped.
+    let directory = TempDir::new("sift-cli-agent-headless-install").unwrap();
+    fs::create_dir_all(directory.path().join(".claude")).unwrap();
+    let environment = Environment::for_test(
+        directory.path().to_path_buf(),
+        directory.path().join("bin/sift-cli"),
+        vec![Harness::Claude],
+    );
+
+    let exit = super::install_environment(
+        &environment,
+        "Installed",
+        &default_registration(AccessMode::ReadOnly),
+    )
+    .unwrap();
+
+    // ExitCode has no PartialEq; its Debug form distinguishes SUCCESS/FAILURE.
+    assert_eq!(
+        format!("{exit:?}"),
+        format!("{:?}", std::process::ExitCode::SUCCESS)
+    );
+    let skill_path = directory.path().join(".claude/skills/sift/SKILL.md");
+    assert_eq!(fs::read_to_string(skill_path).unwrap(), skill::CONTENT);
+    // No registration side effects: nothing wrote a Claude config file.
+    assert!(!directory.path().join(".claude.json").exists());
 }
 
 #[test]

--- a/rust/crates/sift_cli/src/cmd/agent/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/tests.rs
@@ -71,6 +71,7 @@ fn install_without_client_binaries_installs_the_skill_and_skips_registration() {
         &environment,
         "Installed",
         &default_registration(AccessMode::ReadOnly),
+        None,
     )
     .unwrap();
 
@@ -83,6 +84,68 @@ fn install_without_client_binaries_installs_the_skill_and_skips_registration() {
     assert_eq!(fs::read_to_string(skill_path).unwrap(), skill::CONTENT);
     // No registration side effects: nothing wrote a Claude config file.
     assert!(!directory.path().join(".claude.json").exists());
+}
+
+#[test]
+fn install_with_path_and_no_clients_installs_only_there() {
+    // An image build with no coding clients at all still installs the skill
+    // when the caller names the destination.
+    let directory = TempDir::new("sift-cli-agent-path-only").unwrap();
+    let skill_dir = directory.path().join("resources/skills/sift");
+    let environment = Environment::for_test(
+        directory.path().to_path_buf(),
+        directory.path().join("bin/sift-cli"),
+        Vec::new(),
+    );
+
+    let exit = super::install_environment(
+        &environment,
+        "Installed",
+        &default_registration(AccessMode::ReadOnly),
+        Some(&skill_dir),
+    )
+    .unwrap();
+
+    assert_eq!(
+        format!("{exit:?}"),
+        format!("{:?}", std::process::ExitCode::SUCCESS)
+    );
+    assert_eq!(
+        fs::read_to_string(skill_dir.join("SKILL.md")).unwrap(),
+        skill::CONTENT
+    );
+    assert_eq!(skill::inspect(&skill_dir).unwrap(), skill::State::Current);
+}
+
+#[test]
+fn install_with_path_adds_to_detected_clients() {
+    let directory = TempDir::new("sift-cli-agent-path-extra").unwrap();
+    let skill_dir = directory.path().join("bundle/skills/sift");
+    let environment = Environment::for_test(
+        directory.path().to_path_buf(),
+        directory.path().join("bin/sift-cli"),
+        vec![Harness::Cursor],
+    );
+
+    super::install_environment(
+        &environment,
+        "Installed",
+        &default_registration(AccessMode::ReadOnly),
+        Some(&skill_dir),
+    )
+    .unwrap();
+
+    // Both the requested path and the detected client's shared skill exist,
+    // and the client's MCP registration still happened.
+    assert_eq!(skill::inspect(&skill_dir).unwrap(), skill::State::Current);
+    assert_eq!(
+        skill::inspect(&directory.path().join(".agents/skills/sift")).unwrap(),
+        skill::State::Current
+    );
+    assert_eq!(
+        config::inspect(Harness::Cursor, &environment).unwrap(),
+        config::State::Current(default_registration(AccessMode::ReadOnly))
+    );
 }
 
 #[test]
@@ -382,6 +445,7 @@ fn malformed_config_container_is_caught_during_preflight() {
         &environment,
         "Installed",
         &default_registration(AccessMode::ReadOnly),
+        None,
     )
     .unwrap();
 
@@ -608,6 +672,7 @@ fn install_preflight_keeps_every_target_unchanged_on_conflict() {
         &environment,
         "Installed",
         &default_registration(AccessMode::ReadOnly),
+        None,
     )
     .unwrap();
 
@@ -638,6 +703,7 @@ fn failed_later_client_install_rolls_back_earlier_clients_and_skills() {
         &environment,
         "Installed",
         &default_registration(AccessMode::ReadOnly),
+        None,
     );
 
     fs::set_permissions(&opencode_dir, fs::Permissions::from_mode(0o755)).unwrap();

--- a/rust/crates/sift_cli/src/cmd/agent/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/tests.rs
@@ -36,9 +36,6 @@ fn status_tags_use_expected_colors() {
 
 #[test]
 fn native_config_directories_detect_clients_without_binaries() {
-    // Headless environments (container builds, CI) have a config directory
-    // but no client binary on PATH. Detection must still fire so the skill
-    // installs; the binary-dependent MCP registration degrades separately.
     let directory = TempDir::new("sift-cli-agent-detection").unwrap();
     fs::create_dir_all(directory.path().join(".claude")).unwrap();
     fs::create_dir_all(directory.path().join(".codex")).unwrap();
@@ -56,9 +53,6 @@ fn native_config_directories_detect_clients_without_binaries() {
 
 #[test]
 fn install_without_client_binaries_installs_the_skill_and_skips_registration() {
-    // The container/CI case end to end: Claude Code detected via ~/.claude
-    // with no `claude` on PATH. The skill must install and the run must
-    // succeed; only the MCP registration is skipped.
     let directory = TempDir::new("sift-cli-agent-headless-install").unwrap();
     fs::create_dir_all(directory.path().join(".claude")).unwrap();
     let environment = Environment::for_test(
@@ -82,14 +76,11 @@ fn install_without_client_binaries_installs_the_skill_and_skips_registration() {
     );
     let skill_path = directory.path().join(".claude/skills/sift/SKILL.md");
     assert_eq!(fs::read_to_string(skill_path).unwrap(), skill::CONTENT);
-    // No registration side effects: nothing wrote a Claude config file.
     assert!(!directory.path().join(".claude.json").exists());
 }
 
 #[test]
 fn install_with_path_and_no_clients_installs_only_there() {
-    // An image build with no coding clients at all still installs the skill
-    // when the caller names the destination.
     let directory = TempDir::new("sift-cli-agent-path-only").unwrap();
     let skill_dir = directory.path().join("resources/skills/sift");
     let environment = Environment::for_test(
@@ -135,8 +126,6 @@ fn install_with_path_adds_to_detected_clients() {
     )
     .unwrap();
 
-    // Both the requested path and the detected client's shared skill exist,
-    // and the client's MCP registration still happened.
     assert_eq!(skill::inspect(&skill_dir).unwrap(), skill::State::Current);
     assert_eq!(
         skill::inspect(&directory.path().join(".agents/skills/sift")).unwrap(),

--- a/rust/crates/sift_cli/src/cmd/agent/tests.rs
+++ b/rust/crates/sift_cli/src/cmd/agent/tests.rs
@@ -109,6 +109,33 @@ fn install_with_path_and_no_clients_installs_only_there() {
 }
 
 #[test]
+fn install_with_path_accepts_an_existing_empty_directory() {
+    let directory = TempDir::new("sift-cli-agent-empty-path").unwrap();
+    let skill_dir = directory.path().join("resources/skills/sift");
+    fs::create_dir_all(&skill_dir).unwrap();
+    let environment = Environment::for_test(
+        directory.path().to_path_buf(),
+        directory.path().join("bin/sift-cli"),
+        Vec::new(),
+    );
+
+    assert_eq!(skill::inspect(&skill_dir).unwrap(), skill::State::Missing);
+    let exit = super::install_environment(
+        &environment,
+        "Installed",
+        &default_registration(AccessMode::ReadOnly),
+        Some(&skill_dir),
+    )
+    .unwrap();
+
+    assert_eq!(
+        format!("{exit:?}"),
+        format!("{:?}", std::process::ExitCode::SUCCESS)
+    );
+    assert_eq!(skill::inspect(&skill_dir).unwrap(), skill::State::Current);
+}
+
+#[test]
 fn install_with_path_adds_to_detected_clients() {
     let directory = TempDir::new("sift-cli-agent-path-extra").unwrap();
     let skill_dir = directory.path().join("bundle/skills/sift");
@@ -445,6 +472,34 @@ fn malformed_config_container_is_caught_during_preflight() {
     );
 }
 
+#[test]
+fn invalid_json_is_not_skipped_during_install_preflight() {
+    let directory = TempDir::new("sift-cli-agent-invalid-json").unwrap();
+    let environment = Environment::for_test(
+        directory.path().to_path_buf(),
+        directory.path().join("bin/sift-cli"),
+        vec![Harness::Cursor],
+    );
+    let config_path = directory.path().join(".cursor/mcp.json");
+    fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    fs::write(&config_path, "not JSON").unwrap();
+
+    let exit = super::install_environment(
+        &environment,
+        "Installed",
+        &default_registration(AccessMode::ReadOnly),
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(
+        format!("{exit:?}"),
+        format!("{:?}", std::process::ExitCode::FAILURE)
+    );
+    assert!(!directory.path().join(".agents/skills/sift").exists());
+    assert_eq!(fs::read_to_string(config_path).unwrap(), "not JSON");
+}
+
 #[cfg(unix)]
 #[test]
 fn symlinked_skill_is_never_replaced() {
@@ -727,4 +782,24 @@ fn uninstall_preflight_keeps_every_target_unchanged_on_conflict() {
     super::uninstall_environment(&environment).unwrap();
 
     assert!(skill_path.exists());
+}
+
+#[test]
+fn uninstall_without_client_binary_removes_the_skill() {
+    let directory = TempDir::new("sift-cli-agent-headless-uninstall").unwrap();
+    let environment = Environment::for_test(
+        directory.path().to_path_buf(),
+        directory.path().join("bin/sift-cli"),
+        vec![Harness::Claude],
+    );
+    let skill_path = directory.path().join(".claude/skills/sift");
+    skill::install(&skill_path).unwrap();
+
+    let exit = super::uninstall_environment(&environment).unwrap();
+
+    assert_eq!(
+        format!("{exit:?}"),
+        format!("{:?}", std::process::ExitCode::SUCCESS)
+    );
+    assert!(!skill_path.exists());
 }


### PR DESCRIPTION
## Description

`sift-cli agent install` no longer requires the client binaries. A client's config directory (`~/.claude`, `~/.codex`) now counts as detection, the skill installs via plain file IO, and an MCP registration that needs the client's own CLI is skipped with a warning instead of failing the install. `agent doctor` reports an uninspectable registration as a warning, not an error. Conflicts still block the install as before.

Adds `--path <DIR>` to install the skill into a fixed directory, even with zero detected clients, for image builds and packaging.

## Verification

- `cargo test -p sift_cli`: 210 passed, including end-to-end tests for the no-binary install and both `--path` cases.
- `cargo clippy -p sift_cli --all-targets` and `cargo fmt --check` clean.
- Manual: a fresh HOME with only `.claude/` and no client binaries on PATH installs the skill, prints the skip warning, and exits 0.
