### PR TITLE
python(chore): unpin pip-tools for offline builds

### DIFF
--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -117,11 +117,8 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          # pip-tools 7.6.0 imports typing_extensions on Python < 3.11 without
-          # declaring it as a dependency, so pip-compile fails to import on the
-          # 3.9 and 3.10 legs. Drop this cap once 7.6.1 is released:
-          # https://github.com/jazzband/pip-tools/pull/2428
-          pip install build 'pip-tools<7.6'
+          # Keep pip-tools uncapped; pip-compile must match the pip installed above.
+          pip install build pip-tools
 
       - name: Generate requirements
         working-directory: python


### PR DESCRIPTION
https://github.com/jazzband/pip-tools/pull/2428 is merged, uncapped pip-tools


Error: `ImportError: cannot import name 'stdlib_pkgs' from 'pip._internal.utils.compat' (/opt/hostedtoolcache/Python/3.10.21/x64/lib/python3.10/site-packages/pip/_internal/utils/compat.py)`