### PR TITLE
python(feat): add development frontend origin host mapping

### DIFF
--- a/python/lib/sift_client/_internal/urls.py
+++ b/python/lib/sift_client/_internal/urls.py
@@ -15,6 +15,7 @@ from urllib.parse import urlparse
 # API host (host[:port], no scheme) -> frontend origin (with scheme).
 _API_HOST_TO_FRONTEND_ORIGIN: dict[str, str] = {
     "api.siftstack.com": "https://app.siftstack.com",
+    "api.development.siftstack.com": "https://app.development.siftstack.com",
     "gov.api.siftstack.com": "https://gov.siftstack.com",
 }
 

--- a/python/lib/sift_client/_tests/test_urls.py
+++ b/python/lib/sift_client/_tests/test_urls.py
@@ -13,6 +13,10 @@ class TestFrontendOriginForApi:
         ("api_base_url", "expected"),
         [
             ("https://api.siftstack.com", "https://app.siftstack.com"),
+            (
+                "https://api.development.siftstack.com",
+                "https://app.development.siftstack.com",
+            ),
             ("https://gov.api.siftstack.com", "https://gov.siftstack.com"),
             # Bare host (no scheme) resolves the same as the full URL.
             ("api.siftstack.com", "https://app.siftstack.com"),

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sift_stack_py"
-version = "0.19.1"
+version = "0.19.2"
 description = "Python client library for the Sift API"
 requires-python = ">=3.8"
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
## Summary
- Map `api.development.siftstack.com` to `https://app.development.siftstack.com` in `_API_HOST_TO_FRONTEND_ORIGIN` so `SiftClient.app_url` resolves correctly in development.
- Bump `sift-stack-py` to **0.19.2**.

## Test plan
- [x] `test_urls.py` covers the new host entry
- [ ] Publish 0.19.2 to the packages gateway before merging the companion azimuth PR

## Related
Companion change: https://github.com/sift-stack/azimuth/pull/14064 (ENG-14170 / ENG-14324 canvas upload CLI).