### PR TITLE
rust(chore): sift-cli 0.4.4 release prep

### DIFF
--- a/rust/crates/sift_cli/CHANGELOG.md
+++ b/rust/crates/sift_cli/CHANGELOG.md
@@ -7,6 +7,21 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### What's New
 
+## [v0.4.4] - August 24, 2026
+
+### What's New
+
+- Added `sift-cli get asset`, the first of the new `get` subcommands for
+  discovering data in Sift from the terminal. It takes `--filter` with a CEL
+  expression, `--limit` (default 50), and `--output-format` (`text` or
+  `json`).
+- MCP `list_*` tools now accept an optional `fields` projection that keeps
+  only the named fields on each item, cutting response size for wide objects.
+  Names match case-insensitively and ignore underscores and hyphens; names
+  that match nothing are reported back in `unmatched_fields`.
+- MCP `list_*` responses now report `count` (items in the returned page) and
+  `has_more` (whether results were truncated at `limit`), so agents can tell
+  a complete listing from a capped one.
 - Added a `--disable-nonessential-traffic` flag to `sift-cli mcp` that stops
   the MCP server from making non-essential network requests. Release checks
   stay under `--disable-update-check`.

--- a/rust/crates/sift_cli/Cargo.toml
+++ b/rust/crates/sift_cli/Cargo.toml
@@ -3,7 +3,7 @@ test-reports = ["sift_mcp/test-reports"]
 
 [package]
 name = "sift_cli"
-version = "0.4.3"
+version = "0.4.4"
 authors.workspace = true
 edition.workspace = true
 categories.workspace = true


### PR DESCRIPTION

Prepares the sift-cli 0.4.4 release:

- Bumps `sift_cli` from 0.4.3 to 0.4.4.
- Moves the `[Unreleased]` changelog bullets under a new `v0.4.4` section and adds entries for changes shipped since 0.4.3 that were missing from the changelog: `sift-cli get asset` (#731) and the `fields` projection plus `count`/`has_more` response fields on the MCP `list_*` tools (#732).
