### PR TITLE
rust(chore): rust release prep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 
 [workspace.package]
 authors = ["Sift Software Engineers <engineering@siftstack.com>"]
-version = "0.10.2"
+version = "0.11.0"
 edition = "2024"
 categories = ["aerospace", "science::robotics"]
 homepage = "https://github.com/sift-stack/sift"
@@ -85,15 +85,15 @@ tracing-test = { version = "0.2", features = ["no-env-filter"] }
 uuid = { version = "1.22", features = ["v4"] }
 zip = "8.2"
 
-sift_connect = { version = "0.10.2", path = "rust/crates/sift_connect" }
-sift_rs = { version = "0.10.2", path = "rust/crates/sift_rs" }
-sift_error = { version = "0.10.2", path = "rust/crates/sift_error" }
-sift_stream = { version = "0.10.2", path = "rust/crates/sift_stream" }
-sift_pbfs = { version = "0.10.2", path = "rust/crates/sift_pbfs" }
-sift_mcp = { version = "0.10.2", path = "rust/crates/sift_mcp" }
-sift_test_util = { version = "0.10.2", path = "rust/crates/sift_test_util" }
+sift_connect = { version = "0.11.0", path = "rust/crates/sift_connect" }
+sift_rs = { version = "0.11.0", path = "rust/crates/sift_rs" }
+sift_error = { version = "0.11.0", path = "rust/crates/sift_error" }
+sift_stream = { version = "0.11.0", path = "rust/crates/sift_stream" }
+sift_pbfs = { version = "0.11.0", path = "rust/crates/sift_pbfs" }
+sift_mcp = { version = "0.11.0", path = "rust/crates/sift_mcp" }
+sift_test_util = { version = "0.11.0", path = "rust/crates/sift_test_util" }
 
-sift_stream_bindings = { version = "0.4.2", path = "rust/crates/sift_stream_bindings" }
+sift_stream_bindings = { version = "0.5.0", path = "rust/crates/sift_stream_bindings" }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 
 [workspace.package]
 authors = ["Sift Software Engineers <engineering@siftstack.com>"]
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 categories = ["aerospace", "science::robotics"]
 homepage = "https://github.com/sift-stack/sift"
@@ -85,15 +85,15 @@ tracing-test = { version = "0.2", features = ["no-env-filter"] }
 uuid = { version = "1.22", features = ["v4"] }
 zip = "8.2"
 
-sift_connect = { version = "0.10.1", path = "rust/crates/sift_connect" }
-sift_rs = { version = "0.10.1", path = "rust/crates/sift_rs" }
-sift_error = { version = "0.10.1", path = "rust/crates/sift_error" }
-sift_stream = { version = "0.10.1", path = "rust/crates/sift_stream" }
-sift_pbfs = { version = "0.10.1", path = "rust/crates/sift_pbfs" }
-sift_mcp = { version = "0.10.1", path = "rust/crates/sift_mcp" }
-sift_test_util = { version = "0.10.1", path = "rust/crates/sift_test_util" }
+sift_connect = { version = "0.10.2", path = "rust/crates/sift_connect" }
+sift_rs = { version = "0.10.2", path = "rust/crates/sift_rs" }
+sift_error = { version = "0.10.2", path = "rust/crates/sift_error" }
+sift_stream = { version = "0.10.2", path = "rust/crates/sift_stream" }
+sift_pbfs = { version = "0.10.2", path = "rust/crates/sift_pbfs" }
+sift_mcp = { version = "0.10.2", path = "rust/crates/sift_mcp" }
+sift_test_util = { version = "0.10.2", path = "rust/crates/sift_test_util" }
 
-sift_stream_bindings = { version = "0.4.1", path = "rust/crates/sift_stream_bindings" }
+sift_stream_bindings = { version = "0.4.2", path = "rust/crates/sift_stream_bindings" }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -3,8 +3,25 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [v0.10.2] - August 20, 2026
+## [v0.11.0] - August 20, 2026
 ### What's New
+
+#### `finish()` reports undelivered data (PR [#727](https://github.com/sift-stack/sift/pull/727))
+
+`finish` used to discard the result of its internal tasks, so a final flush that never reached Sift still returned `Ok`. Task panics were swallowed the same way. Both now propagate as `ErrorKind::StreamError`.
+
+What `Ok` means depends on the mode:
+
+- Live-only: every message sent before `finish` was acknowledged by Sift. An `Err` means the stream carrying the tail-end data failed and, with no disk backup, that data is unrecoverable. `Ok` still does not account for data lost to earlier mid-stream failures the retry loop recovered from.
+- Live-with-backups: every message was either delivered or durably written to a backup for later reingestion. A failed final flush still routes to reingestion rather than erroring, so `Ok` is not a synchronous receipt that all data reached Sift.
+
+Live-only mode also no longer depends on which `select!` branch observes shutdown first: a stream failure seen after the data channel closes is reported instead of breaking into a clean shutdown.
+
+Callers that ignored the return value should check it:
+
+```rust
+stream.finish().await?;
+```
 
 #### Configurable gRPC decode limit (PR [#746](https://github.com/sift-stack/sift/pull/746))
 
@@ -23,7 +40,7 @@ let mut stream = SiftStreamBuilder::new(credentials)
 
 The override travels on the new `ServiceOptions` struct and applies to the ingestion config service; the asset and run wrappers use the constant. Exceeding the limit now reports a client-side limit and how to raise it, not tonic's bare `OutOfRange`.
 
-##### `sift-stream-bindings` 0.4.2
+##### `sift-stream-bindings` 0.5.0
 
 `max_decoding_message_size` on `SiftStreamBuilderPy` and `StreamConfigBuilderPy`. Leave it unset for the 50 MiB default.
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -3,6 +3,36 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v0.10.2] - August 20, 2026
+### What's New
+
+#### Configurable gRPC decode limit (PR [#746](https://github.com/sift-stack/sift/pull/746))
+
+tonic caps decoded responses at 4 MiB, and Sift's clients inherited that cap. A `ListIngestionConfigFlows` response for a large flow schema can exceed it, failing the stream build even though the server answered successfully.
+
+Wrappers now decode up to 50 MiB, exposed as `sift_connect::MAX_DECODING_MESSAGE_SIZE`, with an override for the flow schema fetch:
+
+```rust
+let mut stream = SiftStreamBuilder::new(credentials)
+    .max_decoding_message_size(100 * 1024 * 1024)
+    .ingestion_config(ingestion_config_form)
+    .live_with_backups()
+    .build()
+    .await?;
+```
+
+The override travels on the new `ServiceOptions` struct and applies to the ingestion config service; the asset and run wrappers use the constant. Exceeding the limit now reports a client-side limit and how to raise it, not tonic's bare `OutOfRange`.
+
+##### `sift-stream-bindings` 0.4.2
+
+`max_decoding_message_size` on `SiftStreamBuilderPy` and `StreamConfigBuilderPy`. Leave it unset for the 50 MiB default.
+
+#### New generated services in `sift_rs` (PRs [#640](https://github.com/sift-stack/sift/pull/640), [#659](https://github.com/sift-stack/sift/pull/659), [#676](https://github.com/sift-stack/sift/pull/676), [#683](https://github.com/sift-stack/sift/pull/683), [#689](https://github.com/sift-stack/sift/pull/689))
+
+Four new packages, `sift.canvas.v1`, `sift.docs.v1`, `sift.families.v1`, and `sift.filters.v1`, with clients for `DocsService`, `FamilyService`, and `FilterGrammarService`. Existing packages gain messages, including `UlogConfig` and `UlogDataConfig` for ULog imports. Nothing was removed.
+
+---
+
 ## [v0.10.1] - June 10, 2026
 ### What's New
 
@@ -809,7 +839,7 @@ A new recovery strategy `RecoveryStrategy::RetryWithBackups` has been developed 
 - `RecoveryStrategy::RetryWithInMemoryBackups` is also being deprecated due to the lack of a known use case
 #### SiftStream Asset/Run Tags and Metadata
 Users now have the ability to add both tags and metadata when specifying a run, or for an asset during initilization of SiftStream.
-- `RunForm` now includes the `metadata` field. Metadata can be easily defined using the `sift_rs::metadata` macro. 
+- `RunForm` now includes the `metadata` field. Metadata can be easily defined using the `sift_rs::metadata` macro.
 - `SiftStreamBuilder` now includes `add_asset_metadata` and `add_asset_tags`
 - See the [SiftStream example](https://github.com/sift-stack/sift/blob/main/rust/crates/sift_stream/examples/quick-start/main.rs) for how tags and metadata can be added.
 

--- a/rust/crates/sift_cli/Cargo.toml
+++ b/rust/crates/sift_cli/Cargo.toml
@@ -15,6 +15,8 @@ license.workspace = true
 description = "Sift CLI"
 # Released as a dist binary
 publish = false
+[package.metadata.dist]
+dist = true
 
 [[bin]]
 name = "sift-cli"

--- a/rust/crates/sift_cli/Cargo.toml
+++ b/rust/crates/sift_cli/Cargo.toml
@@ -13,6 +13,8 @@ keywords.workspace = true
 readme.workspace = true
 license.workspace = true
 description = "Sift CLI"
+# Released as a dist binary
+publish = false
 
 [[bin]]
 name = "sift-cli"

--- a/rust/crates/sift_mcp/Cargo.toml
+++ b/rust/crates/sift_mcp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sift_mcp"
 authors.workspace = true
 version.workspace = true
+publish = false
 edition.workspace = true
 categories.workspace = true
 homepage.workspace = true

--- a/rust/crates/sift_stream_bindings/Cargo.toml
+++ b/rust/crates/sift_stream_bindings/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "sift-stream-bindings"
 version = "0.4.2"
+# Released to PyPI as a wheel, never to crates.io.
+publish = false
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/rust/crates/sift_stream_bindings/Cargo.toml
+++ b/rust/crates/sift_stream_bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sift-stream-bindings"
-version = "0.4.1"
+version = "0.4.2"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/rust/crates/sift_stream_bindings/Cargo.toml
+++ b/rust/crates/sift_stream_bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sift-stream-bindings"
-version = "0.4.2"
+version = "0.5.0"
 # Released to PyPI as a wheel, never to crates.io.
 publish = false
 edition = { workspace = true }

--- a/rust/crates/sift_test_util/Cargo.toml
+++ b/rust/crates/sift_test_util/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sift_test_util"
 authors.workspace = true
 version.workspace = true
+publish = false
 edition.workspace = true
 categories.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
Version bump for the Rust release:
- rust crates `v0.10.1` to `v0.11.0`
- `sift_stream_bindings` `v0.4.1` to `v0.5.0`
- CHANGELOG update

Minor: #727 changes `SiftStream::finish()` from
discarding its internal task results to propagating them, so callers
that ignored the return value now see real errors.

Also marks `sift_mcp`, `sift_test_util`, `sift_cli` and
`sift_stream_bindings` as `publish = false`. None of the four goes to
crates.io, so the publish workflow no longer has to exclude them by hand.

Test: `cargo publish --workspace --dry-run` packages only
`sift_error`, `sift_connect`, `sift_rs`, `sift_pbfs`, `sift_stream`.
