### PR TITLE
rust(feat): mcp get_data accepts asset_id

### DIFF
--- a/rust/crates/sift_mcp/src/tool/data/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/data/mod.rs
@@ -28,7 +28,8 @@ mod test;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct GetDataParams {
-    asset_name: String,
+    asset_name: Option<String>,
+    asset_id: Option<String>,
     run_name: Option<String>,
     start_time_unix_nanos: Option<i64>,
     end_time_unix_nanos: Option<i64>,
@@ -73,7 +74,11 @@ impl SiftMcpServer {
                 `bit_field_elements` keys respectively.
 
             Parameters:
-              - `asset_name`: exact asset name (not a pattern).
+              - `asset_name`: optional, exact asset name (not a pattern). Mutually exclusive with `asset_id`;
+                exactly one of the two MUST be set.
+              - `asset_id`: optional, asset UUID. Mutually exclusive with `asset_name`; exactly one of the two
+                MUST be set. Runs reference assets by id (`list_runs` returns `asset_id`, not a name), so pass
+                that id here directly instead of guessing a name.
               - `run_name`: optional, exact run name within the asset. When provided, the run's start/stop bounds are
                 used as the time range; `start_time_unix_nanos` and/or `end_time_unix_nanos` may narrow either side.
                 When omitted, BOTH `start_time_unix_nanos` and `end_time_unix_nanos` are required.
@@ -87,6 +92,7 @@ impl SiftMcpServer {
 
             Errors:
               - `RESOURCE_NOT_FOUND` if the asset or run is missing or there are no matching channels.
+              - `INVALID_PARAMS` if neither `asset_name` nor `asset_id` is set, or if both are set.
               - `INVALID_PARAMS` if `run_name` is absent and the full time range is not supplied, if neither
                 `channel_names` nor `channel_regex` is set, if both are set, or if `channel_names` is empty.
               - `INVALID_PARAMS` if the channel selection matches 200 or more channels — the result would be
@@ -110,6 +116,7 @@ impl SiftMcpServer {
     pub async fn get_data(&self, params: Parameters<GetDataParams>) -> error::McpResult {
         let Parameters(GetDataParams {
             asset_name,
+            asset_id,
             run_name,
             channel_names,
             channel_regex,
@@ -127,7 +134,28 @@ impl SiftMcpServer {
             ));
         }
 
-        let asset_filter = format!("name == \"{}\"", cel_escape(&asset_name));
+        let (asset_filter, asset_label) = match (&asset_name, &asset_id) {
+            (Some(_), Some(_)) => {
+                return Err(ErrorData::invalid_params(
+                    "exactly one of `asset_name` or `asset_id` must be set, not both",
+                    None,
+                ));
+            }
+            (None, None) => {
+                return Err(ErrorData::invalid_params(
+                    "one of `asset_name` or `asset_id` must be set",
+                    None,
+                ));
+            }
+            (Some(name), None) => (
+                format!("name == \"{}\"", cel_escape(name)),
+                format!("asset '{name}'"),
+            ),
+            (None, Some(id)) => (
+                format!("asset_id == \"{}\"", cel_escape(id)),
+                format!("asset with id '{id}'"),
+            ),
+        };
         let asset = self
             .asset_service
             .list_assets(asset_filter, None, Some(1))
@@ -137,7 +165,7 @@ impl SiftMcpServer {
             .into_iter()
             .next()
             .ok_or_else(|| {
-                ErrorData::resource_not_found(format!("asset '{asset_name}' not found"), None)
+                ErrorData::resource_not_found(format!("{asset_label} not found"), None)
             })?;
 
         let run = match run_name.as_deref() {
@@ -157,7 +185,7 @@ impl SiftMcpServer {
                     .next()
                     .ok_or_else(|| {
                         ErrorData::resource_not_found(
-                            format!("run '{name}' not found for asset '{asset_name}'"),
+                            format!("run '{name}' not found for asset '{}'", asset.name),
                             None,
                         )
                     })?;
@@ -211,7 +239,10 @@ impl SiftMcpServer {
 
         if channels.is_empty() {
             return Err(ErrorData::resource_not_found(
-                format!("no channels matched the search criteria for asset '{asset_name}'"),
+                format!(
+                    "no channels matched the search criteria for asset '{}'",
+                    asset.name
+                ),
                 None,
             ));
         }

--- a/rust/crates/sift_mcp/src/tool/data/test.rs
+++ b/rust/crates/sift_mcp/src/tool/data/test.rs
@@ -57,7 +57,8 @@ fn one_asset_mock() -> MockAssetServiceImpl {
 
 fn get_data_params(channel_regex: &str) -> Parameters<GetDataParams> {
     Parameters(GetDataParams {
-        asset_name: "bench".into(),
+        asset_name: Some("bench".into()),
+        asset_id: None,
         run_name: None,
         start_time_unix_nanos: Some(0),
         end_time_unix_nanos: Some(1),
@@ -66,6 +67,90 @@ fn get_data_params(channel_regex: &str) -> Parameters<GetDataParams> {
         channel_regex: Some(channel_regex.into()),
         output: std::env::temp_dir().join("sift-mcp-get-data-test-never-written.parquet"),
     })
+}
+
+/// `list_runs` hands the caller an `asset_id`, not an asset name, so `get_data`
+/// must accept the id directly. The withf below is the real assertion: the
+/// asset lookup must filter on `asset_id`, not `name`.
+#[tokio::test]
+async fn get_data_resolves_the_asset_by_id() {
+    let mut assets = MockAssetServiceImpl::new();
+    assets
+        .expect_list_assets()
+        .withf(|req| req.get_ref().filter == r#"asset_id == "asset-1""#)
+        .returning(|_| {
+            Ok(Response::new(ListAssetsResponse {
+                assets: vec![Asset {
+                    asset_id: "asset-1".into(),
+                    name: "bench".into(),
+                    ..Default::default()
+                }],
+                next_page_token: String::new(),
+            }))
+        });
+
+    let mut channels = MockChannelServiceImpl::new();
+    channels.expect_list_channels().returning(|_| {
+        Ok(Response::new(ListChannelsResponse {
+            channels: Vec::new(),
+            next_page_token: String::new(),
+        }))
+    });
+
+    let (server, _h) = server_with_mocks(assets, channels).await;
+
+    let mut params = get_data_params("channel\\..*");
+    params.0.asset_name = None;
+    params.0.asset_id = Some("asset-1".into());
+
+    // No channels are mocked to match, so the call still errs — but reaching
+    // RESOURCE_NOT_FOUND for channels proves the id-filtered asset lookup
+    // succeeded (a name-filtered lookup would have failed the withf).
+    let err = server
+        .get_data(params)
+        .await
+        .expect_err("no matching channels is an error");
+
+    assert_eq!(err.code, ErrorCode::RESOURCE_NOT_FOUND);
+    assert!(
+        err.message.contains("no channels matched"),
+        "should fail at channel resolution, not asset resolution: {}",
+        err.message
+    );
+}
+
+/// Exactly one of `asset_name` / `asset_id` must be provided; the error must
+/// name both fields so the caller knows how to recover.
+#[tokio::test]
+async fn get_data_requires_exactly_one_asset_identifier() {
+    let (server, _h) =
+        server_with_mocks(MockAssetServiceImpl::new(), MockChannelServiceImpl::new()).await;
+
+    let mut both = get_data_params("channel\\..*");
+    both.0.asset_id = Some("asset-1".into());
+    let err = server
+        .get_data(both)
+        .await
+        .expect_err("asset_name and asset_id together must be rejected");
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+    assert!(
+        err.message.contains("asset_name") && err.message.contains("asset_id"),
+        "error should name both fields: {}",
+        err.message
+    );
+
+    let mut neither = get_data_params("channel\\..*");
+    neither.0.asset_name = None;
+    let err = server
+        .get_data(neither)
+        .await
+        .expect_err("missing both asset_name and asset_id must be rejected");
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+    assert!(
+        err.message.contains("asset_name") && err.message.contains("asset_id"),
+        "error should name both fields: {}",
+        err.message
+    );
 }
 
 /// A truncated channel selection would produce a Parquet file that is missing


### PR DESCRIPTION
## Motivation

The MCP `get_data` tool required `asset_name` and offered no way to pass an asset id. But `list_runs` returns runs that reference assets by id only (`assetIds` UUIDs, no name), so an LLM agent that finds a run holds a UUID it cannot hand to `get_data`. In production-like testing the agent fabricated an asset name ("ISS_SIM_LIVE" for an asset actually named "ISS"), failed with MCP error -32002 "asset not found", and had to recover by calling `list_assets`. Letting `get_data` take the id closes that gap.

## Changes

- `GetDataParams` gains an optional `asset_id` field and `asset_name` becomes optional.
- **Exactly one of `asset_name` / `asset_id` must be set.** Neither or both returns `INVALID_PARAMS` with an error naming both fields, mirroring the existing `channel_names` / `channel_regex` contract in the same tool.
- When `asset_id` is given, the asset is resolved via the existing `list_assets` path with an `asset_id == "..."` CEL filter (the same filter shape the other tools document).
- Run-not-found and no-channels-matched errors now report the resolved asset's name, so they stay accurate for either input form.
- Tool description documents both parameters and tells the model that runs reference assets by id, so an id from `list_runs` can be passed directly instead of guessing a name.

## Tests

- `get_data_resolves_the_asset_by_id`: asserts the asset lookup filters on `asset_id`, not `name`, and proceeds past asset resolution.
- `get_data_requires_exactly_one_asset_identifier`: both-set and neither-set each return `INVALID_PARAMS` naming both fields.

`cargo test -p sift_mcp` passes (278 tests). `cargo clippy -p sift_mcp --all-targets --all-features` and `cargo fmt --check` clean for the touched files (the two remaining clippy warnings are pre-existing in untouched files).

https://claude.ai/code/session_01Pmx2KWBKZ9Wh9Mk4A4pRTf