### PR TITLE
rust(fix): tell callers when get_data returned decimated data

### DIFF
--- a/rust/crates/sift_mcp/src/prompt/mod.rs
+++ b/rust/crates/sift_mcp/src/prompt/mod.rs
@@ -92,8 +92,9 @@ impl SiftMcpServer {
              channels were named, choose a sensible set and tell the user which you picked.\n\
              3. Pull data with `get_data`. Pass `run_name` so the run's start/stop bounds apply \
              automatically; do not hand-compute timestamps. Use `channel_names` with exact \
-             channel names. Choose `sample_ms` to suit the run length: decimate (e.g. 100-1000 ms) \
-             for long runs and use 0 only when raw fidelity is required. Write to a Parquet path in a \
+             channel names. Pass `sample_ms = 0`: this flow ends in statistics, and statistics taken \
+             off decimated data are wrong. If a long run makes the pull too large, narrow the time \
+             range or the channel set rather than decimating. Write to a Parquet path in a \
              working directory.\n\
              4. Summarize with `sql` against the `get_data` output: per-channel row count, min/max/mean, \
              and null rate, plus anything needed to answer the user's question. Keep \
@@ -140,7 +141,8 @@ impl SiftMcpServer {
              1. Resolve the source asset and run with `list_assets` and `list_runs`. Identify the \
              channels the transform needs via `list_channels` scoped by `asset_id`.\n\
              2. Extract with `get_data`, passing `run_name` so the run bounds apply. Choose \
-             `channel_names` and a `sample_ms` suited to the transform.\n\
+             `channel_names`, and pass `sample_ms = 0` so the transform runs on real samples rather \
+             than a decimated approximation of them.\n\
              3. Apply the transform with `sql`. CRITICAL: column 0 of any dataset uploaded to Sift \
              MUST be `timestamp_unix_nanos` (Int64, non-null). Project it first in the SELECT and never \
              rename or drop it. For aggregations that collapse rows, bucket on a time expression \

--- a/rust/crates/sift_mcp/src/service/data/mod.rs
+++ b/rust/crates/sift_mcp/src/service/data/mod.rs
@@ -99,6 +99,43 @@ impl fmt::Display for NoChannelData {
 
 impl std::error::Error for NoChannelData {}
 
+/// The decimation interval the service actually applied, gathered from
+/// `Metadata.sampled_ms` on every returned data page.
+///
+/// It arrives per page rather than per request, and the API ignores `sample_ms`
+/// for data types it cannot sample, so one request can come back decimated for a
+/// double channel and raw for a string one. Tracking the range keeps that visible
+/// instead of reporting whichever page happened to land last.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct AppliedSampleMs {
+    lowest: Option<u32>,
+    highest: Option<u32>,
+}
+
+impl AppliedSampleMs {
+    fn observe(&mut self, sampled_ms: u32) {
+        self.lowest = Some(self.lowest.map_or(sampled_ms, |v| v.min(sampled_ms)));
+        self.highest = Some(self.highest.map_or(sampled_ms, |v| v.max(sampled_ms)));
+    }
+
+    /// The interval the pages reported, or `None` when none did. When pages
+    /// disagree this is the largest, which is the one that decides whether a
+    /// statistic drawn from the file can be trusted.
+    pub fn highest(&self) -> Option<u32> {
+        self.highest
+    }
+
+    /// True when any page came back decimated.
+    pub fn decimated(&self) -> bool {
+        self.highest.is_some_and(|v| v > 0)
+    }
+
+    /// True when some channels were decimated and others were not.
+    pub fn mixed(&self) -> bool {
+        matches!((self.lowest, self.highest), (Some(lo), Some(hi)) if lo != hi)
+    }
+}
+
 /// What `get_data` wrote, beyond the Parquet file itself.
 #[derive(Debug)]
 pub struct DataOutput {
@@ -107,6 +144,10 @@ pub struct DataOutput {
     /// caller diffing the Parquet schema against its request is the only way to
     /// notice them otherwise.
     pub empty_channels: Vec<String>,
+    /// What the service sampled at, as opposed to what was asked for. A caller
+    /// that never learns this quotes a mean off decimated data with no way to
+    /// know it is wrong.
+    pub applied_sample_ms: AppliedSampleMs,
 }
 
 pub enum ChannelInput {
@@ -330,6 +371,7 @@ impl DataService {
 
         let mut page_token = String::new();
         let mut columns = HashMap::<ColumnName, ChannelColumn>::new();
+        let mut applied_sample_ms = AppliedSampleMs::default();
 
         loop {
             let channel = self.channel.clone();
@@ -377,6 +419,7 @@ impl DataService {
                         let Some(metadata) = metadata else {
                             bail!("unexpected missing channel page metadata");
                         };
+                        applied_sample_ms.observe(metadata.sampled_ms);
 
                         let Some(channel) = metadata.channel else {
                             bail!("unexpected missing channel from metadata");
@@ -421,6 +464,7 @@ impl DataService {
                         let Some(metadata) = metadata else {
                             bail!("unexpected missing channel page metadata");
                         };
+                        applied_sample_ms.observe(metadata.sampled_ms);
 
                         let Some(channel) = metadata.channel else {
                             bail!("unexpected missing channel from metadata");
@@ -482,6 +526,7 @@ impl DataService {
                         let Some(metadata) = metadata else {
                             bail!("unexpected missing channel page metadata");
                         };
+                        applied_sample_ms.observe(metadata.sampled_ms);
 
                         let Some(channel) = metadata.channel else {
                             bail!("unexpected missing channel from metadata");
@@ -543,6 +588,7 @@ impl DataService {
                         let Some(metadata) = metadata else {
                             bail!("unexpected missing channel page metadata");
                         };
+                        applied_sample_ms.observe(metadata.sampled_ms);
 
                         let Some(channel) = metadata.channel else {
                             bail!("unexpected missing channel from metadata");
@@ -590,6 +636,7 @@ impl DataService {
                         let Some(metadata) = metadata else {
                             bail!("unexpected missing channel page metadata");
                         };
+                        applied_sample_ms.observe(metadata.sampled_ms);
 
                         let Some(channel) = metadata.channel else {
                             bail!("unexpected missing channel from metadata");
@@ -637,6 +684,7 @@ impl DataService {
                         let Some(metadata) = metadata else {
                             bail!("unexpected missing channel page metadata");
                         };
+                        applied_sample_ms.observe(metadata.sampled_ms);
 
                         let Some(channel) = metadata.channel else {
                             bail!("unexpected missing channel from metadata");
@@ -684,6 +732,7 @@ impl DataService {
                         let Some(metadata) = metadata else {
                             bail!("unexpected missing channel page metadata");
                         };
+                        applied_sample_ms.observe(metadata.sampled_ms);
 
                         let Some(channel) = metadata.channel else {
                             bail!("unexpected missing channel from metadata");
@@ -731,6 +780,7 @@ impl DataService {
                         let Some(metadata) = metadata else {
                             bail!("unexpected missing channel page metadata");
                         };
+                        applied_sample_ms.observe(metadata.sampled_ms);
 
                         let Some(channel) = metadata.channel else {
                             bail!("unexpected missing channel from metadata");
@@ -778,6 +828,7 @@ impl DataService {
                         let Some(metadata) = metadata else {
                             bail!("unexpected missing channel page metadata");
                         };
+                        applied_sample_ms.observe(metadata.sampled_ms);
 
                         let Some(channel) = metadata.channel else {
                             bail!("unexpected missing channel from metadata");
@@ -825,6 +876,7 @@ impl DataService {
                         let Some(metadata) = metadata else {
                             bail!("unexpected missing channel page metadata");
                         };
+                        applied_sample_ms.observe(metadata.sampled_ms);
 
                         let Some(channel) = metadata.channel else {
                             bail!("unexpected missing channel from metadata");
@@ -872,6 +924,7 @@ impl DataService {
                         let Some(metadata) = metadata else {
                             bail!("unexpected missing channel page metadata");
                         };
+                        applied_sample_ms.observe(metadata.sampled_ms);
 
                         let Some(channel) = metadata.channel else {
                             bail!("unexpected missing channel from metadata");
@@ -1082,7 +1135,10 @@ impl DataService {
             .close()
             .context("failed to finalize arrow writer")?;
 
-        Ok(DataOutput { empty_channels })
+        Ok(DataOutput {
+            empty_channels,
+            applied_sample_ms,
+        })
     }
 
     fn append_null_to_builder(

--- a/rust/crates/sift_mcp/src/service/data/test.rs
+++ b/rust/crates/sift_mcp/src/service/data/test.rs
@@ -729,7 +729,6 @@ async fn get_data_sends_saved_calculation_query() {
     );
 }
 
-
 /// The service reports the rate it applied on every page. A caller that is not
 /// told it holds decimated data has no way to know a mean drawn from the file is
 /// wrong, so the rate has to survive out of `get_data` rather than be discarded.

--- a/rust/crates/sift_mcp/src/service/data/test.rs
+++ b/rust/crates/sift_mcp/src/service/data/test.rs
@@ -109,6 +109,45 @@ fn double_page(channel_id: &str, channel_name: &str, samples: Vec<(i64, f64)>) -
     }
 }
 
+/// Like `double_page`, but sets `Metadata.sampled_ms` — the rate the service
+/// says it actually applied, which is what the caller is told about.
+fn double_page_sampled(
+    channel_id: &str,
+    channel_name: &str,
+    sampled_ms: u32,
+    samples: Vec<(i64, f64)>,
+) -> Any {
+    let values = samples
+        .into_iter()
+        .map(|(ts_nanos, value)| {
+            let (seconds, nanos) = unix_nanos_to_secs_and_subsec_nanos(ts_nanos);
+            DoubleValue {
+                timestamp: Some(Timestamp { seconds, nanos }),
+                value,
+            }
+        })
+        .collect();
+
+    let payload = DoubleValues {
+        metadata: Some(Metadata {
+            channel: Some(metadata::Channel {
+                channel_id: channel_id.into(),
+                name: channel_name.into(),
+                ..Default::default()
+            }),
+            sampled_ms,
+            ..Default::default()
+        }),
+        values,
+        extras: vec![],
+    };
+
+    Any {
+        type_url: "sift.data.v2.DoubleValues".into(),
+        value: Bytes::from(payload.encode_to_vec()),
+    }
+}
+
 fn read_parquet(buffer: Vec<u8>) -> Vec<arrow::array::RecordBatch> {
     let reader = ParquetRecordBatchReaderBuilder::try_new(Bytes::from(buffer))
         .expect("failed to open parquet")
@@ -688,4 +727,110 @@ async fn get_data_sends_saved_calculation_query() {
         "a nameless calculated channel column must fall back to its key: {}",
         schema.field(1).name(),
     );
+}
+
+
+/// The service reports the rate it applied on every page. A caller that is not
+/// told it holds decimated data has no way to know a mean drawn from the file is
+/// wrong, so the rate has to survive out of `get_data` rather than be discarded.
+#[tokio::test]
+async fn get_data_reports_the_applied_sample_rate() {
+    let mut mock = MockDataServiceImpl::new();
+    mock.expect_get_data().times(1).returning(|_| {
+        Ok(Response::new(GetDataResponse {
+            data: vec![double_page_sampled(
+                "c1",
+                "temp",
+                100,
+                vec![(1_000_000_000, 10.0), (2_000_000_000, 11.0)],
+            )],
+            next_page_token: String::new(),
+        }))
+    });
+
+    let (service, _h) = service_with_mock(mock).await;
+    let mut buffer = Vec::new();
+    let output = service
+        .get_data(
+            &[raw_channel("c1")],
+            asset_range(0, 3_000_000_000),
+            100,
+            &mut buffer,
+        )
+        .await
+        .expect("get_data failed");
+
+    assert_eq!(output.applied_sample_ms.highest(), Some(100));
+    assert!(output.applied_sample_ms.decimated());
+    assert!(!output.applied_sample_ms.mixed());
+}
+
+/// A raw pull must report itself as raw, not merely as "no rate reported".
+/// `decimated` false is the assurance a caller needs before quoting a statistic.
+#[tokio::test]
+async fn get_data_reports_raw_when_nothing_was_decimated() {
+    let mut mock = MockDataServiceImpl::new();
+    mock.expect_get_data().times(1).returning(|_| {
+        Ok(Response::new(GetDataResponse {
+            data: vec![double_page_sampled(
+                "c1",
+                "temp",
+                0,
+                vec![(1_000_000_000, 10.0)],
+            )],
+            next_page_token: String::new(),
+        }))
+    });
+
+    let (service, _h) = service_with_mock(mock).await;
+    let mut buffer = Vec::new();
+    let output = service
+        .get_data(
+            &[raw_channel("c1")],
+            asset_range(0, 3_000_000_000),
+            0,
+            &mut buffer,
+        )
+        .await
+        .expect("get_data failed");
+
+    assert_eq!(output.applied_sample_ms.highest(), Some(0));
+    assert!(!output.applied_sample_ms.decimated());
+    assert!(!output.applied_sample_ms.mixed());
+}
+
+/// The API ignores `sample_ms` for data types it cannot sample, so one request
+/// can come back decimated for one channel and raw for another. Reporting a
+/// single rate would describe half the file; `mixed` is what keeps the other
+/// half from being quoted as if it matched.
+#[tokio::test]
+async fn get_data_flags_a_file_that_mixes_decimated_and_raw_channels() {
+    let mut mock = MockDataServiceImpl::new();
+    mock.expect_get_data().times(1).returning(|_| {
+        Ok(Response::new(GetDataResponse {
+            data: vec![
+                double_page_sampled("c1", "sampled", 100, vec![(1_000_000_000, 10.0)]),
+                double_page_sampled("c2", "untouched", 0, vec![(1_000_000_000, 20.0)]),
+            ],
+            next_page_token: String::new(),
+        }))
+    });
+
+    let (service, _h) = service_with_mock(mock).await;
+    let mut buffer = Vec::new();
+    let output = service
+        .get_data(
+            &[raw_channel("c1"), raw_channel("c2")],
+            asset_range(0, 3_000_000_000),
+            100,
+            &mut buffer,
+        )
+        .await
+        .expect("get_data failed");
+
+    // The highest rate is the one that decides whether the file can be trusted,
+    // so a mixed result reports the decimated half rather than the raw one.
+    assert_eq!(output.applied_sample_ms.highest(), Some(100));
+    assert!(output.applied_sample_ms.decimated());
+    assert!(output.applied_sample_ms.mixed());
 }

--- a/rust/crates/sift_mcp/src/tool/data/mod.rs
+++ b/rust/crates/sift_mcp/src/tool/data/mod.rs
@@ -117,6 +117,10 @@ impl SiftMcpServer {
               - `unresolved_calculated_channels` (`[{ \"name\", \"reason\" }]`) is present when a requested name
                 reached calculated-channel resolution and could not be served. It carries the reason for every
                 name in `unmatched_channel_names`.
+              - `sample_ms_applied` and `decimated` report what the service actually sampled at, which is not
+                always what was requested: `sample_ms` is ignored for data types that cannot be sampled. Both
+                keys are ALWAYS present; `sample_ms_applied` is null when no page reported a rate.
+                `mixed_sample_rates` appears when some channels came back decimated and others raw.
 
             Parameters:
               - `asset_name`: optional, exact asset name (not a pattern). Mutually exclusive with `asset_id`;
@@ -127,7 +131,13 @@ impl SiftMcpServer {
               - `run_name`: optional, exact run name within the asset. When provided, the run's start/stop bounds are
                 used as the time range; `start_time_unix_nanos` and/or `end_time_unix_nanos` may narrow either side.
                 When omitted, BOTH `start_time_unix_nanos` and `end_time_unix_nanos` are required.
-              - `sample_ms`: decimation interval in milliseconds. Use `0` for raw samples; larger values reduce volume.
+              - `sample_ms`: decimation interval in milliseconds. Set this to `0` unless the data will be used
+                EXCLUSIVELY to generate a visualization. Decimation applies LTTB, which selects shape-defining
+                extremes rather than representative samples: counts, means, standard deviations and trends
+                computed on decimated output are wrong, and the error depends on where bucket boundaries fall,
+                so it cannot be corrected afterwards. Extremes usually survive but are not guaranteed to.
+                If a raw result would be too large, narrow the time range or the channel set and issue
+                successive calls — do not decimate to reduce volume.
               - `channel_names`: optional array of exact channel names. Mutually exclusive with `channel_regex`;
                 exactly one of the two MUST be set. Prefer this form when the set is known — it's more predictable.
                 A name with no raw channel on the asset is resolved as an active saved calculated channel and
@@ -165,7 +175,12 @@ impl SiftMcpServer {
               - Data is buffered in memory until size/row thresholds are hit, so very large time ranges or wide
                 channel sets can be slow or memory-heavy. For large pulls, split the time range into successive calls
                 with disjoint `[start, end)` windows.
-              - Use `sample_ms > 0` for overview/summary work; reserve `sample_ms = 0` for cases that need raw fidelity.
+              - Analysis needs `sample_ms = 0`. Reserve `sample_ms > 0` for data used exclusively to draw a
+                picture, and prefer `explore_url` over `get_data` entirely when that is the goal. An overview,
+                a summary and a quick look are all analysis: they end in numbers, and numbers taken off
+                decimated data are wrong.
+              - The result reports `sample_ms_applied` and `decimated`. Check them before quoting any statistic:
+                a non-zero applied rate means means, standard deviations and trends from that file are not valid.
               - A successful call does NOT mean every requested channel is in the file. Check
                 `unmatched_channel_names` and `empty_channels` before reporting the result or aggregating over it,
                 and check the same two keys on the error's `data` when a call fails.
@@ -463,8 +478,30 @@ impl SiftMcpServer {
             ));
         }
 
+        let applied = data_output.applied_sample_ms;
+
         let mut next_step =
             format!("Wrote channel data to `{output_str}`. Inform the user where the data lives.");
+        // The caller asked for a rate; the service reports what it actually
+        // applied, and the two are not the same thing for a data type it cannot
+        // sample. Saying so here is the difference between an agent that knows
+        // its file is decimated and one that quotes a standard deviation off it.
+        if applied.decimated() {
+            next_step.push_str(
+                " This data is DECIMATED, not raw. It was sampled with LTTB, which selects \
+                 shape-defining extremes rather than representative samples: counts, means, \
+                 standard deviations and trends computed from this file are wrong. Use it only to \
+                 draw a picture. To analyse, call again with `sample_ms = 0`, narrowing the time \
+                 range or channel set if the raw result would be too large.",
+            );
+            if applied.mixed() {
+                next_step.push_str(
+                    " Note that not every channel was decimated: the service ignores `sample_ms` \
+                     for data types it cannot sample, so this file mixes decimated and raw \
+                     columns.",
+                );
+            }
+        }
         // Without this the agent reads a plain success and reports a partial
         // fetch as a complete one, because a channel with no column is
         // indistinguishable from one that was never requested.
@@ -498,6 +535,17 @@ impl SiftMcpServer {
             "empty_channels".to_string(),
             string_array(data_output.empty_channels),
         );
+        // What the service sampled at, not what was requested. Always present so
+        // "raw" and "this tool never checked" cannot be confused, for the same
+        // reason the two keys above are.
+        body.insert(
+            "sample_ms_applied".to_string(),
+            applied.highest().map_or(Value::Null, Value::from),
+        );
+        body.insert("decimated".to_string(), Value::from(applied.decimated()));
+        if applied.mixed() {
+            body.insert("mixed_sample_rates".to_string(), Value::from(true));
+        }
 
         if !unresolved.is_empty() {
             body.insert(


### PR DESCRIPTION
## What

`get_data` recommended decimation for exactly the work the underlying API warns against, and never reported what rate it actually applied. Together those let an agent compute statistics on plot data and report them as fact.

`sift/data/v2/data.proto` documents that `sample_ms` applies LTTB, and that `0` "is recommended for external data analysis where full fidelity is required, as opposed to plotting where downsampling is typically sufficient." The tool description said the reverse and never named the algorithm.

## Why it matters

LTTB selects shape-defining extremes rather than representative samples, so second-moment and trend statistics drawn from decimated output are wrong. Measured on one channel over one throttle window, raw against a 10 Hz pull:

| | raw 100 Hz | LTTB 10 Hz |
|---|---|---|
| mean | 1355.52 | 1347.56 (−0.6%) |
| standard deviation | 26.67 | 89.00 (+234%) |
| slope per 100s | +23.74 | −17.11 (sign flip) |

The error depends on where bucket boundaries fall relative to the analysis window, so it cannot be corrected after the fact. Bucketing the raw series and comparing each returned sample against its bucket, 50.3% matched the bucket minimum and 49.8% the maximum, which is LTTB working as designed.

## Changes

**Guidance.** `sample_ms` is documented as `0` unless the data will be used exclusively to generate a visualization, with LTTB named and the consequence stated. An oversized result is answered by narrowing the time range or the channel set, not by decimating. The two prompt flows that told the agent to pick a rate to suit the run length now pass `0`, since both end in statistics.

**Reporting.** `Metadata.sampled_ms` arrives on every data page and was being dropped. The result now carries `sample_ms_applied` and `decimated`, always present so raw and unchecked cannot be confused, and the `next_step` text says plainly that a decimated file cannot be analysed.

The rate is tracked as a range rather than a single value because the API ignores `sample_ms` for data types it cannot sample: one request can come back decimated for a double channel and raw for a string one. Reporting whichever page landed last would describe half the file, so a mixed result reports the decimated half and sets `mixed_sample_rates`.

## Verification

`cargo test -p sift_mcp` — 511 pass, 3 new:

- `get_data_reports_the_applied_sample_rate` — a decimated pull reports its rate and sets `decimated`
- `get_data_reports_raw_when_nothing_was_decimated` — a raw pull reports itself as raw, rather than as "no rate reported"
- `get_data_flags_a_file_that_mixes_decimated_and_raw_channels` — a mixed file reports the decimated half and flags the mix

`cargo clippy -p sift_mcp --all-targets` is clean apart from one pre-existing warning in `report_templates`.

## Note for reviewers

This changes agent behaviour, not just documentation. Anything downstream that assumed `get_data` would decimate by default for large pulls will now receive raw samples unless it asks otherwise.