### PR TITLE
python(bug): support bytes in flow registration

### DIFF
--- a/python/lib/sift_client/_tests/sift_types/test_ingestion.py
+++ b/python/lib/sift_client/_tests/sift_types/test_ingestion.py
@@ -10,6 +10,7 @@ from sift_client.sift_types.ingestion import (
     ChannelConfig,
     FlowConfig,
     IngestionConfig,
+    _to_rust_type,
 )
 
 
@@ -71,6 +72,16 @@ class TestChannelConfig:
             data_type=ChannelDataType.DOUBLE,
         )
         assert channel.data_type == ChannelDataType.DOUBLE
+
+    def test_to_rust_type_covers_every_channel_data_type(self):
+        """Test _to_rust_type has a branch for every ChannelDataType, including BYTES."""
+        # Importing here to match the lazy import convention in sift_types.ingestion
+        from sift_stream_bindings import ChannelDataTypePy
+
+        for data_type in ChannelDataType:
+            # Raises ValueError("Unknown data type: ...") if a variant is missing.
+            assert _to_rust_type(data_type) is not None
+        assert _to_rust_type(ChannelDataType.BYTES) == ChannelDataTypePy.Bytes
 
 
 class TestFlowConfig:

--- a/python/lib/sift_client/sift_types/ingestion.py
+++ b/python/lib/sift_client/sift_types/ingestion.py
@@ -529,4 +529,6 @@ def _to_rust_type(data_type: ChannelDataType) -> ChannelDataTypePy:
         return ChannelDataTypePy.Uint32
     elif data_type == ChannelDataType.UINT_64:
         return ChannelDataTypePy.Uint64
+    elif data_type == ChannelDataType.BYTES:
+        return ChannelDataTypePy.Bytes
     raise ValueError(f"Unknown data type: {data_type}")


### PR DESCRIPTION
Registering a flow with a `bytes` channel raised `ValueError: Unknown data type: bytes` in `_to_rust_type`. `ChannelDataType.BYTES` and `ChannelDataTypePy.Bytes` both already existed.

Adds the branch and a test that runs every `ChannelDataType` variant through `_to_rust_type`