### PR TITLE
Python(fix): adjusting gRPC limits and page size

### DIFF
--- a/python/lib/sift_client/_internal/grpc_transport/transport.py
+++ b/python/lib/sift_client/_internal/grpc_transport/transport.py
@@ -34,7 +34,7 @@ SiftAsyncChannel: TypeAlias = grpc_aio.Channel
 DEFAULT_REQUEST_TIMEOUT_SECONDS = 60.0
 """Default per-call deadline applied to unary RPCs that don't set their own."""
 
-_MAX_DECODING_MESSAGE_SIZE = 50 * 1024 * 1024
+MAX_DECODING_MESSAGE_SIZE = 50 * 1024 * 1024
 """Largest gRPC response the client will decode, in bytes (50 MiB)."""
 
 
@@ -170,11 +170,11 @@ def _compute_channel_options(opts: SiftChannelConfig) -> list[tuple[str, Any]]:
         ("grpc.secondary_user_agent", _compute_user_agent()),
         (
             "grpc.max_receive_message_length",
-            opts.get("max_receive_message_length", _MAX_DECODING_MESSAGE_SIZE),
+            opts.get("max_receive_message_length", MAX_DECODING_MESSAGE_SIZE),
         ),
         (
             "grpc.max_send_message_length",
-            opts.get("max_send_message_length", _MAX_DECODING_MESSAGE_SIZE),
+            opts.get("max_send_message_length", MAX_DECODING_MESSAGE_SIZE),
         ),
     ]
 

--- a/python/lib/sift_client/_internal/grpc_transport/transport.py
+++ b/python/lib/sift_client/_internal/grpc_transport/transport.py
@@ -168,7 +168,8 @@ def _compute_channel_options(opts: SiftChannelConfig) -> list[tuple[str, Any]]:
         # Primary cannot be overriden:
         #  https://github.com/grpc/grpc/blob/0498194240f55d7f4b12633ad01339fb690621bf/src/core/ext/filters/http/client/http_client_filter.cc#L97
         ("grpc.secondary_user_agent", _compute_user_agent()),
-        ("grpc.max_receive_message_length", MAX_DECODING_MESSAGE_SIZE),
+        ("grpc.max_receive_message_length", opts.get("max_receive_message_length", MAX_DECODING_MESSAGE_SIZE)),
+        ("grpc.max_send_message_length", opts.get("max_send_message_length", MAX_DECODING_MESSAGE_SIZE)),
     ]
 
     enable_keepalive = opts.get("enable_keepalive", True)
@@ -251,3 +252,5 @@ class SiftChannelConfig(TypedDict):
     use_ssl: NotRequired[bool]
     cert_via_openssl: NotRequired[bool]
     request_timeout: NotRequired[float | None]
+    max_receive_message_length: NotRequired[int]
+    max_send_message_length: NotRequired[int]

--- a/python/lib/sift_client/_internal/grpc_transport/transport.py
+++ b/python/lib/sift_client/_internal/grpc_transport/transport.py
@@ -168,8 +168,14 @@ def _compute_channel_options(opts: SiftChannelConfig) -> list[tuple[str, Any]]:
         # Primary cannot be overriden:
         #  https://github.com/grpc/grpc/blob/0498194240f55d7f4b12633ad01339fb690621bf/src/core/ext/filters/http/client/http_client_filter.cc#L97
         ("grpc.secondary_user_agent", _compute_user_agent()),
-        ("grpc.max_receive_message_length", opts.get("max_receive_message_length", MAX_DECODING_MESSAGE_SIZE)),
-        ("grpc.max_send_message_length", opts.get("max_send_message_length", MAX_DECODING_MESSAGE_SIZE)),
+        (
+            "grpc.max_receive_message_length",
+            opts.get("max_receive_message_length", MAX_DECODING_MESSAGE_SIZE),
+        ),
+        (
+            "grpc.max_send_message_length",
+            opts.get("max_send_message_length", MAX_DECODING_MESSAGE_SIZE),
+        ),
     ]
 
     enable_keepalive = opts.get("enable_keepalive", True)

--- a/python/lib/sift_client/_internal/grpc_transport/transport.py
+++ b/python/lib/sift_client/_internal/grpc_transport/transport.py
@@ -34,7 +34,7 @@ SiftAsyncChannel: TypeAlias = grpc_aio.Channel
 DEFAULT_REQUEST_TIMEOUT_SECONDS = 60.0
 """Default per-call deadline applied to unary RPCs that don't set their own."""
 
-MAX_DECODING_MESSAGE_SIZE = 50 * 1024 * 1024
+_MAX_DECODING_MESSAGE_SIZE = 50 * 1024 * 1024
 """Largest gRPC response the client will decode, in bytes (50 MiB)."""
 
 
@@ -170,11 +170,11 @@ def _compute_channel_options(opts: SiftChannelConfig) -> list[tuple[str, Any]]:
         ("grpc.secondary_user_agent", _compute_user_agent()),
         (
             "grpc.max_receive_message_length",
-            opts.get("max_receive_message_length", MAX_DECODING_MESSAGE_SIZE),
+            opts.get("max_receive_message_length", _MAX_DECODING_MESSAGE_SIZE),
         ),
         (
             "grpc.max_send_message_length",
-            opts.get("max_send_message_length", MAX_DECODING_MESSAGE_SIZE),
+            opts.get("max_send_message_length", _MAX_DECODING_MESSAGE_SIZE),
         ),
     ]
 

--- a/python/lib/sift_client/_internal/low_level_wrappers/data.py
+++ b/python/lib/sift_client/_internal/low_level_wrappers/data.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 # Configure logging
 logger = logging.getLogger(__name__)
 
-CHANNELS_DEFAULT_PAGE_SIZE = 10_000
+CHANNELS_DEFAULT_PAGE_SIZE = 100_000
 # TODO: There is a pagination issue API side when requesting multiple channels in single request.
 # If all data points for all channels in a single request don't fit into a single page, then
 # paging seems to omit all but a single channel. We can increase this batch size once that issue

--- a/python/lib/sift_client/_tests/_internal/test_transport.py
+++ b/python/lib/sift_client/_tests/_internal/test_transport.py
@@ -5,10 +5,9 @@ import threading
 import pytest
 
 from sift_client._internal.grpc_transport.transport import (
-    MAX_DECODING_MESSAGE_SIZE,
     _compute_channel_options,
 )
-from sift_client.transport.grpc_transport import GrpcClient, GrpcConfig
+from sift_client.transport.grpc_transport import MAX_DECODING_MESSAGE_SIZE, GrpcClient, GrpcConfig
 from sift_client.transport.rest_transport import DEFAULT_REST_TIMEOUT, RestClient, RestConfig
 
 

--- a/python/lib/sift_client/transport/grpc_transport.py
+++ b/python/lib/sift_client/transport/grpc_transport.py
@@ -16,10 +16,12 @@ from urllib.parse import urlparse
 
 from sift_client._internal.grpc_transport.transport import (
     DEFAULT_REQUEST_TIMEOUT_SECONDS,
-    MAX_DECODING_MESSAGE_SIZE,
     SiftChannelConfig,
     use_sift_async_channel,
 )
+
+MAX_DECODING_MESSAGE_SIZE = 50 * 1024 * 1024
+"""Largest gRPC message the client will accept or send, in bytes (50 MiB)."""
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -64,9 +66,9 @@ class GrpcConfig:
             request_timeout: Default deadline in seconds applied to unary RPCs that don't set
                 their own. Defaults to 60s. Set to None to disable the default deadline.
             max_receive_message_length: Maximum gRPC message size the client will accept (bytes).
-                Defaults to :data:`~sift_client._internal.grpc_transport.transport.MAX_DECODING_MESSAGE_SIZE`.
+                Defaults to [MAX_DECODING_MESSAGE_SIZE][].
             max_send_message_length: Maximum gRPC message size the client will send (bytes).
-                Defaults to :data:`~sift_client._internal.grpc_transport.transport.MAX_DECODING_MESSAGE_SIZE`.
+                Defaults to [MAX_DECODING_MESSAGE_SIZE][].
         """
         parsed_url = urlparse(url)
         normalized_url = url

--- a/python/lib/sift_client/transport/grpc_transport.py
+++ b/python/lib/sift_client/transport/grpc_transport.py
@@ -66,9 +66,9 @@ class GrpcConfig:
             request_timeout: Default deadline in seconds applied to unary RPCs that don't set
                 their own. Defaults to 60s. Set to None to disable the default deadline.
             max_receive_message_length: Maximum gRPC message size the client will accept (bytes).
-                Defaults to [MAX_DECODING_MESSAGE_SIZE][].
+                Defaults to `MAX_DECODING_MESSAGE_SIZE`.
             max_send_message_length: Maximum gRPC message size the client will send (bytes).
-                Defaults to [MAX_DECODING_MESSAGE_SIZE][].
+                Defaults to `MAX_DECODING_MESSAGE_SIZE`.
         """
         parsed_url = urlparse(url)
         normalized_url = url

--- a/python/lib/sift_client/transport/grpc_transport.py
+++ b/python/lib/sift_client/transport/grpc_transport.py
@@ -48,6 +48,8 @@ class GrpcConfig:
         cert_via_openssl: bool = False,
         metadata: dict[str, str] | None = None,
         request_timeout: float | None = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+        max_receive_message_length: int = 50 * 1024 * 1024,
+        max_send_message_length: int = 50 * 1024 * 1024,
     ):
         """Initialize the gRPC configuration.
 
@@ -60,6 +62,10 @@ class GrpcConfig:
             metadata: Additional metadata to include in all requests.
             request_timeout: Default deadline in seconds applied to unary RPCs that don't set
                 their own. Defaults to 60s. Set to None to disable the default deadline.
+            max_receive_message_length: Maximum gRPC message size the client will accept (bytes).
+                Defaults to 50 MiB to match the server-side ceiling.
+            max_send_message_length: Maximum gRPC message size the client will send (bytes).
+                Defaults to 50 MiB to match the server-side ceiling.
         """
         parsed_url = urlparse(url)
         normalized_url = url
@@ -77,6 +83,8 @@ class GrpcConfig:
         self.cert_via_openssl = cert_via_openssl
         self.metadata = metadata or {}
         self.request_timeout = request_timeout
+        self.max_receive_message_length = max_receive_message_length
+        self.max_send_message_length = max_send_message_length
 
     def _to_sift_channel_config(self) -> SiftChannelConfig:
         """Convert to a SiftChannelConfig.
@@ -90,6 +98,8 @@ class GrpcConfig:
             "use_ssl": self.use_ssl,
             "cert_via_openssl": self.cert_via_openssl,
             "request_timeout": self.request_timeout,
+            "max_receive_message_length": self.max_receive_message_length,
+            "max_send_message_length": self.max_send_message_length,
         }
 
 

--- a/python/lib/sift_client/transport/grpc_transport.py
+++ b/python/lib/sift_client/transport/grpc_transport.py
@@ -64,9 +64,9 @@ class GrpcConfig:
             request_timeout: Default deadline in seconds applied to unary RPCs that don't set
                 their own. Defaults to 60s. Set to None to disable the default deadline.
             max_receive_message_length: Maximum gRPC message size the client will accept (bytes).
-                Defaults to 50 MiB to match the server-side ceiling.
+                Defaults to :data:`~sift_client._internal.grpc_transport.transport.MAX_DECODING_MESSAGE_SIZE`.
             max_send_message_length: Maximum gRPC message size the client will send (bytes).
-                Defaults to 50 MiB to match the server-side ceiling.
+                Defaults to :data:`~sift_client._internal.grpc_transport.transport.MAX_DECODING_MESSAGE_SIZE`.
         """
         parsed_url = urlparse(url)
         normalized_url = url

--- a/python/lib/sift_client/transport/grpc_transport.py
+++ b/python/lib/sift_client/transport/grpc_transport.py
@@ -16,6 +16,7 @@ from urllib.parse import urlparse
 
 from sift_client._internal.grpc_transport.transport import (
     DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    MAX_DECODING_MESSAGE_SIZE,
     SiftChannelConfig,
     use_sift_async_channel,
 )
@@ -48,8 +49,8 @@ class GrpcConfig:
         cert_via_openssl: bool = False,
         metadata: dict[str, str] | None = None,
         request_timeout: float | None = DEFAULT_REQUEST_TIMEOUT_SECONDS,
-        max_receive_message_length: int = 50 * 1024 * 1024,
-        max_send_message_length: int = 50 * 1024 * 1024,
+        max_receive_message_length: int = MAX_DECODING_MESSAGE_SIZE,
+        max_send_message_length: int = MAX_DECODING_MESSAGE_SIZE,
     ):
         """Initialize the gRPC configuration.
 


### PR DESCRIPTION
Aligning gRPC max received response limit with the backend. With the new limits, we can increase the page size on getData resulting in a faster data retrieval.