### PR TITLE
rust(fix): include annotation enums in MCP tool schemas

### DIFF
--- a/rust/crates/sift_mcp/src/tool/annotations/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/annotations/mod.rs
@@ -39,14 +39,51 @@ pub struct AnnotationListParams {
     pub(crate) fields: Option<Vec<String>>,
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, JsonSchema)]
+enum AnnotationTypeParam {
+    #[serde(rename = "ANNOTATION_TYPE_DATA_REVIEW", alias = "data_review")]
+    DataReview,
+    #[serde(rename = "ANNOTATION_TYPE_PHASE", alias = "phase")]
+    Phase,
+}
+
+impl From<AnnotationTypeParam> for AnnotationType {
+    fn from(value: AnnotationTypeParam) -> Self {
+        match value {
+            AnnotationTypeParam::DataReview => Self::DataReview,
+            AnnotationTypeParam::Phase => Self::Phase,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, JsonSchema)]
+enum AnnotationStateParam {
+    #[serde(rename = "ANNOTATION_STATE_OPEN", alias = "open")]
+    Open,
+    #[serde(rename = "ANNOTATION_STATE_FLAGGED", alias = "flagged")]
+    Flagged,
+    #[serde(rename = "ANNOTATION_STATE_RESOLVED", alias = "resolved")]
+    Resolved,
+}
+
+impl From<AnnotationStateParam> for AnnotationState {
+    fn from(value: AnnotationStateParam) -> Self {
+        match value {
+            AnnotationStateParam::Open => Self::Open,
+            AnnotationStateParam::Flagged => Self::Flagged,
+            AnnotationStateParam::Resolved => Self::Resolved,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct CreateAnnotationParams {
     name: String,
     description: Option<String>,
     start_time_unix_nanos: i64,
     end_time_unix_nanos: i64,
-    annotation_type: String,
-    state: Option<String>,
+    annotation_type: AnnotationTypeParam,
+    state: Option<AnnotationStateParam>,
     assets: Option<Vec<String>>,
     tags: Option<Vec<String>>,
     linked_channel_ids: Option<Vec<String>>,
@@ -64,34 +101,11 @@ pub struct UpdateAnnotationParams {
     start_time_unix_nanos: Option<i64>,
     end_time_unix_nanos: Option<i64>,
     assigned_to_user_id: Option<String>,
-    state: Option<String>,
+    state: Option<AnnotationStateParam>,
     tags: Option<Vec<String>>,
     linked_channel_ids: Option<Vec<String>>,
     metadata: Option<Vec<MetadataEntry>>,
     is_archived: Option<bool>,
-}
-
-fn parse_annotation_type(s: &str) -> Result<AnnotationType, ErrorData> {
-    match s.to_ascii_lowercase().as_str() {
-        "data_review" => Ok(AnnotationType::DataReview),
-        "phase" => Ok(AnnotationType::Phase),
-        other => Err(ErrorData::invalid_params(
-            format!("unknown `annotation_type` `{other}`; expected `data_review` or `phase`"),
-            None,
-        )),
-    }
-}
-
-fn parse_annotation_state(s: &str) -> Result<AnnotationState, ErrorData> {
-    match s.to_ascii_lowercase().as_str() {
-        "open" => Ok(AnnotationState::Open),
-        "flagged" => Ok(AnnotationState::Flagged),
-        "resolved" => Ok(AnnotationState::Resolved),
-        other => Err(ErrorData::invalid_params(
-            format!("unknown `state` `{other}`; expected `open`, `flagged`, or `resolved`"),
-            None,
-        )),
-    }
 }
 
 #[tool_router(router = annotations_router, vis = "pub(crate)")]
@@ -122,6 +136,9 @@ impl SiftMcpServer {
                 `annotation_type`, `tag_name`, `report_id`, `asset_id`, `asset_name`, `pending`, `assignee`,
                 `campaign_reports`, `metadata`, `archived_date`, `is_archived`. Reference metadata entries as
                 `metadata.{key}` (e.g. `metadata.severity == \"high\"`).
+                Compare `state` with `ANNOTATION_STATE_OPEN`, `ANNOTATION_STATE_FLAGGED`, or
+                `ANNOTATION_STATE_RESOLVED`. Compare `annotation_type` with `ANNOTATION_TYPE_DATA_REVIEW` or
+                `ANNOTATION_TYPE_PHASE`. Use these exact string enum values in quoted filter operands.
                 When filtering or searching, use `name.matches(\"(?i)vibration\")`, not `==`. Use `==` only for an
                 exact value from a prior result. `contains`/`startsWith`/`endsWith` are case-SENSITIVE:
                 `contains(\"Vibration\")` silently misses `vibration-check`.
@@ -197,9 +214,10 @@ impl SiftMcpServer {
               - `description`: optional free-text description.
               - `start_time_unix_nanos` / `end_time_unix_nanos`: required time bounds in Unix nanoseconds.
                 `end_time_unix_nanos` must be >= `start_time_unix_nanos`.
-              - `annotation_type`: required; one of `data_review` or `phase`.
-              - `state`: optional; one of `open`, `flagged`, `resolved`. MUST be omitted when `annotation_type`
-                is `phase` (the server rejects a phase annotation with a state).
+              - `annotation_type`: required; `ANNOTATION_TYPE_DATA_REVIEW` or `ANNOTATION_TYPE_PHASE`.
+              - `state`: optional; `ANNOTATION_STATE_OPEN`, `ANNOTATION_STATE_FLAGGED`, or
+                `ANNOTATION_STATE_RESOLVED`. MUST be omitted when `annotation_type` is `ANNOTATION_TYPE_PHASE`
+                (the server rejects a phase annotation with a state).
               - `assets`: optional list of asset NAMES to associate.
               - `tags`: optional list of tag names to associate. Names that do not yet exist are created.
               - `linked_channel_ids`: optional list of channel ids to link. Only plain channels are supported;
@@ -260,12 +278,12 @@ impl SiftMcpServer {
             ));
         }
 
-        let annotation_type = parse_annotation_type(&annotation_type)?;
-        let state = state.map(|s| parse_annotation_state(&s)).transpose()?;
+        let annotation_type = AnnotationType::from(annotation_type);
+        let state = state.map(AnnotationState::from);
 
         if annotation_type == AnnotationType::Phase && state.is_some() {
             return Err(ErrorData::invalid_params(
-                "`state` must be omitted when `annotation_type` is `phase`",
+                "`state` must be omitted when `annotation_type` is `ANNOTATION_TYPE_PHASE`",
                 None,
             ));
         }
@@ -336,7 +354,8 @@ impl SiftMcpServer {
               - `description`: optional new description.
               - `start_time_unix_nanos` / `end_time_unix_nanos`: optional new time bounds in Unix nanoseconds.
               - `assigned_to_user_id`: optional new assignee user id.
-              - `state`: optional; one of `open`, `flagged`, `resolved`.
+              - `state`: optional; `ANNOTATION_STATE_OPEN`, `ANNOTATION_STATE_FLAGGED`, or
+                `ANNOTATION_STATE_RESOLVED`.
               - `tags`: optional; REPLACES the full tag list. Pass `[]` to clear all tags.
               - `linked_channel_ids`: optional; REPLACES the full linked-channel list with plain channel links.
                 Pass `[]` to clear. Bit-field and calculated-channel links are not exposed here.
@@ -431,7 +450,7 @@ impl SiftMcpServer {
             ));
         }
 
-        let state = state.map(|s| parse_annotation_state(&s)).transpose()?;
+        let state = state.map(AnnotationState::from);
         let metadata = metadata.map(|m| m.into_iter().map(MetadataValue::from).collect::<Vec<_>>());
         let requested_ids = annotation_ids.clone();
         let requested_count = annotation_ids.len();

--- a/rust/crates/sift_mcp/src/tool/annotations/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/annotations/mod.rs
@@ -60,9 +60,17 @@ impl From<AnnotationTypeParam> for AnnotationType {
 enum AnnotationStateParam {
     #[serde(rename = "ANNOTATION_STATE_OPEN", alias = "open")]
     Open,
-    #[serde(rename = "ANNOTATION_STATE_FLAGGED", alias = "flagged")]
+    #[serde(
+        rename = "ANNOTATION_STATE_FLAGGED",
+        alias = "flagged",
+        alias = "failed"
+    )]
     Flagged,
-    #[serde(rename = "ANNOTATION_STATE_RESOLVED", alias = "resolved")]
+    #[serde(
+        rename = "ANNOTATION_STATE_RESOLVED",
+        alias = "resolved",
+        alias = "accepted"
+    )]
     Resolved,
 }
 

--- a/rust/crates/sift_mcp/src/tool/annotations/test.rs
+++ b/rust/crates/sift_mcp/src/tool/annotations/test.rs
@@ -313,6 +313,26 @@ fn annotation_params_accept_published_enum_values() {
     assert!(matches!(update.state, Some(AnnotationStateParam::Resolved)));
 }
 
+#[test]
+fn annotation_params_accept_state_aliases() {
+    let failed = serde_json::from_value::<UpdateAnnotationParams>(serde_json::json!({
+        "annotation_ids": ["ann1"],
+        "state": "failed",
+    }))
+    .expect("`failed` must alias the flagged state");
+    assert!(matches!(failed.state, Some(AnnotationStateParam::Flagged)));
+
+    let accepted = serde_json::from_value::<UpdateAnnotationParams>(serde_json::json!({
+        "annotation_ids": ["ann1"],
+        "state": "accepted",
+    }))
+    .expect("`accepted` must alias the resolved state");
+    assert!(matches!(
+        accepted.state,
+        Some(AnnotationStateParam::Resolved)
+    ));
+}
+
 #[tokio::test]
 async fn create_annotation_rejects_state_on_phase() {
     let (server, _h) = server_with_mock(MockAnnotationServiceImpl::new()).await;

--- a/rust/crates/sift_mcp/src/tool/annotations/test.rs
+++ b/rust/crates/sift_mcp/src/tool/annotations/test.rs
@@ -3,7 +3,10 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
 };
 
-use rmcp::{handler::server::wrapper::Parameters, model::ErrorCode};
+use rmcp::{
+    handler::server::wrapper::Parameters,
+    model::{ErrorCode, Tool},
+};
 use sift_rs::annotations::v1::{
     Annotation, BatchArchiveAnnotationsResponse, CreateAnnotationResponse, ListAnnotationsResponse,
     UpdateAnnotationResponse, annotation_service_server::AnnotationServiceServer,
@@ -12,11 +15,112 @@ use sift_test_util::{grpc::memory_sift_channel, mock::annotations::v1::MockAnnot
 use tokio::task::JoinHandle;
 use tonic::{Response, Status, transport::Server};
 
-use super::{AnnotationListParams, CreateAnnotationParams, UpdateAnnotationParams};
+use super::{
+    AnnotationListParams, AnnotationStateParam, AnnotationTypeParam, CreateAnnotationParams,
+    UpdateAnnotationParams,
+};
 use crate::{
     server::SiftMcpServer,
     tool::common::test_support::{structured, structured_field},
 };
+
+fn annotation_tool(name: &str) -> Tool {
+    SiftMcpServer::annotations_router()
+        .list_all()
+        .into_iter()
+        .find(|tool| tool.name == name)
+        .unwrap_or_else(|| panic!("missing annotation tool `{name}`"))
+}
+
+fn contains_enum(schema: &serde_json::Value, node: &serde_json::Value, expected: &[&str]) -> bool {
+    let expected_values = expected
+        .iter()
+        .map(|value| serde_json::Value::String((*value).to_string()))
+        .collect::<Vec<_>>();
+    if node
+        .get("enum")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|values| values == &expected_values)
+    {
+        return true;
+    }
+
+    if let Some(reference) = node.get("$ref").and_then(serde_json::Value::as_str)
+        && let Some(name) = reference.strip_prefix("#/$defs/")
+        && contains_enum(schema, &schema["$defs"][name], expected)
+    {
+        return true;
+    }
+
+    ["anyOf", "oneOf", "allOf"].into_iter().any(|key| {
+        node.get(key)
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|nodes| {
+                nodes
+                    .iter()
+                    .any(|node| contains_enum(schema, node, expected))
+            })
+    })
+}
+
+fn assert_property_enum(tool: &Tool, property: &str, expected: &[&str]) {
+    let schema = serde_json::Value::Object(tool.input_schema.as_ref().clone());
+    let property_schema = &schema["properties"][property];
+    assert!(
+        contains_enum(&schema, property_schema, expected),
+        "`{}` must define `{property}` with enum values {expected:?}; schema: {schema}",
+        tool.name
+    );
+}
+
+#[test]
+fn annotation_tool_schemas_publish_exact_enum_values() {
+    let create = annotation_tool("create_annotation");
+    assert_property_enum(
+        &create,
+        "annotation_type",
+        &["ANNOTATION_TYPE_DATA_REVIEW", "ANNOTATION_TYPE_PHASE"],
+    );
+    assert_property_enum(
+        &create,
+        "state",
+        &[
+            "ANNOTATION_STATE_OPEN",
+            "ANNOTATION_STATE_FLAGGED",
+            "ANNOTATION_STATE_RESOLVED",
+        ],
+    );
+
+    let update = annotation_tool("update_annotation");
+    assert_property_enum(
+        &update,
+        "state",
+        &[
+            "ANNOTATION_STATE_OPEN",
+            "ANNOTATION_STATE_FLAGGED",
+            "ANNOTATION_STATE_RESOLVED",
+        ],
+    );
+}
+
+#[test]
+fn list_annotations_description_publishes_filter_enum_values() {
+    let tool = annotation_tool("list_annotations");
+    let description = tool.description.expect("tool must have a description");
+
+    for value in [
+        "ANNOTATION_STATE_OPEN",
+        "ANNOTATION_STATE_FLAGGED",
+        "ANNOTATION_STATE_RESOLVED",
+        "ANNOTATION_TYPE_DATA_REVIEW",
+        "ANNOTATION_TYPE_PHASE",
+    ] {
+        assert!(
+            description.contains(value),
+            "list_annotations description must name `{value}`"
+        );
+    }
+}
 
 async fn server_with_mock(mock: MockAnnotationServiceImpl) -> (SiftMcpServer, JoinHandle<()>) {
     let (client, server) = tokio::io::duplex(1024);
@@ -42,7 +146,7 @@ fn create_params() -> CreateAnnotationParams {
         description: None,
         start_time_unix_nanos: 1_000_000_000,
         end_time_unix_nanos: 2_000_000_000,
-        annotation_type: "data_review".into(),
+        annotation_type: AnnotationTypeParam::DataReview,
         state: None,
         assets: None,
         tags: None,
@@ -173,19 +277,40 @@ async fn create_annotation_rejects_inverted_time_range() {
     assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
 }
 
-#[tokio::test]
-async fn create_annotation_rejects_unknown_type() {
-    let (server, _h) = server_with_mock(MockAnnotationServiceImpl::new()).await;
+#[test]
+fn create_annotation_params_reject_unknown_type() {
+    let params = serde_json::from_value::<CreateAnnotationParams>(serde_json::json!({
+        "name": "review window",
+        "start_time_unix_nanos": 1_000_000_000,
+        "end_time_unix_nanos": 2_000_000_000,
+        "annotation_type": "bogus",
+    }));
 
-    let mut params = create_params();
-    params.annotation_type = "bogus".into();
+    assert!(params.is_err());
+}
 
-    let err = server
-        .create_annotation(Parameters(params))
-        .await
-        .expect_err("expected error");
+#[test]
+fn annotation_params_accept_published_enum_values() {
+    let create = serde_json::from_value::<CreateAnnotationParams>(serde_json::json!({
+        "name": "review window",
+        "start_time_unix_nanos": 1_000_000_000,
+        "end_time_unix_nanos": 2_000_000_000,
+        "annotation_type": "ANNOTATION_TYPE_DATA_REVIEW",
+        "state": "ANNOTATION_STATE_FLAGGED",
+    }))
+    .expect("published create enum values must deserialize");
+    assert!(matches!(
+        create.annotation_type,
+        AnnotationTypeParam::DataReview
+    ));
+    assert!(matches!(create.state, Some(AnnotationStateParam::Flagged)));
 
-    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+    let update = serde_json::from_value::<UpdateAnnotationParams>(serde_json::json!({
+        "annotation_ids": ["ann1"],
+        "state": "ANNOTATION_STATE_RESOLVED",
+    }))
+    .expect("published update enum values must deserialize");
+    assert!(matches!(update.state, Some(AnnotationStateParam::Resolved)));
 }
 
 #[tokio::test]
@@ -193,8 +318,8 @@ async fn create_annotation_rejects_state_on_phase() {
     let (server, _h) = server_with_mock(MockAnnotationServiceImpl::new()).await;
 
     let mut params = create_params();
-    params.annotation_type = "phase".into();
-    params.state = Some("open".into());
+    params.annotation_type = AnnotationTypeParam::Phase;
+    params.state = Some(AnnotationStateParam::Open);
 
     let err = server
         .create_annotation(Parameters(params))


### PR DESCRIPTION
## Description

- Publish exact annotation state and type values in MCP input schemas.
- Document the exact enum strings for annotation filters.
- Keep the existing lowercase create and update aliases.

## Verification

- `cargo test -p sift_mcp`
- `cargo clippy -p sift_mcp --tests -- -D warnings -A clippy::too_many_arguments`
- `cargo fmt --all -- --check`


<img width="1129" height="648" alt="CleanShot 2026-09-02 at 17 28 14" src="https://github.com/user-attachments/assets/81fe0462-3370-4d80-b240-a50d3df2ed21" />
