### PR TITLE
rust(chore): sift-cli 0.5.0 release prep

### DIFF
--- a/rust/crates/sift_cli/CHANGELOG.md
+++ b/rust/crates/sift_cli/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### What's New
 
+## [v0.5.0] - September 3, 2026
+
+### What's New
+
 - MCAP (`.mcap`) files can now be imported with `sift-cli import mcap`. Every
   decodable topic is imported one channel per flattened field, named
   `<topic>.<field path>`. Only ROS 2 topics (`cdr` messages with `ros2msg`


### PR DESCRIPTION
## Description

Cuts the `sift-cli` 0.5.0 changelog section. The crate on `main` is already at
version 0.5.0, so no version bump is needed for the `sift_cli-v0.5.0` tag to build.

## Verification

- Changelog only; no code changes.
- `[Unreleased]` entries moved under a dated `[v0.5.0]` heading, `[Unreleased]` left empty for the next cycle.