### PR TITLE
rust(chore): rust release prep 0.13.0, sift-stream-bindings 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 
 [workspace.package]
 authors = ["Sift Software Engineers <engineering@siftstack.com>"]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 categories = ["aerospace", "science::robotics"]
 homepage = "https://github.com/sift-stack/sift"
@@ -87,15 +87,15 @@ tracing-test = { version = "0.2", features = ["no-env-filter"] }
 uuid = { version = "1.22", features = ["v4"] }
 zip = "8.2"
 
-sift_connect = { version = "0.12.0", path = "rust/crates/sift_connect" }
-sift_rs = { version = "0.12.0", path = "rust/crates/sift_rs" }
-sift_error = { version = "0.12.0", path = "rust/crates/sift_error" }
-sift_stream = { version = "0.12.0", path = "rust/crates/sift_stream" }
-sift_pbfs = { version = "0.12.0", path = "rust/crates/sift_pbfs" }
-sift_mcp = { version = "0.12.0", path = "rust/crates/sift_mcp" }
-sift_test_util = { version = "0.12.0", path = "rust/crates/sift_test_util" }
+sift_connect = { version = "0.13.0", path = "rust/crates/sift_connect" }
+sift_rs = { version = "0.13.0", path = "rust/crates/sift_rs" }
+sift_error = { version = "0.13.0", path = "rust/crates/sift_error" }
+sift_stream = { version = "0.13.0", path = "rust/crates/sift_stream" }
+sift_pbfs = { version = "0.13.0", path = "rust/crates/sift_pbfs" }
+sift_mcp = { version = "0.13.0", path = "rust/crates/sift_mcp" }
+sift_test_util = { version = "0.13.0", path = "rust/crates/sift_test_util" }
 
-sift_stream_bindings = { version = "0.5.0", path = "rust/crates/sift_stream_bindings" }
+sift_stream_bindings = { version = "0.5.1", path = "rust/crates/sift_stream_bindings" }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [v0.13.0] - September 4, 2026
 ### What's New
 
 #### Bytes channel values

--- a/rust/crates/sift_stream_bindings/Cargo.toml
+++ b/rust/crates/sift_stream_bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sift-stream-bindings"
-version = "0.5.0"
+version = "0.5.1"
 # Released to PyPI as a wheel, never to crates.io.
 publish = false
 edition = { workspace = true }


### PR DESCRIPTION
## Summary

Bumps the Rust workspace from `0.12.0` to `0.13.0` and `sift-stream-bindings` from `0.5.0` to `0.5.1`, and turns the Unreleased CHANGELOG section into `v0.13.0`.

Stacked on #782. Merge that first.

### Why

#782 adds `Value::Bytes` to `sift_stream` and exposes it in `sift_stream_bindings`. Adding a variant to the public `Value` enum breaks downstream exhaustive matches, so this is a minor bump for the workspace. The bindings need a PyPI release so the Python library can depend on `ValuePy.Bytes`; the Python fix for bytes channel ingestion is blocked on `sift-stream-bindings==0.5.1` being published.

### Changes

- `Cargo.toml`: workspace version `0.12.0` → `0.13.0` and the 7 internal dependency pins (`sift_error`, `sift_rs`, `sift_connect`, `sift_stream`, `sift_pbfs`, `sift_mcp`, `sift_test_util`). `sift_stream_bindings` pin `0.5.0` → `0.5.1`. `sift_cli` (0.5.0) is unchanged.
- `rust/crates/sift_stream_bindings/Cargo.toml`: `0.5.0` → `0.5.1`.
- `rust/CHANGELOG.md`: `## [Unreleased]` → `## [v0.13.0] - September 4, 2026`.

### After merge

Tag `rust/v0.13.0` and `sift-stream-bindings/v0.5.1`, then bump the `sift-stream-bindings` pin in `python/pyproject.toml` and land the Python bytes PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
