### PR TITLE
rust(feature): add ability to disable retries in sift_stream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 
 [workspace.package]
 authors = ["Sift Software Engineers <engineering@siftstack.com>"]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 categories = ["aerospace", "science::robotics"]
 homepage = "https://github.com/sift-stack/sift"
@@ -87,13 +87,13 @@ tracing-test = { version = "0.2", features = ["no-env-filter"] }
 uuid = { version = "1.22", features = ["v4"] }
 zip = "8.2"
 
-sift_connect = { version = "0.11.0", path = "rust/crates/sift_connect" }
-sift_rs = { version = "0.11.0", path = "rust/crates/sift_rs" }
-sift_error = { version = "0.11.0", path = "rust/crates/sift_error" }
-sift_stream = { version = "0.11.0", path = "rust/crates/sift_stream" }
-sift_pbfs = { version = "0.11.0", path = "rust/crates/sift_pbfs" }
-sift_mcp = { version = "0.11.0", path = "rust/crates/sift_mcp" }
-sift_test_util = { version = "0.11.0", path = "rust/crates/sift_test_util" }
+sift_connect = { version = "0.12.0", path = "rust/crates/sift_connect" }
+sift_rs = { version = "0.12.0", path = "rust/crates/sift_rs" }
+sift_error = { version = "0.12.0", path = "rust/crates/sift_error" }
+sift_stream = { version = "0.12.0", path = "rust/crates/sift_stream" }
+sift_pbfs = { version = "0.12.0", path = "rust/crates/sift_pbfs" }
+sift_mcp = { version = "0.12.0", path = "rust/crates/sift_mcp" }
+sift_test_util = { version = "0.12.0", path = "rust/crates/sift_test_util" }
 
 sift_stream_bindings = { version = "0.5.0", path = "rust/crates/sift_stream_bindings" }
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [v0.12.0]
 ### What's New
 
 #### Live-only retries can be disabled

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -3,6 +3,40 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### What's New
+
+#### Live-only retries can be disabled
+
+[`LiveOnlyBuilder::retry_policy`](crates/sift_stream/src/stream/builder.rs) now accepts `None`:
+
+```rust
+let mut sift_stream = SiftStreamBuilder::new(credentials)
+    .ingestion_config(ingestion_config)
+    .live_only()
+    .retry_policy(None)
+    .build()
+    .await?;
+```
+
+The method takes `impl Into<Option<RetryPolicy>>`, so existing calls that pass a `RetryPolicy`
+still compile.
+
+With retries disabled, the ingestion task still makes the first attempt but does not open a
+replacement stream after a failure. It stops, closes the ingestion channel, and reports the
+failure. `send` and `try_send` then report a closed channel, and `finish` returns
+`ErrorKind::StreamError`.
+
+This closes a gap in live-only mode. Retries there recover the connection but not the data:
+messages already handed to the failed stream are dropped, and live-only mode keeps no disk
+backup to replay them from. `finish` could therefore return `Ok` after a mid-stream failure
+that lost samples. With retries disabled, every stream failure is reported, so an `Ok` from
+`finish` means Sift acknowledged every message that was sent. Callers that keep their own
+durable copy of the data can use that verdict to decide whether to resend a range.
+
+`live_with_backups()` mode is unchanged and always retries. Recovery there depends on the
+ingestion task staying alive to drive checkpoints and reingestion from disk.
+
 ## [v0.11.0] - August 20, 2026
 ### What's New
 

--- a/rust/crates/sift_stream/src/lib.rs
+++ b/rust/crates/sift_stream/src/lib.rs
@@ -81,8 +81,8 @@
 //! the channel architecture, backpressure behavior, and durability guarantees:
 //!
 //! | Builder method | Transport type | Backpressure source | Checkpointing | Disk backup | Retries |
-//! |---|---|---|---|---|
-//! | `.live_only()` | [`LiveStreamingOnly`] | ingestion channel | No | No | Yes |
+//! |---|---|---|---|---|---|
+//! | `.live_only()` | [`LiveStreamingOnly`] | ingestion channel | No | No | Optional |
 //! | `.live_with_backups()` | [`LiveStreamingWithBackups`] | backup channel | Yes | Yes | Yes |
 //! | `.file_backup()` | [`FileBackup`] | write channel | No | Yes | N/A |
 //!
@@ -90,7 +90,8 @@
 //!
 //! Streams to Sift in real-time over a single bounded ingestion channel. Backpressure is applied
 //! directly when that channel is full: [`send`](stream::SiftStream::send) awaits until the
-//! ingestion task drains capacity. Supports retries.
+//! ingestion task drains capacity. Retries are on by default and can be disabled with
+//! [`LiveOnlyBuilder::retry_policy(None)`](LiveOnlyBuilder::retry_policy).
 //!
 //! ```ignore
 //! let stream = SiftStreamBuilder::new(credentials)
@@ -383,7 +384,28 @@
 //!     .await?;
 //! ```
 //!
-//! For more information see [LiveWithBackupsBuilder::retry_policy], [RetryPolicy], and [DiskBackupPolicy].
+//! `live_only()` mode also retries by default, and [LiveOnlyBuilder::retry_policy] accepts
+//! `None` to turn retries off:
+//!
+//! ```ignore
+//! let mut sift_stream = SiftStreamBuilder::new(credentials)
+//!     .ingestion_config(ingestion_config)
+//!     .live_only()
+//!     .retry_policy(None)
+//!     .build()
+//!     .await?;
+//! ```
+//!
+//! With retries disabled, the ingestion task still makes the first attempt but does not open a
+//! replacement stream after a failure. It stops, closes the ingestion channel, and reports the
+//! failure from [`finish`](stream::SiftStream::finish). This trades availability for an
+//! unambiguous delivery verdict: an `Ok` from `finish` then means Sift acknowledged every
+//! message that was sent. It suits callers that keep their own durable copy of the data and
+//! resend a range themselves rather than lose it. Live-only mode has no disk backup, so a
+//! retried mid-stream failure silently drops whatever that stream was carrying.
+//!
+//! For more information see [LiveOnlyBuilder::retry_policy],
+//! [LiveWithBackupsBuilder::retry_policy], [RetryPolicy], and [DiskBackupPolicy].
 //!
 //! ## Checkpoints
 //!

--- a/rust/crates/sift_stream/src/stream/builder.rs
+++ b/rust/crates/sift_stream/src/stream/builder.rs
@@ -261,7 +261,7 @@ impl StreamConfigBuilder {
             metrics_streaming_interval: Some(DEFAULT_METRICS_STREAMING_INTERVAL),
             ingestion_data_channel_capacity: DATA_CHANNEL_CAPACITY,
             control_channel_capacity: CONTROL_CHANNEL_CAPACITY,
-            retry_policy: RetryPolicy::default(),
+            retry_policy: Some(RetryPolicy::default()),
         }
     }
 
@@ -313,7 +313,7 @@ pub struct LiveOnlyBuilder {
     metrics_streaming_interval: Option<Duration>,
     ingestion_data_channel_capacity: usize,
     control_channel_capacity: usize,
-    retry_policy: RetryPolicy,
+    retry_policy: Option<RetryPolicy>,
 }
 
 impl LiveOnlyBuilder {
@@ -353,8 +353,33 @@ impl LiveOnlyBuilder {
     }
 
     /// Sets the retry policy. Defaults to [RetryPolicy::default].
-    pub fn retry_policy(mut self, policy: RetryPolicy) -> Self {
-        self.retry_policy = policy;
+    ///
+    /// Accepts a [`RetryPolicy`], `Some(policy)`, or `None`.
+    ///
+    /// `None` disables retries. The ingestion task still makes the first attempt, but it does
+    /// not open a replacement stream after a failure. It stops, and the failure surfaces from
+    /// [`SiftStream::finish`](crate::SiftStream::finish) as `ErrorKind::StreamError`. The
+    /// ingestion channel closes at the same time, so [`send`](crate::SiftStream::send) and
+    /// [`try_send`](crate::SiftStream::try_send) start reporting a closed channel.
+    ///
+    /// Disable retries when the caller keeps its own durable copy of the data and needs an
+    /// unambiguous delivery verdict. With retries enabled, a transient failure mid-stream
+    /// drops whatever that stream was carrying, reconnects, and still lets `finish` return
+    /// `Ok`, because live-only mode keeps no disk backup to replay from. With retries
+    /// disabled, an `Ok` from `finish` means Sift acknowledged every message that was sent.
+    ///
+    /// ```no_run
+    /// # use sift_stream::{RetryPolicy, StreamConfigBuilder};
+    /// # fn f(a: StreamConfigBuilder, b: StreamConfigBuilder) {
+    /// // Retry with the default policy.
+    /// let with_retries = a.live_only().retry_policy(RetryPolicy::default());
+    ///
+    /// // Do not retry; report the first failure instead.
+    /// let without_retries = b.live_only().retry_policy(None);
+    /// # }
+    /// ```
+    pub fn retry_policy(mut self, policy: impl Into<Option<RetryPolicy>>) -> Self {
+        self.retry_policy = policy.into();
         self
     }
 

--- a/rust/crates/sift_stream/src/stream/mode/live_only.rs
+++ b/rust/crates/sift_stream/src/stream/mode/live_only.rs
@@ -75,8 +75,10 @@ impl Transport for LiveStreamingOnly {
     /// Sends a message, awaiting capacity on the **ingestion channel** if it is full.
     ///
     /// Backpressure comes from the bounded ingestion channel. The caller blocks until
-    /// the ingestion task drains capacity. Returns an error only if the channel is
-    /// closed (i.e. the stream is shutting down).
+    /// the ingestion task drains capacity. Returns an error only if the channel is closed,
+    /// which means the stream is shutting down or the ingestion task has stopped. The task
+    /// stops on a stream failure when retries are disabled; see
+    /// [`LiveOnlyBuilder::retry_policy`](crate::LiveOnlyBuilder::retry_policy).
     async fn send(
         &mut self,
         stream_id: &Uuid,
@@ -163,12 +165,22 @@ impl Transport for LiveStreamingOnly {
 
     /// Closes the ingestion channel, sends the shutdown signal, and awaits task completion.
     ///
-    /// The ingestion task drains any messages already queued before acting on the shutdown
-    /// signal, so all messages sent before `finish` is called are delivered. An `Err` means the
-    /// stream carrying that tail-end data failed and Sift never acknowledged it; since live-only
-    /// mode keeps no disk backup, that data is unrecoverable. An `Ok` means shutdown completed
-    /// with an acknowledged stream. Note that `Ok` does not account for data lost to earlier
-    /// mid-stream failures that the retry loop recovered from.
+    /// The ingestion task drains whatever is still queued on the ingestion channel before it
+    /// acts on the shutdown signal, so no message is left behind in the channel.
+    ///
+    /// An `Err` means a stream failed and Sift never acknowledged the data that stream was
+    /// carrying. Live-only mode keeps no disk backup, so that data is unrecoverable here.
+    ///
+    /// What `Ok` guarantees depends on
+    /// [`LiveOnlyBuilder::retry_policy`](crate::LiveOnlyBuilder::retry_policy):
+    ///
+    /// - With retries enabled (the default), `Ok` means the stream that was alive at shutdown
+    ///   drained and Sift acknowledged it. It does not account for data lost to an earlier
+    ///   mid-stream failure that the retry loop recovered from. Messages already handed to the
+    ///   failed stream are dropped and nothing replays them.
+    /// - With retries disabled (`retry_policy(None)`), any stream failure stops the ingestion
+    ///   task and is reported here, so `Ok` means Sift acknowledged every message that was
+    ///   sent.
     async fn finish(self, stream_id: &Uuid) -> Result<()> {
         self.ingestion_tx.close();
         let _ = self.control_tx.send(ControlMessage::Shutdown);

--- a/rust/crates/sift_stream/src/stream/tasks/builder.rs
+++ b/rust/crates/sift_stream/src/stream/tasks/builder.rs
@@ -25,7 +25,9 @@ pub(crate) struct LiveOnlyTaskConfig {
     pub(crate) enable_compression_for_ingestion: bool,
     pub(crate) ingestion_data_channel_capacity: usize,
     pub(crate) control_channel_capacity: usize,
-    pub(crate) retry_policy: RetryPolicy,
+    /// `None` disables stream retries. See
+    /// [`LiveOnlyBuilder::retry_policy`](crate::LiveOnlyBuilder::retry_policy).
+    pub(crate) retry_policy: Option<RetryPolicy>,
     pub(crate) metrics_streaming_interval: Option<Duration>,
     /// Scoped dispatch to wrap spawned futures. `None` disables scoped dispatch.
     #[cfg(feature = "tracing")]
@@ -213,7 +215,7 @@ impl TaskBuilder {
             ingestion_channel: config.ingestion_channel,
             enable_compression_for_ingestion: config.enable_compression_for_ingestion,
             metrics: config.metrics.clone(),
-            retry_policy: config.retry_policy,
+            retry_policy: Some(config.retry_policy),
             checkpoint_interval: Some(config.checkpoint_interval),
         };
         let mut ingestion_task = IngestionTask::new(

--- a/rust/crates/sift_stream/src/stream/tasks/ingestion.rs
+++ b/rust/crates/sift_stream/src/stream/tasks/ingestion.rs
@@ -54,7 +54,10 @@ pub(crate) struct IngestionTaskConfig {
     pub(crate) ingestion_channel: SiftChannel,
     pub(crate) enable_compression_for_ingestion: bool,
     pub(crate) metrics: Arc<SiftStreamMetrics>,
-    pub(crate) retry_policy: RetryPolicy,
+    /// `None` disables stream retries: the task does not reconnect after a stream
+    /// failure and instead returns the failure to the caller. See
+    /// [`LiveOnlyBuilder::retry_policy`](crate::LiveOnlyBuilder::retry_policy).
+    pub(crate) retry_policy: Option<RetryPolicy>,
     /// Present only in LiveStreamingWithBackups mode. When None, the task
     /// never sets up a checkpoint timer and ignores all checkpoint control messages.
     pub(crate) checkpoint_interval: Option<Duration>,
@@ -185,6 +188,21 @@ impl IngestionTask {
                                 return Err(Error::new(ErrorKind::StreamError, e))
                                     .context("stream to Sift failed during shutdown");
                             }
+
+                            // Retries are disabled, so no new stream will be created to carry
+                            // what this one was holding. Report the failure rather than
+                            // reconnecting and letting the caller believe the data landed.
+                            if self.config.retry_policy.is_none() {
+                                #[cfg(feature = "tracing")]
+                                tracing::error!(
+                                    sift_stream_id = %self.config.sift_stream_id,
+                                    error = %e,
+                                    "stream failed and retries are disabled"
+                                );
+
+                                return Err(Error::new(ErrorKind::StreamError, e))
+                                    .context("stream to Sift failed and retries are disabled");
+                            }
                         }
                     }
 
@@ -206,7 +224,7 @@ impl IngestionTask {
                     self.config.metrics.checkpoint.checkpoint_timer_reached_cnt.increment();
 
                     // Timeout if Sift doesn't respond to the checkpoint signal quickly.
-                    match tokio::time::timeout(CHECKPOINT_TIMEOUT, stream.as_mut().unwrap()).await {
+                    let checkpoint_failure = match tokio::time::timeout(CHECKPOINT_TIMEOUT, stream.as_mut().unwrap()).await {
                         Ok(Ok(_)) => {
                             #[cfg(feature = "tracing")]
                             tracing::info!(
@@ -215,13 +233,26 @@ impl IngestionTask {
                             );
                             self.config.metrics.grpc_status_counts[0].increment();
                             self.config.metrics.cur_retry_count.set(0);
+                            None
                         }
-                        Ok(Err(e)) => {
-                            current_wait = self.handle_failed_stream(&e, stream_created_at, current_wait, first_message_id.load(Ordering::Relaxed), last_message_id.load(Ordering::Relaxed))?;
-                        }
-                        Err(_elapsed) => {
-                            let timeout_status = GrpcStatus::deadline_exceeded("checkpoint timed out waiting for Sift");
-                            current_wait = self.handle_failed_stream(&timeout_status, stream_created_at, current_wait, first_message_id.load(Ordering::Relaxed), last_message_id.load(Ordering::Relaxed))?;
+                        Ok(Err(e)) => Some(e),
+                        Err(_elapsed) => Some(GrpcStatus::deadline_exceeded("checkpoint timed out waiting for Sift")),
+                    };
+
+                    if let Some(status) = checkpoint_failure {
+                        current_wait = self.handle_failed_stream(&status, stream_created_at, current_wait, first_message_id.load(Ordering::Relaxed), last_message_id.load(Ordering::Relaxed))?;
+
+                        // Retries are disabled, so the checkpoint will not be reattempted.
+                        if self.config.retry_policy.is_none() {
+                            #[cfg(feature = "tracing")]
+                            tracing::error!(
+                                sift_stream_id = %self.config.sift_stream_id,
+                                error = %status,
+                                "checkpoint failed and retries are disabled"
+                            );
+
+                            return Err(Error::new(ErrorKind::StreamError, status))
+                                .context("checkpoint to Sift failed and retries are disabled");
                         }
                     }
 
@@ -303,13 +334,19 @@ impl IngestionTask {
                 .map_err(|e| Error::new(ErrorKind::StreamError, e))?;
         }
 
+        // With retries disabled the caller reports the failure instead of reconnecting, so
+        // there is no backoff to compute and no retry to count.
+        let Some(retry_policy) = self.config.retry_policy.as_ref() else {
+            return Ok(Duration::ZERO);
+        };
+
         // If the stream was healthy for sufficiently long, reset the wait time used for exponential backoff.
-        let backoff = if stream_created_at.elapsed() > self.config.retry_policy.max_backoff * 2 {
+        let backoff = if stream_created_at.elapsed() > retry_policy.max_backoff * 2 {
             self.config.metrics.cur_retry_count.set(0);
             Duration::ZERO
         } else {
             self.config.metrics.cur_retry_count.add(1);
-            self.config.retry_policy.backoff(current_wait)
+            retry_policy.backoff(current_wait)
         };
 
         Ok(backoff)
@@ -398,7 +435,7 @@ mod tests {
             ingestion_channel,
             enable_compression_for_ingestion: false,
             metrics,
-            retry_policy: RetryPolicy::default(),
+            retry_policy: Some(RetryPolicy::default()),
             checkpoint_interval: Some(checkpoint_interval),
         }
     }
@@ -676,23 +713,24 @@ mod tests {
         let (data_tx, data_rx) = async_channel::bounded(1024);
         let metrics = Arc::new(SiftStreamMetrics::default());
         let checkpoint_interval = Duration::from_millis(100);
+        let retry_policy = RetryPolicy {
+            max_attempts: 3,
+            initial_backoff: Duration::from_millis(1),
+            max_backoff: Duration::from_millis(100),
+            backoff_multiplier: 5,
+        };
+        let max_attempts = retry_policy.max_attempts as usize;
         let config = IngestionTaskConfig {
             session_name: "test-session".to_string(),
             sift_stream_id: Uuid::new_v4(),
             ingestion_channel,
             enable_compression_for_ingestion: false,
             metrics: metrics.clone(),
-            retry_policy: RetryPolicy {
-                max_attempts: 3,
-                initial_backoff: Duration::from_millis(1),
-                max_backoff: Duration::from_millis(100),
-                backoff_multiplier: 5,
-            },
+            retry_policy: Some(retry_policy),
             checkpoint_interval: Some(checkpoint_interval),
         };
 
         // Ingestion is continuously retried, limited by the max retry duration only.
-        let max_attempts = config.retry_policy.max_attempts as usize;
         mock_service.set_num_errors_to_return(max_attempts + 1);
 
         let control_rx_task = control_tx.subscribe();
@@ -899,7 +937,7 @@ mod tests {
             ingestion_channel,
             enable_compression_for_ingestion: false,
             metrics,
-            retry_policy: RetryPolicy::default(),
+            retry_policy: Some(RetryPolicy::default()),
             checkpoint_interval: None,
         }
     }
@@ -1066,12 +1104,12 @@ mod tests {
         let (data_tx, data_rx) = async_channel::bounded(1024);
         let metrics = Arc::new(SiftStreamMetrics::default());
         let mut config = make_live_only_ingestion_task_config(ingestion_channel, metrics);
-        config.retry_policy = RetryPolicy {
+        config.retry_policy = Some(RetryPolicy {
             max_attempts: 3,
             initial_backoff: Duration::from_millis(1),
             max_backoff: Duration::from_millis(10),
             backoff_multiplier: 2,
-        };
+        });
 
         // Every stream attempt fails, so nothing is ever acknowledged by Sift.
         mock_service.set_num_errors_to_return(usize::MAX);
@@ -1093,5 +1131,55 @@ mod tests {
 
         let err = res.expect_err("live-only mode must not report Ok for undelivered data");
         assert_eq!(err.kind(), ErrorKind::StreamError);
+    }
+
+    /// With retries disabled the task must not open a replacement stream after a failure. The
+    /// mock fails only the first attempt, so a retrying task would reconnect and capture the
+    /// data; a non-retrying task must instead report the failure and capture nothing.
+    #[tokio::test]
+    async fn test_live_only_retries_disabled_reports_first_failure() {
+        let (ingestion_channel, mock_service) =
+            crate::test::create_mock_grpc_channel_with_service().await;
+        let (control_tx, _control_rx) = broadcast::channel(1024);
+        let (data_tx, data_rx) = async_channel::bounded(1024);
+        let metrics = Arc::new(SiftStreamMetrics::default());
+        let mut config = make_live_only_ingestion_task_config(ingestion_channel, metrics.clone());
+        config.retry_policy = None;
+
+        // Only the first stream attempt fails.
+        mock_service.set_num_errors_to_return(1);
+
+        let control_rx_task = control_tx.subscribe();
+        let mut ingestion_task = IngestionTask::new(control_tx, control_rx_task, data_rx, config);
+
+        // Queue the data before the task starts so the failure is observed while the channel
+        // is still open. That exercises the mid-stream path rather than the shutdown path.
+        send_messages_for_ingestion(&data_tx, 10).await;
+
+        let handle = tokio::spawn(async move { ingestion_task.run().await });
+
+        let res = tokio::time::timeout(Duration::from_secs(10), handle)
+            .await
+            .expect("ingestion task should not hang")
+            .expect("ingestion task should not panic");
+
+        let err = res.expect_err("a stream failure with retries disabled must be reported");
+        assert_eq!(err.kind(), ErrorKind::StreamError);
+
+        assert!(
+            mock_service.get_captured_data().is_empty(),
+            "the task must not open a replacement stream when retries are disabled"
+        );
+        assert_eq!(
+            metrics.cur_retry_count.get(),
+            0,
+            "a disabled retry policy should not count retries"
+        );
+
+        // Dropping the task drops every receiver, which closes the channel for the caller.
+        assert!(
+            data_tx.is_closed(),
+            "the ingestion channel should close once the task stops"
+        );
     }
 }

--- a/rust/crates/sift_stream/tests/test_live_only_streaming_retries.rs
+++ b/rust/crates/sift_stream/tests/test_live_only_streaming_retries.rs
@@ -213,3 +213,88 @@ pub async fn test_live_only_retries_exhausted() {
         "test server shutdown failed unexpectedly"
     );
 }
+
+/// With retries disabled the ingestion task must not open a replacement stream. It reports the
+/// first failure instead, which closes the caller's channel and surfaces from `finish`.
+#[tokio::test]
+pub async fn test_live_only_retries_disabled() {
+    let return_error = Arc::new(AtomicBool::new(true));
+
+    let num_messages_received = Arc::new(AtomicU32::default());
+    let num_streams_opened = Arc::new(AtomicU32::default());
+
+    let ingest_service = IngestServiceMock {
+        num_stream_opened: num_streams_opened.clone(),
+        num_messages_received: num_messages_received.clone(),
+        return_error: return_error.clone(),
+    };
+
+    let (client, server) = common::start_test_ingest_server(ingest_service).await;
+
+    let flows = vec![FlowConfig {
+        name: "flow-0".to_string(),
+        channels: vec![ChannelConfig {
+            name: "generator".to_string(),
+            data_type: ChannelDataType::Double.into(),
+            ..Default::default()
+        }],
+    }];
+
+    let mut sift_stream = SiftStreamBuilder::from_channel(client)
+        .ingestion_config(IngestionConfigForm {
+            asset_name: "test_asset".to_string(),
+            client_key: "test_client_key".to_string(),
+            flows,
+        })
+        .live_only()
+        .retry_policy(None)
+        .metrics_streaming_interval(None)
+        .build()
+        .await
+        .expect("failed to build sift stream");
+
+    // The ingestion task stops on the first stream failure, which drops the receiver and
+    // closes the channel for the caller.
+    let mut send_failed = false;
+    for _ in 0..100 {
+        let msg = Flow::new(
+            "flow",
+            TimeValue::from(Local::now().to_utc()),
+            &[ChannelValue::new("generator", 1.0)],
+        );
+        if sift_stream.send(msg).await.is_err() {
+            send_failed = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        send_failed,
+        "the ingestion channel should close once the ingestion task stops"
+    );
+
+    // Well past the default initial backoff, so a retrying task would have reconnected.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    assert_eq!(
+        num_streams_opened.load(Ordering::Relaxed),
+        1,
+        "a disabled retry policy must not open a replacement stream"
+    );
+    assert_eq!(
+        num_messages_received.load(Ordering::Relaxed),
+        0,
+        "the server never accepted a stream, so it received nothing"
+    );
+
+    let err = sift_stream
+        .finish()
+        .await
+        .expect_err("finish must surface the stream failure that stopped ingestion");
+    assert_eq!(err.kind(), ErrorKind::StreamError);
+
+    assert!(
+        server.await.is_ok(),
+        "test server shutdown failed unexpectedly"
+    );
+}


### PR DESCRIPTION
There was an interesting gap with `live_only` mode. We don't offer the ability to disable retries so `finish` doesn't truthfully give the user an acknowledgement that all data has been received by Sift between the start of `SiftStream` and when `finish` is called. This is because of the intermittent retries that could kick in between.

For users who manage their own durability book-keeping they need `SiftStream::finish` to give a truthful acknowledgement which is only possible if retries are disabled. This PR adds the option to disable retries.

## Verification

- Integration testing
- Manual testing