### PR TITLE
rust(chore): agent skill refresh and sift-cli 0.5.0 release prep

### DIFF
--- a/rust/crates/sift_cli/CHANGELOG.md
+++ b/rust/crates/sift_cli/CHANGELOG.md
@@ -7,6 +7,27 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### What's New
 
+## [v0.5.0] - August 26, 2026
+
+### What's New
+
+- Added MCP tools for managing calculated channels: `list_calculated_channels`,
+  `list_calculated_channel_versions`, `create_calculated_channel`,
+  `update_calculated_channel`, `archive_calculated_channel`, and
+  `unarchive_calculated_channel`.
+- `get_data` now serves saved calculated channels. A name in `channel_names`
+  with no raw-channel match resolves as an active saved calculated channel for
+  the asset and run; unresolvable names are reported explicitly.
+- Added `preview_rule`, which dry-runs a saved rule or an ad-hoc draft rule
+  config against a run without persisting anything.
+- Added MCP tools for managing user-defined functions:
+  `list_user_defined_functions`, `list_user_defined_function_versions`,
+  `create_user_defined_function`, `update_user_defined_function`,
+  `archive_user_defined_function`, and `unarchive_user_defined_function`.
+- `update_annotation` now updates 1 to 1000 annotations per call and reports
+  failures for individual IDs.
+- Refreshed the bundled Sift agent skill to cover the expanded MCP tool surface.
+
 ## [v0.4.4] - August 24, 2026
 
 ### What's New

--- a/rust/crates/sift_cli/CHANGELOG.md
+++ b/rust/crates/sift_cli/CHANGELOG.md
@@ -18,14 +18,19 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `get_data` now serves saved calculated channels. A name in `channel_names`
   with no raw-channel match resolves as an active saved calculated channel for
   the asset and run; unresolvable names are reported explicitly.
+- `get_data` now accepts `asset_id` as an alternative to `asset_name`; exactly
+  one must be set.
 - Added `preview_rule`, which dry-runs a saved rule or an ad-hoc draft rule
   config against a run without persisting anything.
 - Added MCP tools for managing user-defined functions:
   `list_user_defined_functions`, `list_user_defined_function_versions`,
   `create_user_defined_function`, `update_user_defined_function`,
   `archive_user_defined_function`, and `unarchive_user_defined_function`.
-- `update_annotation` now updates 1 to 1000 annotations per call and reports
-  failures for individual IDs.
+- `update_annotation` now requires `annotation_ids` instead of `annotation_id`,
+  a breaking change for existing callers; pass a one-element list for one
+  annotation. It updates 1 to 1000 annotations per call with per-ID failure
+  reporting, and its new `is_archived` parameter archives or unarchives
+  annotations.
 - Refreshed the bundled Sift agent skill to cover the expanded MCP tool surface.
 
 ## [v0.4.4] - August 24, 2026

--- a/rust/crates/sift_cli/Cargo.toml
+++ b/rust/crates/sift_cli/Cargo.toml
@@ -3,7 +3,7 @@ test-reports = ["sift_mcp/test-reports"]
 
 [package]
 name = "sift_cli"
-version = "0.4.4"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 categories.workspace = true

--- a/rust/crates/sift_cli/assets/skills/sift/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/sift/SKILL.md
@@ -1,20 +1,19 @@
 ---
 name: sift
 description: >-
-  Use when working with Sift: ingesting or importing time-series data,
-  querying assets/runs/channels/users, managing calculated channels, rules,
-  user-defined functions, exporting data, decimating or running SQL over data,
-  opening a view in the Sift Explore web
-  app, writing code that integrates with Sift, installing, updating, or
-  diagnosing the Sift agent integration, or looking up how Sift works in its
-  product and API documentation. Covers the Sift MCP server (started by
-  `sift-cli mcp`), the `sift-cli` itself, the Sift REST API over cURL, the Sift
-  Python library (`sift_client`), and the Sift Rust streaming library
+  Use for Sift tasks: ingesting or importing time-series data, querying
+  assets/runs/channels/users, managing calculated channels, rules, and
+  user-defined functions, exporting or decimating data, running SQL over data,
+  opening a view in Sift Explore, writing code that integrates with Sift,
+  installing, updating, or diagnosing the Sift agent integration, or looking
+  up how Sift works in its product and API documentation. Covers the Sift MCP
+  server (started by `sift-cli mcp`), `sift-cli`, the Sift REST API over cURL,
+  the Sift Python library (`sift_client`), and the Sift Rust streaming library
   (`sift_stream`).
   Triggers include phrases like "import this file into Sift", "stream data to
   Sift", "list assets/runs/channels", "runs I created", "runs a teammate
-  created", "export a run", "query Sift", "graph", "plot", "visualize", "open
-  in Explore", "write code to integrate with Sift", "how does X work in Sift",
+  created", "export a run", "query Sift", "graph", "plot", "visualize", "open in
+  Explore", "write code to integrate with Sift", "how does X work in Sift",
   "what does this endpoint do", "list calculated channels", "preview a rule",
   or "look up the Sift API reference".
 ---
@@ -121,9 +120,10 @@ exists.
   `update_calculated_channel` take the expression with `$1`, `$2`, …
   placeholders plus `expression_channel_references_json`, a JSON string array
   mapping each placeholder to a channel. Resolve those channel names with
-  `list_channels` first. Update and archive both create a new version instead of
-  replacing or deleting anything, and `list_calculated_channel_versions` shows
-  the history.
+  `list_channels` first. An update creates a new version and leaves earlier
+  versions intact; `list_calculated_channel_versions` shows that history.
+  Archiving sets an archived state, which `unarchive_calculated_channel` clears;
+  it is not a versioned, history-visible change.
 - **Use or change a user-defined function.** Call
   `list_user_defined_functions` before writing an expression that calls a UDF:
   it gives the exact name, input order, and output type the expression must

--- a/rust/crates/sift_cli/assets/skills/sift/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/sift/SKILL.md
@@ -2,18 +2,21 @@
 name: sift
 description: >-
   Use when working with Sift: ingesting or importing time-series data,
-  querying assets/runs/channels/users, exporting data, decimating or running
-  SQL over data, opening a view in the Sift Explore web app, writing code that
-  integrates with Sift, installing, updating, or diagnosing the Sift agent
-  integration, or looking up how Sift works in its product and API
-  documentation. Covers the Sift MCP server (started by `sift-cli mcp`), the
-  `sift-cli` itself, the Sift REST API over cURL, the Sift Python library
-  (`sift_client`), and the Sift Rust streaming library (`sift_stream`).
+  querying assets/runs/channels/users, managing calculated channels, rules,
+  user-defined functions, campaigns, tags, and metadata, exporting data,
+  decimating or running SQL over data, opening a view in the Sift Explore web
+  app, writing code that integrates with Sift, installing, updating, or
+  diagnosing the Sift agent integration, or looking up how Sift works in its
+  product and API documentation. Covers the Sift MCP server (started by
+  `sift-cli mcp`), the `sift-cli` itself, the Sift REST API over cURL, the Sift
+  Python library (`sift_client`), and the Sift Rust streaming library
+  (`sift_stream`).
   Triggers include phrases like "import this file into Sift", "stream data to
   Sift", "list assets/runs/channels", "runs I created", "runs a teammate
   created", "export a run", "query Sift", "graph", "plot", "visualize", "open
   in Explore", "write code to integrate with Sift", "how does X work in Sift",
-  "what does this endpoint do", or "look up the Sift API reference".
+  "what does this endpoint do", "list calculated channels", "preview a rule",
+  "review a campaign", "what tags exist", or "look up the Sift API reference".
 ---
 
 <!--
@@ -48,11 +51,24 @@ exists.
 
 - **Setup:** When available, `check_for_updates` reports the installed sift-cli
   version, the latest stable version, and the exact installer command. Servers
-  started with `--disable-update-check` omit this tool.
+  started with `--disable-update-check` omit this tool. `ping` is a
+  connectivity check; when it fails, expect every other Sift tool to fail too.
 - **Discovery:** `list_assets`, `list_runs`, `list_channels`, `list_reports`,
-  `list_report_templates`, `list_rules`, `list_rule_versions`, `list_annotations`.
+  `list_report_templates`, `list_rules`, `list_rule_versions`, `list_annotations`,
+  `list_campaigns`, `list_tags`.
+- **Derived channels:** `list_calculated_channels`,
+  `list_calculated_channel_versions`, `list_user_defined_functions`,
+  `list_user_defined_function_versions`.
+- **Metadata:** `list_metadata_keys`, `list_metadata_values`,
+  `list_metadata_usage`.
 - **People:** `list_users`.
-- **Report detail:** `list_report_rule_summaries`.
+- **Rollups:** `list_report_rule_summaries` for a report's rule progress,
+  `review_campaigns` for a campaign's annotation and rule totals.
+  `review_campaigns` is expensive; call it only when the user asks for the
+  rollup.
+- **Rule dry runs:** `preview_rule` returns the annotations a rule would create
+  without persisting anything. It is read-only whatever the server's access
+  mode, so it needs no write flag.
 - **Test results:** `list_test_reports`, `list_test_steps`,
   `list_test_measurements`, `count_test_steps`, `count_test_measurements`.
   These, along with the `create_test_report` and `append_test_measurements`
@@ -64,8 +80,13 @@ exists.
 - **Docs:** `search_docs`.
 - **Writes:** `create_rule`, `update_rule`, `archive_rule`, `unarchive_rule`,
   `create_annotation`, `update_annotation`, `create_report`, `update_report`,
-  `create_report_template`, `update_report_template`, `create_test_report`,
-  `append_test_measurements`, `update_asset`, `update_run`.
+  `create_report_template`, `update_report_template`,
+  `create_calculated_channel`, `update_calculated_channel`,
+  `archive_calculated_channel`, `unarchive_calculated_channel`,
+  `create_user_defined_function`, `update_user_defined_function`,
+  `archive_user_defined_function`, `unarchive_user_defined_function`,
+  `create_test_report`, `append_test_measurements`, `update_asset`,
+  `update_run`.
 
 ## Workflows that span tools
 
@@ -86,6 +107,43 @@ exists.
   `get_data` does not mean every requested channel is in the file: check
   `unmatched_channel_names` and `empty_channels` in the result and name any
   missing channel to the user before reporting numbers derived from it.
+- **Query a derived channel.** `get_data` serves saved calculated channels as
+  well as raw ones: name the calculated channel in `channel_names` and it is
+  evaluated for the requested asset and run. Confirm the name with
+  `list_calculated_channels` filtered on the asset first. A raw channel wins a
+  name it shares with a calculated channel, and `channel_regex` matches raw
+  channels only, so name calculated channels explicitly. When the result
+  carries `unresolved_calculated_channels`, the file is missing those columns:
+  tell the user which channels did not resolve rather than reporting the file as
+  complete.
+- **Author or change a calculated channel.** A calculated channel is a SEL
+  expression plus an asset scope. `create_calculated_channel` and
+  `update_calculated_channel` take the expression with `$1`, `$2`, …
+  placeholders plus `expression_channel_references_json`, a JSON string array
+  mapping each placeholder to a channel. Resolve those channel names with
+  `list_channels` first. Update and archive both create a new version instead of
+  replacing or deleting anything, and `list_calculated_channel_versions` shows
+  the history.
+- **Use or change a user-defined function.** Call
+  `list_user_defined_functions` before writing an expression that calls a UDF:
+  it gives the exact name, input order, and output type the expression must
+  match. An update creates a new version and leaves earlier ones intact, so
+  `list_user_defined_function_versions` gives history and pinned version ids.
+  Send a rename on its own. The API applies a `name` change by itself and
+  ignores every other field, so `update_user_defined_function` rejects `name`
+  combined with anything else.
+- **Review a campaign.** `list_campaigns` browses and never returns review
+  counts. Annotation totals and rule pass/fail counts come only from
+  `review_campaigns`, keyed by the `campaign_id`s you pass in, and only when the
+  user asks for the rollup. For archived campaigns alone, pass
+  `include_archived: true` AND an `is_archived == true` filter; the flag by
+  itself only stops the backend from excluding them.
+- **Tag something or set metadata.** Call `list_tags` or `list_metadata_keys`
+  before introducing new taxonomy, because near-duplicate names (`prod` vs
+  `production`) fragment filtering later. `list_metadata_values` needs a real
+  `metadata_key_name` from `list_metadata_keys`; a guessed name returns
+  `RESOURCE_NOT_FOUND`, not an empty list. `list_metadata_usage` shows where a
+  key or value is already applied.
 - **Produce a chart.** Build a link with `explore_url`. When the user wants a
   chart and numbers, do both and give the user both.
 - **Answer a question about how Sift works.** Call `search_docs`. Do not answer
@@ -99,7 +157,11 @@ exists.
   gated tool and the exact `sift-cli agent update --allow-create` command, and
   wait for the user to widen access.
 - **Evaluate rules against a run.** Find rules with `list_rules` and author rules
-  with `create_rule`. To reuse the same rule set across many runs, bundle
+  with `create_rule`. Dry-run first: `preview_rule` returns the annotations a
+  rule would generate for one run and persists nothing. It takes either a saved
+  rule (`rule_id` or `rule_name`) or a fully ad-hoc `draft_rule_config` JSON
+  string, so a rule need not be saved to be tested. Use `create_report` when the
+  evaluation should persist. To reuse the same rule set across many runs, bundle
   standard rules (`is_external: false`) into a template with `create_report_template`,
   then call `create_report` with `report_template_id`. For a one-off — or for
   ad-hoc rules (`is_external: true`, which the API also calls "external" but
@@ -133,9 +195,11 @@ exists.
   Several creates happen as side effects of other MCP tools — an asset is
   created when `upload_dataset` names one that doesn't exist, a run is
   created when a `create_report`/`create_test_report`/`upload_dataset` names
-  one. When the user asks for a create with no matching `create_*` tool,
-  look for the tool that creates it as a side effect before falling out of
-  MCP. If that side-effect tool is gated and blocked, that IS the block —
+  one, and a tag is created when `update_asset` or `update_run` names one that
+  doesn't exist (there is no `create_tag` tool). When the user asks for a create
+  with no matching `create_*` tool, look for the tool that creates it as a side
+  effect before falling out of MCP. If that side-effect tool is gated and
+  blocked, that IS the block —
   surface it, do not treat "no `create_asset` tool" as license to shell out
   to REST/gRPC/`sift-cli import`.
 - **Choose one profile for the session and keep it.** Never switch profiles to

--- a/rust/crates/sift_cli/assets/skills/sift/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/sift/SKILL.md
@@ -3,8 +3,8 @@ name: sift
 description: >-
   Use when working with Sift: ingesting or importing time-series data,
   querying assets/runs/channels/users, managing calculated channels, rules,
-  user-defined functions, exporting data,
-  decimating or running SQL over data, opening a view in the Sift Explore web
+  user-defined functions, exporting data, decimating or running SQL over data,
+  opening a view in the Sift Explore web
   app, writing code that integrates with Sift, installing, updating, or
   diagnosing the Sift agent integration, or looking up how Sift works in its
   product and API documentation. Covers the Sift MCP server (started by
@@ -98,8 +98,10 @@ exists.
   `me: true`. Never guess which listed user is the caller.
 - **Update annotations.** `update_annotation` takes a required
   `annotation_ids` list of 1 to 1000 ids and applies the same changes to every
-  target. Check its per-id `failures`, `not_attempted` ids, and archive outcome
-  before reporting success; a partial failure sets `isError`.
+  target. Set `is_archived: true` to archive or `is_archived: false` to
+  unarchive; there is no separate archive tool. Check its per-id `failures`,
+  `not_attempted` ids, and archive outcome before reporting success; a partial
+  failure sets `isError`.
 - **Produce numbers.** `get_data` writes a Parquet file. `sql` then queries it.
   Add `upload_dataset` when the result belongs back in Sift. A successful
   `get_data` does not mean every requested channel is in the file: check
@@ -181,13 +183,12 @@ exists.
   Several creates happen as side effects of other MCP tools — an asset is
   created when `upload_dataset` names one that doesn't exist, a run is
   created when a `create_report`/`create_test_report`/`upload_dataset` names
-  one, and a tag is created when `update_asset` or `update_run` names one that
+  one, and a tag is created when `create_annotation` includes a name that
   doesn't exist (there is no `create_tag` tool). When the user asks for a create
   with no matching `create_*` tool, look for the tool that creates it as a side
   effect before falling out of MCP. If that side-effect tool is gated and
-  blocked, that IS the block —
-  surface it, do not treat "no `create_asset` tool" as license to shell out
-  to REST/gRPC/`sift-cli import`.
+  blocked, that IS the block — surface it, do not treat "no `create_asset` tool"
+  as license to shell out to REST/gRPC/`sift-cli import`.
 - **Choose one profile for the session and keep it.** Never switch profiles to
   recover from a failure. Surface the failure and ask the user.
 

--- a/rust/crates/sift_cli/assets/skills/sift/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/sift/SKILL.md
@@ -115,7 +115,7 @@ exists.
   carries `unresolved_calculated_channels`, the file is missing those columns:
   tell the user which channels did not resolve rather than reporting the file as
   complete.
-- **Author or change a calculated channel.** A calculated channel is a SEL
+- **Author or change a calculated channel.** A calculated channel is a CEL
   expression plus an asset scope. `create_calculated_channel` and
   `update_calculated_channel` take the expression with `$1`, `$2`, …
   placeholders plus `expression_channel_references_json`, a JSON string array

--- a/rust/crates/sift_cli/assets/skills/sift/SKILL.md
+++ b/rust/crates/sift_cli/assets/skills/sift/SKILL.md
@@ -3,7 +3,7 @@ name: sift
 description: >-
   Use when working with Sift: ingesting or importing time-series data,
   querying assets/runs/channels/users, managing calculated channels, rules,
-  user-defined functions, campaigns, tags, and metadata, exporting data,
+  user-defined functions, exporting data,
   decimating or running SQL over data, opening a view in the Sift Explore web
   app, writing code that integrates with Sift, installing, updating, or
   diagnosing the Sift agent integration, or looking up how Sift works in its
@@ -16,7 +16,7 @@ description: >-
   created", "export a run", "query Sift", "graph", "plot", "visualize", "open
   in Explore", "write code to integrate with Sift", "how does X work in Sift",
   "what does this endpoint do", "list calculated channels", "preview a rule",
-  "review a campaign", "what tags exist", or "look up the Sift API reference".
+  or "look up the Sift API reference".
 ---
 
 <!--
@@ -54,18 +54,12 @@ exists.
   started with `--disable-update-check` omit this tool. `ping` is a
   connectivity check; when it fails, expect every other Sift tool to fail too.
 - **Discovery:** `list_assets`, `list_runs`, `list_channels`, `list_reports`,
-  `list_report_templates`, `list_rules`, `list_rule_versions`, `list_annotations`,
-  `list_campaigns`, `list_tags`.
+  `list_report_templates`, `list_rules`, `list_rule_versions`, `list_annotations`.
 - **Derived channels:** `list_calculated_channels`,
   `list_calculated_channel_versions`, `list_user_defined_functions`,
   `list_user_defined_function_versions`.
-- **Metadata:** `list_metadata_keys`, `list_metadata_values`,
-  `list_metadata_usage`.
 - **People:** `list_users`.
-- **Rollups:** `list_report_rule_summaries` for a report's rule progress,
-  `review_campaigns` for a campaign's annotation and rule totals.
-  `review_campaigns` is expensive; call it only when the user asks for the
-  rollup.
+- **Rollups:** `list_report_rule_summaries` for a report's rule progress.
 - **Rule dry runs:** `preview_rule` returns the annotations a rule would create
   without persisting anything. It is read-only whatever the server's access
   mode, so it needs no write flag.
@@ -102,6 +96,10 @@ exists.
 - **Attribute something to a person.** Resolve the person with `list_users`,
   then filter another list on `created_by_user_id`. For "runs I created", pass
   `me: true`. Never guess which listed user is the caller.
+- **Update annotations.** `update_annotation` takes a required
+  `annotation_ids` list of 1 to 1000 ids and applies the same changes to every
+  target. Check its per-id `failures`, `not_attempted` ids, and archive outcome
+  before reporting success; a partial failure sets `isError`.
 - **Produce numbers.** `get_data` writes a Parquet file. `sql` then queries it.
   Add `upload_dataset` when the result belongs back in Sift. A successful
   `get_data` does not mean every requested channel is in the file: check
@@ -132,18 +130,6 @@ exists.
   Send a rename on its own. The API applies a `name` change by itself and
   ignores every other field, so `update_user_defined_function` rejects `name`
   combined with anything else.
-- **Review a campaign.** `list_campaigns` browses and never returns review
-  counts. Annotation totals and rule pass/fail counts come only from
-  `review_campaigns`, keyed by the `campaign_id`s you pass in, and only when the
-  user asks for the rollup. For archived campaigns alone, pass
-  `include_archived: true` AND an `is_archived == true` filter; the flag by
-  itself only stops the backend from excluding them.
-- **Tag something or set metadata.** Call `list_tags` or `list_metadata_keys`
-  before introducing new taxonomy, because near-duplicate names (`prod` vs
-  `production`) fragment filtering later. `list_metadata_values` needs a real
-  `metadata_key_name` from `list_metadata_keys`; a guessed name returns
-  `RESOURCE_NOT_FOUND`, not an empty list. `list_metadata_usage` shows where a
-  key or value is already applied.
 - **Produce a chart.** Build a link with `explore_url`. When the user wants a
   chart and numbers, do both and give the user both.
 - **Answer a question about how Sift works.** Call `search_docs`. Do not answer


### PR DESCRIPTION
## Description

Replaces #742, which GitHub's stack lock prevented from being retargeted after the stack restructure.

Two changes that close out the MCP tool expansion:

Refreshes the bundled Sift agent skill for the tools introduced below this branch in the stack. The skill's tool inventory now mirrors the server registry exactly (49 tools), and the workflow guidance covers calculated channel management, saved calculated channels through `get_data`, `preview_rule` dry runs, user-defined function discovery and versioning, and bulk `update_annotation` semantics (required `annotation_ids` list, per-id failure reporting).

Preps the sift-cli 0.5.0 release: version bump in `sift_cli/Cargo.toml` and a `CHANGELOG.md` entry covering the new tool surface, in the same format as the 0.4.4 entry.

## Verification

- `cargo test -p sift_cli cmd::agent`: 38 passed, 0 failed, including the skill/reference-bundle map test.
- Inventory cross-check: every tool named in the skill exists in the server registry and `tool_events.json` (49 keys); the only names in the skill that are not registry tools are deliberate "there is no such tool" statements.
- At this branch (the stack tip): `cargo test -p sift_mcp` 428 passed, `cargo test -p sift_cli` 218 passed, `cargo fmt --all -- --check` clean, `cargo build -p sift_mcp --no-default-features` clean.
