### PR TITLE
rust(bug): include LICENSE at sdist root

### DIFF
--- a/rust/crates/sift_stream_bindings/pyproject.toml
+++ b/rust/crates/sift_stream_bindings/pyproject.toml
@@ -17,3 +17,5 @@ maintainers = [
 
 [tool.maturin]
 features = ["pyo3/extension-module"]
+# Workspace-rooted sdist: PyPI resolves License-File from the archive root.
+include = [{ path = "LICENSE", format = "sdist" }]


### PR DESCRIPTION
The v0.5.0 release published all 49 wheels but PyPI rejected the sdist:

<img width="1400" height="1690" alt="image" src="https://github.com/user-attachments/assets/0a1206f1-6e08-49d7-a2fa-5428985fcc0a" />

maturin declares `License-File: LICENSE` in PKG-INFO because the crate has a LICENSE symlink (added in #695), but this crate's sdist is rooted at the workspace, so the file lands at `rust/crates/sift_stream_bindings/LICENSE`. PyPI resolves the declaration from the archive root, finds nothing, and fails the upload.

Adding the LICENSE to `[tool.maturin] include` places a copy at the archive root where the metadata already points. Scoped to `format = "sdist"` since wheels were never affected; they carry the license in `.dist-info/licenses/`.

Reproduced the rejection locally with maturin 1.14.1, the version CI resolves, then confirmed the fixed sdist resolves `License-File` from the root.
