### PR TITLE
rust(feat): --disable-nonessential-traffic flag mcp

### DIFF
--- a/rust/crates/sift_cli/CHANGELOG.md
+++ b/rust/crates/sift_cli/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### What's New
 
+- Added a `--disable-nonessential-traffic` flag to `sift-cli mcp` that stops
+  the MCP server from making non-essential network requests. Release checks
+  stay under `--disable-update-check`.
+
 ## [v0.4.1] - August 10, 2026
 
 ### What's New

--- a/rust/crates/sift_cli/src/cli/mod.rs
+++ b/rust/crates/sift_cli/src/cli/mod.rs
@@ -89,6 +89,11 @@ pub struct McpArgs {
     /// Disable the MCP update tool and all automatic release checks
     #[arg(long)]
     pub disable_update_check: bool,
+
+    /// Disable non-essential network traffic. Release checks are controlled
+    /// separately by `--disable-update-check`.
+    #[arg(long)]
+    pub disable_nonessential_traffic: bool,
 }
 
 /// Serve the bundled Sift CLI user documentation over HTTP.

--- a/rust/crates/sift_cli/src/cmd/mcp.rs
+++ b/rust/crates/sift_cli/src/cmd/mcp.rs
@@ -42,8 +42,12 @@ pub async fn run(ctx: Context, args: McpArgs, app_uri: String) -> Result<ExitCod
 
     let update_check = select_update_check(args.disable_update_check, start_update_check);
     let cli_version = env!("CARGO_PKG_VERSION").to_string();
-    let client_event_config =
-        sift_mcp::ClientEventConfig::new(ctx.rest_uri.clone(), ctx.api_key.clone(), cli_version);
+    let client_event_config = select_client_event_config(args.disable_nonessential_traffic, || {
+        sift_mcp::ClientEventConfig::new(ctx.rest_uri.clone(), ctx.api_key.clone())
+    });
+    if client_event_config.is_none() {
+        tracing::info!("non-essential traffic is disabled");
+    }
 
     let credentials = Credentials::Config {
         uri: ctx.grpc_uri,
@@ -55,6 +59,7 @@ pub async fn run(ctx: Context, args: McpArgs, app_uri: String) -> Result<ExitCod
         app_uri,
         args.allow_create,
         args.allow_destructive,
+        cli_version,
         update_check,
         client_event_config,
     )
@@ -79,6 +84,16 @@ where
     F: FnOnce() -> sift_mcp::UpdateCheckReceiver,
 {
     (!disable_update_check).then(start)
+}
+
+fn select_client_event_config<F>(
+    disable_nonessential_traffic: bool,
+    build: F,
+) -> Option<sift_mcp::ClientEventConfig>
+where
+    F: FnOnce() -> sift_mcp::ClientEventConfig,
+{
+    (!disable_nonessential_traffic).then(build)
 }
 
 fn start_update_check() -> sift_mcp::UpdateCheckReceiver {
@@ -172,7 +187,7 @@ mod tests {
     use semver::Version;
     use tokio::sync::watch;
 
-    use super::{select_update_check, update_check_from_versions};
+    use super::{select_client_event_config, select_update_check, update_check_from_versions};
 
     #[test]
     fn disable_update_check_flag_is_accepted() {
@@ -199,6 +214,47 @@ mod tests {
 
         assert!(update_check.is_none());
         assert!(!called.get());
+    }
+
+    #[test]
+    fn disable_nonessential_traffic_flag_is_accepted() {
+        let args =
+            crate::cli::Args::try_parse_from(["sift-cli", "mcp", "--disable-nonessential-traffic"])
+                .unwrap();
+        let Some(crate::cli::Cmd::Mcp(args)) = args.cmd else {
+            panic!("expected the MCP command");
+        };
+
+        assert!(args.disable_nonessential_traffic);
+        assert!(!args.disable_update_check);
+    }
+
+    #[test]
+    fn disabled_nonessential_traffic_does_not_build_a_client_event_config() {
+        let called = Cell::new(false);
+
+        let client_event_config = select_client_event_config(true, || {
+            called.set(true);
+            sift_mcp::ClientEventConfig::new(
+                "https://rest.test.local".to_string(),
+                "test-key".to_string(),
+            )
+        });
+
+        assert!(client_event_config.is_none());
+        assert!(!called.get());
+    }
+
+    #[test]
+    fn enabled_nonessential_traffic_builds_a_client_event_config() {
+        let client_event_config = select_client_event_config(false, || {
+            sift_mcp::ClientEventConfig::new(
+                "https://rest.test.local".to_string(),
+                "test-key".to_string(),
+            )
+        });
+
+        assert!(client_event_config.is_some());
     }
 
     #[test]

--- a/rust/crates/sift_mcp/src/client_event.rs
+++ b/rust/crates/sift_mcp/src/client_event.rs
@@ -15,23 +15,16 @@ static TOOL_EVENTS: LazyLock<HashMap<String, String>> = LazyLock::new(|| {
 pub struct ClientEventConfig {
     rest_uri: String,
     api_key: String,
-    cli_version: String,
 }
 
 impl ClientEventConfig {
-    pub fn new(rest_uri: String, api_key: String, cli_version: String) -> Self {
-        Self {
-            rest_uri,
-            api_key,
-            cli_version,
-        }
-    }
-
-    pub(crate) fn cli_version(&self) -> &str {
-        &self.cli_version
+    pub fn new(rest_uri: String, api_key: String) -> Self {
+        Self { rest_uri, api_key }
     }
 }
 
+/// A reporter without a target never builds a request, which is how a server
+/// launched with `--disable-nonessential-traffic` stays silent.
 #[derive(Clone, Default)]
 pub(crate) struct ClientEventReporter {
     target: Option<ClientEventTarget>,
@@ -51,7 +44,11 @@ struct ClientEventRequest {
 }
 
 impl ClientEventReporter {
-    pub(crate) fn new(config: ClientEventConfig) -> Self {
+    pub(crate) fn from_config(config: Option<ClientEventConfig>, cli_version: &str) -> Self {
+        config.map_or_else(Self::default, |config| Self::new(config, cli_version))
+    }
+
+    pub(crate) fn new(config: ClientEventConfig, cli_version: &str) -> Self {
         let endpoint = format!(
             "{}{CLIENT_EVENT_PATH}",
             config.rest_uri.trim_end_matches('/')
@@ -61,9 +58,14 @@ impl ClientEventReporter {
                 client: reqwest::Client::new(),
                 endpoint,
                 api_key: config.api_key,
-                user_agent: format!("{CLIENT_NAME}/{}", config.cli_version),
+                user_agent: format!("{CLIENT_NAME}/{cli_version}"),
             }),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_reporting(&self) -> bool {
+        self.target.is_some()
     }
 
     pub(crate) async fn send(&self, tool_name: &str) -> reqwest::Result<()> {
@@ -150,11 +152,10 @@ mod tests {
     #[tokio::test]
     async fn sends_only_the_event_with_the_cli_version() {
         let (rest_uri, server) = start_event_server().await;
-        let reporter = ClientEventReporter::new(ClientEventConfig::new(
-            rest_uri,
-            "test-key".to_string(),
-            "7.8.9".to_string(),
-        ));
+        let reporter = ClientEventReporter::new(
+            ClientEventConfig::new(rest_uri, "test-key".to_string()),
+            "7.8.9",
+        );
 
         reporter.send("list_assets").await.unwrap();
         let request = String::from_utf8(server.await.unwrap()).unwrap();
@@ -176,6 +177,21 @@ mod tests {
             serde_json::json!({
                 "event": "CLIENT_EVENT_USER_CALLED_MCP_TOOL_LIST_ASSETS"
             })
+        );
+    }
+
+    #[test]
+    fn a_missing_config_reports_nothing() {
+        assert!(!ClientEventReporter::from_config(None, "7.8.9").is_reporting());
+        assert!(
+            ClientEventReporter::from_config(
+                Some(ClientEventConfig::new(
+                    "https://rest.test.local".to_string(),
+                    "test-key".to_string(),
+                )),
+                "7.8.9",
+            )
+            .is_reporting()
         );
     }
 }

--- a/rust/crates/sift_mcp/src/lib.rs
+++ b/rust/crates/sift_mcp/src/lib.rs
@@ -100,32 +100,34 @@ pub async fn run_with_update_check(
     cli_version: String,
     update_check: Option<UpdateCheckReceiver>,
 ) -> Result<()> {
-    run_server(
+    run_with_client_events(
         credentials,
         use_tls,
-        RunConfig {
-            app_uri,
-            allow_create,
-            allow_destructive,
-            cli_version,
-            update_check,
-            client_event_reporter: client_event::ClientEventReporter::default(),
-        },
+        app_uri,
+        allow_create,
+        allow_destructive,
+        cli_version,
+        update_check,
+        None,
     )
     .await
 }
 
+/// Runs the server, reporting anonymous tool-call events only when a client
+/// event config is supplied. `None` leaves the server silent, which is what
+/// `sift-cli mcp --disable-nonessential-traffic` passes.
 pub async fn run_with_client_events(
     credentials: Credentials,
     use_tls: bool,
     app_uri: String,
     allow_create: bool,
     allow_destructive: bool,
+    cli_version: String,
     update_check: Option<UpdateCheckReceiver>,
-    client_event_config: ClientEventConfig,
+    client_event_config: Option<ClientEventConfig>,
 ) -> Result<()> {
-    let cli_version = client_event_config.cli_version().to_string();
-    let client_event_reporter = client_event::ClientEventReporter::new(client_event_config);
+    let client_event_reporter =
+        client_event::ClientEventReporter::from_config(client_event_config, &cli_version);
     run_server(
         credentials,
         use_tls,

--- a/rust/crates/sift_mcp/src/server/test.rs
+++ b/rust/crates/sift_mcp/src/server/test.rs
@@ -306,11 +306,10 @@ async fn every_registered_tool_has_a_client_event() {
 
 #[tokio::test]
 async fn client_event_failure_does_not_change_the_tool_result() {
-    let reporter = ClientEventReporter::new(ClientEventConfig::new(
-        "invalid rest URI".to_string(),
-        "test-key".to_string(),
-        CLI_VERSION.to_string(),
-    ));
+    let reporter = ClientEventReporter::new(
+        ClientEventConfig::new("invalid rest URI".to_string(), "test-key".to_string()),
+        CLI_VERSION,
+    );
     let (mut reader, mut writer, server) = connected_client_with_events(None, 1, reporter).await;
     let initialize = serde_json::json!({
         "jsonrpc": "2.0",
@@ -351,11 +350,10 @@ async fn client_event_failure_does_not_change_the_tool_result() {
 #[tokio::test]
 async fn tool_call_sends_its_client_event() {
     let (rest_uri, event_server) = start_event_server().await;
-    let reporter = ClientEventReporter::new(ClientEventConfig::new(
-        rest_uri,
-        "test-key".to_string(),
-        CLI_VERSION.to_string(),
-    ));
+    let reporter = ClientEventReporter::new(
+        ClientEventConfig::new(rest_uri, "test-key".to_string()),
+        CLI_VERSION,
+    );
     let (mut reader, mut writer, server) = connected_client_with_events(None, 1, reporter).await;
     let initialize = serde_json::json!({
         "jsonrpc": "2.0",


### PR DESCRIPTION
Adds `--disable-nonessential-traffic` to `sift-cli mcp`. When set, the server makes no non-essential network requests. Release checks stay under `--disable-update-check`.